### PR TITLE
Making this work w/ new serpent by default

### DIFF
--- a/load_contracts.py
+++ b/load_contracts.py
@@ -463,9 +463,9 @@ def compile(fullname):
         with open(fullname, 'w') as f:
             f.write(code)
 
-    # new version of serpent:
-    # fullsig = serpent.mk_full_signature(code)
-    fullsig = json.loads(serpent.mk_full_signature(code))
+    # old version of serpent:
+    #fullsig = json.loads(serpent.mk_full_signature(code))
+    fullsig = serpent.mk_full_signature(code)
     shortname = get_shortname(fullname)
 
     if 'WHITELIST' in code:


### PR DESCRIPTION
I'd like to request that load_contracts works with the newer serpent by default. This will be helpful for azure integration so that it will work with the version of serpent that 

```
pip install ethereum-serpent
```
gives you, and I won't have to instead try to find an older compatible version.