### PR TITLE
fewer requirements for contract loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/requirements-load.txt
+++ b/requirements-load.txt
@@ -1,0 +1,2 @@
+colorama
+pyethereum


### PR DESCRIPTION
This adds a second python requirements file to be used with `pip install -r requirements-load.txt` in preparation for `python load_contracts.py`.  It's much lighter than the original requirements file.

`load_contracts.py` does not complain about dependencies, so it seems that everything is covered.  Although the script does just hang on this output, so maybe something's still missing:
```
# inset('../../macros/arrays.se')
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
Waiting 12.000000 seconds..........
etc...
```

Also, I'm used to the `venv` folder for virtual environments in python, so added it to gitignore