### PR TITLE
Removing getMarketInfoCache

### DIFF
--- a/load_contracts/build.json
+++ b/load_contracts/build.json
@@ -2806,7 +2806,7 @@
         "sig": "extern completeSets: [buyCompleteSets:[int256,int256]:int256, sellCompleteSets:[int256,int256]:int256, test_callstack:[]:int256]"
     }, 
     "compositeGetters": {
-        "address": "0xcd49a9bf994b9cc61a3af5cf70588d9eedd1acc3", 
+        "address": "0xc5318e0ae3ef2f6883d12f88ac16896074f22c0d", 
         "code": [
             "# This software (Augur) allows buying && selling event outcomes in ethereum", 
             "# Copyright (C) 2015 Forecast Foundation OU", 
@@ -2931,36 +2931,6 @@
             "        c += 1", 
             "    return(marketInfo: arr)", 
             "", 
-            "def getMarketInfoCache(marketID):", 
-            "    refund()", 
-            "    index = BASE_CACHE_FIELDS", 
-            "    descriptionLength = INFO.getDescriptionLength(marketID)", 
-            "    marketInfo = array(BASE_CACHE_FIELDS + descriptionLength + 1)", 
-            "    marketInfo[0] = marketID", 
-            "    marketInfo[1] = MARKETS.getMakerFees(marketID)", 
-            "    marketInfo[2] = MARKETS.getTradingPeriod(marketID)", 
-            "    marketInfo[3] = MARKETS.getTradingFee(marketID)", 
-            "    marketInfo[4] = MARKETS.getCreationTime(marketID)", 
-            "    marketInfo[5] = MARKETS.getVolume(marketID)", 
-            "    tags = slice(MARKETS.returnTags(marketID, outitems=3), items=0, items=3)", 
-            "    marketInfo[6] = tags[0]", 
-            "    marketInfo[7] = tags[1]", 
-            "    marketInfo[8] = tags[2]", 
-            "    # Only expirationDate is cached by an augur_node, so ignoring all other event data:", 
-            "    events = slice(MARKETS.getMarketEvents(marketID, outitems=1), items=0, items=1)", 
-            "    marketInfo[9] = EVENTS.getExpiration(events[0])", 
-            "", 
-            "    # append description character codes", 
-            "    marketInfo[index] = descriptionLength", 
-            "    index += 1", 
-            "    description = INFO.getDescription(marketID, outchars=descriptionLength)", 
-            "    c = 0", 
-            "    while c < descriptionLength:", 
-            "        marketInfo[index + c] = getch(description, c)", 
-            "        c += 1", 
-            "", 
-            "    return(marketInfo: arr)", 
-            "", 
             "def batchGetMarketInfo(marketIDs: arr):", 
             "    refund()", 
             "    numMarkets = len(marketIDs)", 
@@ -3069,23 +3039,6 @@
                 "constant": false, 
                 "inputs": [
                     {
-                        "name": "marketID", 
-                        "type": "int256"
-                    }
-                ], 
-                "name": "getMarketInfoCache(int256)", 
-                "outputs": [
-                    {
-                        "name": "out", 
-                        "type": "int256[]"
-                    }
-                ], 
-                "type": "function"
-            }, 
-            {
-                "constant": false, 
-                "inputs": [
-                    {
                         "name": "branch", 
                         "type": "int256"
                     }, 
@@ -3137,7 +3090,7 @@
                 "type": "function"
             }
         ], 
-        "sig": "extern compositeGetters: [batchGetMarketInfo:[int256[]]:int256[], getMarketInfo:[int256]:int256[], getMarketInfoCache:[int256]:int256[], getMarketsInfo:[int256,int256,int256]:int256[], getOrderBook:[int256]:int256[], test_callstack:[]:int256]"
+        "sig": "extern compositeGetters: [batchGetMarketInfo:[int256[]]:int256[], getMarketInfo:[int256]:int256[], getMarketsInfo:[int256,int256,int256]:int256[], getOrderBook:[int256]:int256[], test_callstack:[]:int256]"
     }, 
     "consensus": {
         "address": "0xd75138a01cc0d56d6bfc4e00088458e501657579", 

--- a/src/functions/compositeGetters.se
+++ b/src/functions/compositeGetters.se
@@ -116,36 +116,6 @@ def getMarketInfo(marketID):
         c += 1
     return(marketInfo: arr)
 
-def getMarketInfoCache(marketID):
-    refund()
-    index = BASE_CACHE_FIELDS
-    descriptionLength = INFO.getDescriptionLength(marketID)
-    marketInfo = array(BASE_CACHE_FIELDS + descriptionLength + 1)
-    marketInfo[0] = marketID
-    marketInfo[1] = MARKETS.getMakerFees(marketID)
-    marketInfo[2] = MARKETS.getTradingPeriod(marketID)
-    marketInfo[3] = MARKETS.getTradingFee(marketID)
-    marketInfo[4] = MARKETS.getCreationTime(marketID)
-    marketInfo[5] = MARKETS.getVolume(marketID)
-    tags = slice(MARKETS.returnTags(marketID, outitems=3), items=0, items=3)
-    marketInfo[6] = tags[0]
-    marketInfo[7] = tags[1]
-    marketInfo[8] = tags[2]
-    # Only expirationDate is cached by an augur_node, so ignoring all other event data:
-    events = slice(MARKETS.getMarketEvents(marketID, outitems=1), items=0, items=1)
-    marketInfo[9] = EVENTS.getExpiration(events[0])
-
-    # append description character codes
-    marketInfo[index] = descriptionLength
-    index += 1
-    description = INFO.getDescription(marketID, outchars=descriptionLength)
-    c = 0
-    while c < descriptionLength:
-        marketInfo[index + c] = getch(description, c)
-        c += 1
-
-    return(marketInfo: arr)
-
 def batchGetMarketInfo(marketIDs: arr):
     refund()
     numMarkets = len(marketIDs)

--- a/src/python_serpent_test.py
+++ b/src/python_serpent_test.py
@@ -431,38 +431,6 @@ def test_trading():
     print "BUY AND SELL OK"
     return(1)
 
-def test_getMarketInfoCache():
-    global initial_gas
-    initial_gas = 0
-    t.gas_limit = 100000000
-    s = t.state()
-    c = s.abi_contract('functions/output.se')
-    c.initiateOwner(1010101)
-    blocktime = s.block.timestamp
-    event = c.createEvent(1010101, "new event", blocktime+1, ONE, TWO, 2, "ok")
-    description = "new market"
-    tradingFee = 184467440737095516
-    tags = [1,2,3]
-    makerFee = 0
-    market = c.createMarket(1010101, description, tradingFee, event, tags[0], tags[1], tags[2], makerFee, "yayaya", value=10**19)
-    info = c.getMarketInfoCache(market)
-    #BASE_CACHE_FIELS + description length
-    expected_size = 10 + len(description) + 1
-    assert(len(info)==expected_size)
-    assert(info[0]==market)
-    assert(info[1]==makerFee)
-    assert(info[2]==c.getTradingPeriod(market))
-    assert(info[3]==tradingFee)
-    #no volume yet
-    assert(info[5]==0)
-    assert(info[6]==tags[0])
-    assert(info[7]==tags[1])
-    assert(info[8]==tags[2])
-    #description starts at index 12, length stored at 11
-    desc_result = ''.join(map(chr,info[11:11+info[10]]))
-    assert(description==desc_result)
-    gas_use(s)
-
 def test_close_market():
     global initial_gas
     initial_gas = 0
@@ -1322,7 +1290,6 @@ if __name__ == '__main__':
     #test_catchup()
     #test_slashrep()
     #test_claimrep()
-    #test_getMarketInfoCache()
     #test_consensus_multiple_reporters()
     #test_pen_not_enough_reports()
     print "DONE TESTING"


### PR DESCRIPTION
This is no longer needed. Cache nodes now store full market data so a full market data fetch is required anyway.