### PR TITLE
load_contracts2.py updates

### DIFF
--- a/load_contracts2.py
+++ b/load_contracts2.py
@@ -20,112 +20,135 @@
 # SOFTWARE.
 from __future__ import print_function
 import argparse
-import serpent
 import os
+import errno
 import re
-import binascii
-import json
+from binascii import hexlify
 import shutil
 import sys
-import multiprocessing
-import requests
+from serpent import mk_signature
 import tempfile
+import warnings
 
 if (3, 0) <= sys.version_info:
-    _old_mk_signature = serpent.mk_signature
-    def mk_signature(code):
-        return _old_mk_signature(code).decode()
-    serpent.mk_signature = mk_signature
 
-WORKER_POOL_SIZE = 2
+    def pretty_signature(path, name):
+        ugly_signature = mk_signature(path).decode()
+        extern_name = 'extern {}:'.format(name)
+        name_end = ugly_signature.find(':') + 1
+        signature = extern_name + ugly_signature[name_end:]
+        return signature
+
+    _hexlify = hexlify
+
+    def hexlify(binary):
+        return _hexlify(binary).decode()
+else:
+
+    def pretty_signature(path, name):
+        ugly_signature = mk_signature(path)
+        extern_name = 'extern {}:'.format(name)
+        name_end = ugly_signature.find(':') + 1
+        signature = extern_name + ugly_signature[name_end:]
+        return signature
 
 PYNAME = '[A-Za-z_][A-Za-z0-9_]*'
 IMPORT = re.compile('import ({0}) as ({0})'.format(PYNAME))
 EXTERN = re.compile('extern ({}): .+'.format(PYNAME))
 
-EXTERN_ERROR_MSG = 'Weird extern in {path} at line {line}: {eg}'
-IMPORT_ERROR_MSG = 'Weird import in {path} at line {line}: {eg}'
-
-# these are standard contracts that don't have a specific / unique controller address
 STANDARD_EXTERNS = {
-    'Controller': 'extern Controller: [lookup:[int256]:int256, checkWhitelist:[int256]:int256]',
+    'controller': 'extern controller: [lookup:[int256]:int256, checkWhitelist:[int256]:int256]',
 
     # ERC20 and aliases used in Augur code
-    'ERC20': 'extern ERC20: [allowance:[address,address]:uint256, approve:[address,uint256]:uint256, balanceOf:[address]:uint256, decimals:[]:uint256, name:[]:uint256, symbol:[]:uint256, totalSupply:[]:uint256, transfer:[address,uint256]:uint256, transferFrom:[address,address,uint256]:uint256]',
-    'subcurrency': 'extern subcurrency: [allowance:[address,address]:uint256, approve:[address,uint256]:uint256, balanceOf:[address]:uint256, decimals:[]:uint256, name:[]:uint256, symbol:[]:uint256, totalSupply:[]:uint256, transfer:[address,uint256]:uint256, transferFrom:[address,address,uint256]:uint256]',
-    'wallet': 'extern wallet: [initialize:[int256]:int256, setWinningOutcomeContractAddressInitialize:[int256,int256]:int256, transfer:[address,uint256]:int256]',
-    'rateContract': 'extern rateContract: [rateFunction:[]:int256]',
-    'forkResolveContract': 'extern forkResolveContract: [resolveFork:[]:int256]',
+    'ERC20': 'extern ERC20: [allowance:[uint256,uint256]:uint256, approve:[uint256,uint256]:uint256, balance:[]:uint256, balanceOf:[uint256]:uint256, transfer:[uint256,uint256]:uint256, transferFrom:[uint256,uint256,uint256]:uint256]',
+    'subcurrency': 'extern subcurrency: [allowance:[uint256,uint256]:uint256, approve:[uint256,uint256]:uint256, balance:[]:uint256, balanceOf:[uint256]:uint256, transfer:[uint256,uint256]:uint256, transferFrom:[uint256,uint256,uint256]:uint256]',
 }
 
 DEFAULT_RPCADDR = 'http://localhost:8545'
-DEFAULT_CONTROLLER = 'macro Controller: 0xC001D00D'
+DEFAULT_CONTROLLER = '0xDEADBEEF'
+CONTROLLER_PATTERN = re.compile('^\s{4}self.controller\s?=\s?(0x[0-9a-fA-F]+)$')
+ADDRESS_HEX = re.compile('^0x([0-9A-F]{1,40}|[0-9a-f]{1,40})$')
 
 SERPENT_EXT = '.se'
 MACRO_EXT = '.sem'
 
-parser = argparse.ArgumentParser(description='Compiles collections of serpent contracts.',
-                                 epilog='Try a command followed by -h to see it\'s help info.')
-#parser.set_defaults(command='help')
 
-commands = parser.add_subparsers(title='commands')
-
-translate = commands.add_parser('translate', help='Translate imports to externs.')
-translate.add_argument('-s', '--source', help='Directory to search for Serpent code', required=True)
-translate.add_argument('-t', '--target', help='Directory to save translated code in.', required=True)
-translate.set_defaults(command='translate')
-
-update = commands.add_parser('update', help='Updates the externs in --source.')
-update.add_argument('-s', '--source', help='Directory to search for Serpent code', required=True)
-update.add_argument('-c', '--controller', help='The address in hex of the Controller contract.', default=None)
-update.set_defaults(command='update')
-
-compile_ = commands.add_parser('compile', help='Compiles and uploads all the contracts in --source. (TODO)')
-compile_.add_argument('-s', '--source', help='Directory to search for Serpent code', required=True)
-compile_.add_argument('-r', '--rpcaddr', help='Address of RPC server', default=DEFAULT_RPCADDR)
-compile_.set_defaults(command='compile')
+class LoadContractsError(Exception):
+    """Error class for all errors while processing Serpent code."""
+    def __init__(self, msg, *format_args, **format_params):
+        super(self.__class__, self).__init__(msg.format(*format_args, **format_params))
+        if not hasattr(self, 'message'):
+            self.message = self.args[0]
 
 
-class ContractError(Exception):
-    """Error class for all errors by load_contracts."""
+class TempDirCopy(object):
+    """Makes a temporary copy of a directory and provides a context manager for automatic cleanup."""
+    def __init__(self, source_dir):
+        self.source_dir = os.path.abspath(source_dir)
+        self.temp_dir = tempfile.mkdtemp()
+        self.temp_source_dir = os.path.join(self.temp_dir,
+                                            os.path.basename(source_dir))
 
+    def __enter__(self):
+        shutil.copytree(self.source_dir, self.temp_source_dir)
+        return self
 
-def find_files(source_dir, extension):
-    """Makes a list of paths in the directory which end in the extenstion."""
-    paths = []
-    for entry in os.listdir(source_dir):
-        entry = os.path.join(source_dir, entry)
-        if os.path.isfile(entry) and entry.endswith(extension):
-            paths.append(entry)
-        elif os.path.isdir(entry):
-            paths.extend(find_files(entry, extension))
+    def __exit__(self, exc_type, exc, traceback):
+        shutil.rmtree(self.temp_dir)
+        if not any((exc_type, exc, traceback)):
+            return True
+        return False
+
+    def find_files(self, extension):
+        """Finds all the files ending with the extension in the directory."""
+        paths = []
+        for directory, subdirs, files in os.walk(self.temp_source_dir):
+            for filename in files:
+                if filename.endswith(extension):
+                    paths.append(os.path.join(directory, filename))
+
+        return paths
+
+    def commit(self, dest_dir):
+        """Copies the contents of the temporary directory to the destination."""
+        if os.path.exists(dest_dir):
+            LoadContractsError(
+                'The target path already exists: {}'.format(
+                    os.path.abspath(dest_dir)))
+
+        shutil.copytree(self.temp_source_dir, dest_dir)
+
+    def cleanup(self):
+        """Deletes the temporary directory."""
+        try:
+            shutil.rmtree(self.temp_dir)
+        except OSError as exc:
+            # If ENOENT it raised then the directory was already removed.
+            # This error is not harmful so it shouldn't be raised.
+            # Anything else is probably bad.
+            if exc.errno == errno.ENOENT:
+                return False
+            else:
+                raise
         else:
-            continue
-    return paths
+            return True
+
+    def original_path(self, path):
+        """Returns the orignal path which the copy points to."""
+        return path.replace(self.temp_source_dir, self.source_dir)
 
 
-def split_crud(code_lines):
-    """Separates comment-crud at the top of the file from everything else."""
-    crud = []
-    noncrud = []
-
+def strip_license(code_lines):
+    """Separates the top-of-the-file license stuff from the rest of the code."""
     for i, line in enumerate(code_lines):
-        if line.startswith('#'):
-            crud.append(line)
-        else:
-            noncrud.extend(code_lines[i:])
-            break
-
-    return crud, noncrud
+        if not line.startswith('#'):
+            return code_lines[:i], code_lines[i:]
+    return [], code_lines
 
 
-def strip_dependencies(serpent_file):
+def strip_imports(code_lines):
     """Separates dependency information from Serpent code in the file."""
-
-    with open(serpent_file) as f:
-        code = f.read().split('\n')
-
-    crud, code = split_crud(code)
+    license, code = strip_license(code_lines)
     dependencies = []
     other_code = []
 
@@ -135,158 +158,278 @@ def strip_dependencies(serpent_file):
             if m:
                 dependencies.append((m.group(1), m.group(2)))
             else:
-                msg = IMPORT_ERROR_MSG.format(
-                    path=serpent_file,
-                    line=(i + len(crud)),
-                    eq=line)
-                raise ContractError(msg)
+                raise LoadContractsError(
+                    'Weird import at {line_num}: {line}',
+                    line_num=i,
+                    line=line)
         else:
             other_code.append(line)
 
-    if other_code[-1]:
-        other_code.append('') # makes sure the file ends with a blank line
+    return license, dependencies, other_code
 
-    crud.append('') # makes sure there is a blank line between crud and dependencies
 
-    return dependencies, '\n'.join(other_code), '\n'.join(crud)
+def path_to_name(path):
+    """Extracts the contract name from the path."""
+    return os.path.basename(path).replace(SERPENT_EXT, '')
 
+
+def is_not_indented(line):
+    """True if a line starts with a space of tab."""
+    return not (line.startswith(' ') or line.startswith('\t'))
+
+
+def find_init(code_lines):
+    """Finds the line bounds of a Serpent init function."""
+
+    # If there are multiple init functions, the Serpent
+    # compiler will silently drop all but the last, and
+    # only compile the last. That's bad! >:(
+
+    init_bounds = []
+    start = None
+    
+    for i, line in enumerate(code_lines):
+        if line.startswith('def init():'):
+            start = i
+        elif start is not None and is_not_indented(line):
+            init_bounds.append((start, i))
+            start = None
+        else:
+            continue
+
+    if start and not init_bounds:
+        return [(start, -1)]
+
+    if not init_bounds:
+        return [(None, None)]
+
+    return init_bounds
+
+
+def update_controller(code_lines, controller_addr):
+    """Updates the controller address in the code.
+
+    If there is no 'data controller' declaration it is added.
+    Similarly, if no controller initialization line is found in
+    the init function, then it is added, and if there is no init
+    function, one is added.
+    """
+    if not ADDRESS_HEX.match(controller_addr):
+        raise LoadContractsError('Controller address invalid! {}', controller_addr)
+
+    code_lines = code_lines[:]
+
+    for i in range(len(code_lines)):
+        line = code_lines[i]
+        if line == 'data controller':
+            break
+    else:
+        code_lines = ['data controller', ''] + code_lines
+
+    init_bounds = find_init(code_lines)
+
+    if len(init_bounds) > 1:
+        raise LoadContractsError('Multiple init functions!')
+
+    init_start, init_stop = init_bounds[0]
+
+    controller_line = '    self.controller = {}'.format(controller_addr)
+
+    if init_stop == -1:
+        raise LoadContractsError('Weird init function at line {line}!', line=init_start)
+
+    if init_start is None:
+        # Augur code follows a convention where data declarations are
+        # followed by a comment block describing the declaration's meaning.
+        # The blocks are immediately followed by the declaration. data
+        # declarations may have a blank line afterward.
+        last_data = None
+        for i in range(len(code_lines)):
+            line = code_lines[i]
+            if line.startswith('data'):
+                last_data = i
+            if line.startswith('#') or line == '':
+                continue
+            if i > last_data:
+                break
+
+        return code_lines[:i] + ['def init():', '', controller_line, ''] + code_lines[i:]
+
+    for i in range(init_start, init_stop):
+        line = code_lines[i]
+        m = CONTROLLER_PATTERN.match(line)
+        if m:
+            code_lines[i] = controller_line
+            return code_lines
+    else:
+        code_lines.insert(init_stop, controller_line)
+        return code_lines
 
 def imports_to_externs(source_dir, target_dir):
     """Translates code using import syntax to standard Serpent externs."""
-    source_dir = os.path.abspath(source_dir)
-    target_dir = os.path.abspath(target_dir)
+    with TempDirCopy(source_dir) as td:
+        serpent_paths = td.find_files(SERPENT_EXT)
 
-    if os.path.exists(target_dir):
-        raise ContractError('The target directory already exists!')
+        contracts = {}
 
-    tempdir = tempfile.mkdtemp()
-    temp_target_copy = os.path.join(tempdir, os.path.basename(target_dir))
-    shutil.copytree(source_dir, temp_target_copy)
+        for path in serpent_paths:
+            name = path_to_name(path)
 
-    try:
-        serpent_files = find_files(temp_target_copy, SERPENT_EXT)
+            with open(path) as f:
+                code_lines = [line.rstrip() for line in f]
 
-        source_map = {}
+            try:
+                code_lines = update_controller(code_lines, DEFAULT_CONTROLLER)
+                license, dependencies, other_code = strip_imports(code_lines)
+            except LoadContractsError as exc:
+                raise LoadContractsError(
+                    'Caught error while processing {name}: {error}',
+                    name=name,
+                    error=exc.message)
 
-        for path in serpent_files:
-            name = os.path.basename(path).replace(SERPENT_EXT, '')
-            info = {}
-            info['dependencies'], info['stripped_code'], info['crud'] = strip_dependencies(path)
-            
-            with open(path, 'w') as temp:
-                temp.write(info['stripped_code'])
+            info = {'license': license,
+                    'dependencies': dependencies,
+                    'stripped_code': '\n'.join(other_code)}
 
-            extern_name = 'extern {}:'.format(name)
-            signature = serpent.mk_signature(path)
-            name_end = signature.find(':') + 1
-            signature = extern_name + signature[name_end:]
-            info['signature'] = signature
+            # the stripped code is writen back so the serpent module can handle 'inset' properly
+            with open(path, 'w') as f:
+                f.write(info['stripped_code'])
+
+            info['signature'] = pretty_signature(path, name)
             info['path'] = path
-            source_map[name] = info
+            contracts[name] = info
 
-        lookup_fmt = '{} = Controller.lookup(\'{}\')'
-        for name in source_map:
-            info = source_map[name]
-            signatures = [DEFAULT_CONTROLLER, # a place holder that needs to be updated before compiling
-                          STANDARD_EXTERNS['Controller']]
+        lookup_fmt = '{} = self.controller.lookup(\'{}\')'
+        for name in contracts:
+            info = contracts[name]
+            signatures = ['', STANDARD_EXTERNS['controller'], '']
             for oname, alias in info['dependencies']:
                 signatures.append('')
                 signatures.append(lookup_fmt.format(alias, oname))
-                signatures.append(source_map[oname]['signature'])
+                signatures.append(contracts[oname]['signature'])
             signatures.append('') # blank line between signatures section and rest of code
-            new_code = '\n'.join([info['crud']] + signatures + [info['stripped_code']])
+            new_code = '\n'.join(info['license'] + signatures + [info['stripped_code']])
             path = info['path']
 
             with open(path, 'w') as f:
                 f.write(new_code)
-    except Exception:
-        raise
-    else:
-        shutil.copytree(temp_target_copy, target_dir)
-    finally:
-        shutil.rmtree(tempdir)
+
+        td.commit(target_dir)
 
 
 def update_externs(source_dir, controller):
     """Updates all externs in source_dir."""
-    if controller:
-        new_controller = 'macro Controller: {}'.format(controller)
-    source_dir = os.path.abspath(source_dir)
-    tempdir = tempfile.mkdtemp()
-    source_copy = os.path.join(tempdir, os.path.basename(source_dir))
-    shutil.copytree(source_dir, source_copy)
-    extern_map = STANDARD_EXTERNS.copy()
 
-
-    try:
-        serpent_files = find_files(source_copy, SERPENT_EXT)
+    with TempDirCopy(source_dir) as td:
+        extern_map = STANDARD_EXTERNS.copy()
+        serpent_files = td.find_files(SERPENT_EXT)
 
         for path in serpent_files:
-            name = os.path.basename(path).replace(SERPENT_EXT, '')
-            extern_name = 'extern {}:'.format(name)
-            signature = serpent.mk_signature(path)
-            name_end = signature.find(':') + 1
-            signature = extern_name + signature[name_end:]
-            extern_map[name] = signature
+            name = path_to_name(path)
+            extern_map[name] = pretty_signature(path, name)
 
         for path in serpent_files:
             with open(path) as f:
-                code = f.read().split('\n')
+                code_lines = [line.rstrip() for line in f]
 
-            crud, code = split_crud(code)
-            saw_controller = False
+            license, code_lines = strip_license(code_lines)
 
-            for i in range(len(code)):
+            if controller:
+                code_lines = update_controller(code_lines, controller)
 
-                m = EXTERN.match(code[i])
+            for i in range(len(code_lines)):
+                line = code_lines[i]
+                m = EXTERN.match(line)
 
-                if code[i].startswith('extern') and m is None:
-                    msg = EXTERN_ERROR_MSG.format(path=path, line=(i + len(crud)), eg=code[i])
-                    raise ContractError(msg)
-                if m and m.group(1) not in extern_map:
-                    msg = EXTERN_ERROR_MSG.format(path=path, line=(i + len(crud)), eg=code[i])
-                    raise ContractError(msg)
+                if (line.startswith('extern') and m is None or 
+                    m and m.group(1) not in extern_map):
 
-                if m:
-                    code[i] = extern_map[m.group(1)]
-                elif code[i].startswith('macro Controller:'):
-                    saw_controller = True
-                    if controller:
-                        code[i] = new_controller
+                    raise LoadContractsError(
+                        'Weird extern at line {line_num} in file {path}: {line}',
+                        line_num=(len(license) + i),
+                        path=td.original_path(path),
+                        line=line)
+                elif m:
+                    extern_name = m.group(1)
+                    code_lines[i]  = extern_map[extern_name]
 
-            if not saw_controller:
-                crud.append(DEFAULT_CONTROLLER)
-
-            code = '\n'.join(crud + code)
+            code_lines = '\n'.join(license + code_lines)
             with open(path, 'w') as f:
-                f.write(code)
-    except Exception:
-        raise
-    else:
+                f.write(code_lines)
+
         shutil.rmtree(source_dir)
-        shutil.copytree(source_copy, source_dir)
-    finally:
-        shutil.rmtree(tempdir)
+        td.commit(source_dir)
+
+
+class ContractLoader(object):
+    pass
 
 
 def main():
+    parser = argparse.ArgumentParser(
+        description='Compiles collections of serpent contracts.',
+        epilog='Try a command followed by -h to see it\'s help info.')
+    parser.set_defaults(command=None)
+
+    commands = parser.add_subparsers(title='commands')
+
+    translate = commands.add_parser('translate',
+                                    help='Translate imports to externs.')
+    translate.add_argument('-s', '--source',
+                           help='Directory to search for Serpent code',
+                           required=True)
+    translate.add_argument('-t', '--target',
+                           help='Directory to save translated code in.',
+                           required=True)
+    translate.set_defaults(command='translate')
+
+    update = commands.add_parser('update',
+                                 help='Updates the externs in --source.')
+    update.add_argument('-s', '--source',
+                        help='Directory to search for Serpent code',
+                        required=True)
+    update.add_argument('-c', '--controller',
+                        help='The address in hex of the Controller contract.',
+                        default=None)
+    update.set_defaults(command='update')
+
+    compile_ = commands.add_parser('compile',
+                                   help='Compiles and uploads all the contracts in --source. (TODO)')
+    compile_.add_argument('-s', '--source',
+                          help='Directory to search for Serpent code',
+                          required=True)
+    compile_.add_argument('-r', '--rpcaddr',
+                          help='Address of RPC server',
+                          default=DEFAULT_RPCADDR)
+    compile_.add_argument('-o', '--out',
+                          help='Filename for address json.')
+    compile_.add_argument('-O', '--overwrite',
+                          help='If address json already exists, overwrite',
+                          action='store_true', default=False)
+    compile_.set_defaults(command='compile')
+
     args = parser.parse_args()
 
     try:
-        if args.command == 'help':
+        if args.command is None:
             parser.print_help()
         elif args.command == 'translate':
             imports_to_externs(args.source, args.target)
         elif args.command ==  'update':
             update_externs(args.source, args.controller)
         else:
-            print('command not implemented:', args.command)
-            return 1
-    except ContractError as exc:
-        print(exc.args[0])
+            raise LoadContractsError('command not implemented: {cmd}', cmd=args.command)
+    except Exception as exc:
+        if hasattr(exc, 'message'):
+            print(exc.message)
+        elif len(exc.args) == 1:
+            print(exc.args[0])
+        else:
+            print(exc.args)
         return 1
+    else:
+        return 0
 
-    return 0
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/load_contracts2.py
+++ b/load_contracts2.py
@@ -383,7 +383,7 @@ class ContractLoader(object):
     """A class which updates and compiles Serpent code via ethereum.tester.state.
 
     Examples:
-    contracts = ContractLoader('src', ['controller.se']
+    contracts = ContractLoader('src', ['controller.se'])
     print(contracts.foo.echo('lol'))
     print(contracts['bar'].bar())
     contracts.cleanup()

--- a/serpent_style.md
+++ b/serpent_style.md
@@ -1,6 +1,15 @@
 # Serpent Style Guide
 
-All Serpent contract files should have the extension `.se`, and all Serpent macros should be in their own files, with the filename `.sem`.
+This is a collection of rules to make large Serpent projects easier to work with.
+
+## Source File Organization
+
+* All Serpent contract files should have the extension `.se`, and all Serpent macros should be in their own files with the extension `.sem`.
+* The Serpent source tree should contain nothing but Serpent contract and macro files.
+* All indentation should be multiples of 4 spaces, not tabs or any other size spaces.
+
+## Code Sections
+
 All Serpent contracts should be organized into the following sections in the following order, whenever each section is neccessary:
 
 1. The license.
@@ -10,7 +19,6 @@ All Serpent contracts should be organized into the following sections in the fol
 5. global variables
 6. functions
 
-## Sections
 Each section should be separated by two blanks lines.
 
 ### The License

--- a/serpent_style.md
+++ b/serpent_style.md
@@ -1,0 +1,33 @@
+# Serpent Style Guide
+
+All Serpent contract files should have the extension `.se`, and all Serpent macros should be in their own files, with the filename `.sem`.
+All Serpent contracts should be organized into the following sections in the following order, whenever each section is neccessary:
+
+1. The license.
+2. Macro file insets.
+3. externs
+4. data declarations
+5. global variables
+6. functions
+
+## Sections
+Each section should be separated by two blanks lines.
+
+### The License
+Each file should start with a comment block containing the relevant license.
+
+### Macro Insets
+All macro insets should be placed on consecutive lines, with no comments or blank lines between them.
+
+### The `extern` Section
+All externs should be placed on consecutive lines, with no comments or blank lines between them.
+
+### `data` Declarations
+The data section may have comments and blank lines in between however the author wishes, except that two consecutive blank lines should not appear within the section.
+
+### Global Variables
+This section should follow the same rules as the data section.
+
+### Functions
+Serpent has three important special functions: `init`, `shared`, and `any`.
+The init function, if any, should appear first in the file, and there must only be one init function in the file. The `shared` function should be next, and then the `any` function if necessary. Care should be taken if using an `any` function and global variables. The Serpent compiler gathers all code in the global variables section together with all code in the `any` function, and executes it all each time the contracts is called. All other functions should go after the special functions. There should be no occurrences of consecutive blank lines in this section, and it should end in a blank line.


### PR DESCRIPTION
Added a class to help with testing, the ContractLoader class. I've also updated the controller mechanism so that if the controller is replaced then the contracts can switch to the new controller. Basically, the controller address is kept in each contract's storage instead of being hardcoded as a macro.

I've also added the upgrade command to automate migrating from the macro based controller to the new storage based controller, as well as updated the 'update' and 'translate' commands to work with the new mechanism.