### PR TITLE
generate_gospel fix

### DIFF
--- a/load_contracts/generate_gospel.py
+++ b/load_contracts/generate_gospel.py
@@ -96,15 +96,30 @@ def update_contracts(in_path=None, out_path=None,
                      rpc_host=RPCHOST, rpc_port=RPCPORT, network_id=None):
     gospel = generate_gospel_from_db()
     contracts = get_contracts(in_path)
-    if network_id is None: network_id = get_network_id(rpc_host, rpc_port)
-    if network_id is not None:
-        print("Network ID: " + str(network_id))
-    else:
-        print("Network ID lookup failed. Using default value: '" + DEFAULT_NETWORK_ID + "'.")
-        network_id = DEFAULT_NETWORK_ID
+    
+    id_requested = network_id 
+
+    #gospel is the contracts from the current_network_id. if a different id 
+    #is passed in, validate it and replace gospel with those from contracts[network_id]
+    current_network_id = get_network_id(rpc_host, rpc_port);
+    if network_id is None:
+        network_id = current_network_id
+    elif network_id != current_network_id:
+        if network_id in contracts:
+            gospel = contracts[network_id]
+        else:
+            print("Network ID: " + str(network_id) + " not found. Using default");
+            network_id = DEFAULT_NETWORK_ID
+
+    print("Network ID: " + str(network_id))
+
     if contracts and out_path is not None:
-        contracts[network_id] = gospel
-        write_contracts(out_path, contracts)
+        if id_requested is not None:
+            write_contracts(out_path, gospel)
+        else:
+            #if -o used w/out -n, write out addressed for all networkIDs
+            contracts[network_id] = gospel
+            write_contracts(out_path, contracts)
     else:
         print(json.dumps(gospel, indent=4, sort_keys=True))
 


### PR DESCRIPTION
Looked into #90 a little closer, and it looks like it was always returning the addresses for network 2 no matter what you pass in with -n. The other issue was that while using -o and -n together, it always outputs all networks instead of only the one you requested.

If using -o without -n, I did preserve the behavior of spitting out all networks, since I assume @tinybike uses this to generate the json in augur-contracts. In all other cases, -n now prints/outputs the (correct) json for that network only.
