### PR TITLE
Renames mutexWhitelisted to isCallerWhitelisted.

### DIFF
--- a/src/functions/cash.se
+++ b/src/functions/cash.se
@@ -52,9 +52,9 @@ def init():
 
 def transfer(to: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     senderBalance = self.accounts[msg.sender].balance
     if(senderBalance < value):
@@ -65,15 +65,15 @@ def transfer(to: address, value: uint256):
     self.accounts[msg.sender].balance -= value
     self.accounts[to].balance += value
     log(type = Transfer, msg.sender, to, value)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
 def transferFrom(from: address, to: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     senderBalance = self.accounts[from].balance
     if(senderBalance < value or value > self.accounts[from].spenders[msg.sender].maxValue):
@@ -85,20 +85,20 @@ def transferFrom(from: address, to: address, value: uint256):
     self.accounts[from].balance -= value
     self.accounts[to].balance += value
     log(type = Transfer, from, to, value)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
 def approve(spender: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     self.accounts[msg.sender].spenders[spender].maxValue = value
     log(type=Approval, msg.sender, spender, value)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -112,9 +112,9 @@ def setCash(address: address, balance: uint256):
     return(1)
 
 def depositEther():
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     amount = msg.value
@@ -122,7 +122,7 @@ def depositEther():
         throw()
     self.accounts[msg.sender].balance += amount
     self.totalSupply += amount
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 

--- a/src/functions/closeMarket.se
+++ b/src/functions/closeMarket.se
@@ -67,9 +67,9 @@ def init():
 
 def closeMarket(market, sender):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     event = MARKETS.getMarketEvent(market, 0)
     branch = EVENTS.getEventBranch(event)
@@ -91,31 +91,31 @@ def closeMarket(market, sender):
     marketWallet = INFO.getWallet(market)
     marketWallet.transfer(BRANCHES.getBranchWallet(branch, marketCurrency), marketCurrency.balanceOf(marketWallet) - safeFxpMul(MARKETS.getSharesPurchased(market, 1), MARKETS.getCumulativeScale(market)))
 
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     logReturn(closeMarketLogReturn, 1)
 
 macro checkCloseMarketPreconditions():
     # as long as resolved and not challenged we can then resolve, i.e. if not challenged and > 6 days then can take prelim outcome and make it final outcome
     if(period <= votingPeriodEvent || (!EVENTS.getChallenged(event) && block.timestamp < expiration + SIX_DAYS)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         logReturn(closeMarketLogReturn, 0)
     if(MARKETS.getOneWinningOutcome(market, 0)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         logReturn(closeMarketLogReturn, -1)
     if(!EVENTS.getUncaughtOutcome(event) && !EVENTS.getFirstPreliminaryOutcome(event)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         logReturn(closeMarketLogReturn, -2)
     if(BACKSTOPS.getRoundTwo(event) and !BACKSTOPS.getFinal(event)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         logReturn(closeMarketLogReturn, -3)
     # if an event is one from before a fork and hasn't been moved yet or it's the event the fork occurred over and it's not over yet don't resolve it
     if((EVENTS.getForked(event) and !EVENTS.getForkedDone(event)) or eventCreatedPriorToFork(eventID)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         logReturn(closeMarketLogReturn, -4)
 
@@ -131,7 +131,7 @@ macro resolveEventsInMarket():
     else:
         throw()
     if(resolution == -1):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         logReturn(closeMarketLogReturn, -5)
 

--- a/src/functions/collectFees.se
+++ b/src/functions/collectFees.se
@@ -35,7 +35,7 @@ def init():
     self.controller = 0xC001D00D
 
 def collectRep(branch, sender):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
     MUTEX.setMutex()
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -48,12 +48,12 @@ def collectRep(branch, sender):
     # need 1 rep to claim fees
     if(newRep < ONE):
         prepareInfoForConsensus()
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(2)
     collectRedistributedRep()
     prepareInfoForConsensus()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -65,7 +65,7 @@ def collectRep(branch, sender):
     # -3: rep not collected yet
 # 2 means no errors but didnt report last period
 def collectFees(branch, sender, currency):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
     MUTEX.setMutex()
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -77,11 +77,11 @@ def collectFees(branch, sender, currency):
     checkCollectFeesPreconditions()
     # need 1 rep to claim fees
     if(newRep < ONE):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(2)
     collectTradeFees()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -89,11 +89,11 @@ macro checkCollectRepPreconditions():
     atSecondHalfOfPeriod()
     if(!CONSENSUS.getRepRedistributionDone(branch, sender)):
         # need to call penalize for all events and penalize for too lazy to report or catchup if necessary
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     if(repCollected):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
@@ -101,12 +101,12 @@ macro checkCollectFeesPreconditions():
     atSecondHalfOfPeriod()
     if(!CONSENSUS.getRepRedistributionDone(branch, sender)):
         # need to call penalize for all events and penalize for too lazy to report or catchup if necessary
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     feesCollected = CONSENSUS.getFeesCollected(branch, sender, lastPeriod, currency)
     if(feesCollected):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
     if(!repCollected):

--- a/src/functions/consensus.se
+++ b/src/functions/consensus.se
@@ -133,13 +133,13 @@ def penalizeWrong(branch, event):
 # ui has to call this to stay cheap / not check it elsewhere
 def incrementPeriodAfterReporting(branch):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     # do this after reporting is finished
     if(!periodOver(branch)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
     periodVotingOnNow = block.timestamp / BRANCHES.getPeriodLength($branch) - 1
@@ -153,7 +153,7 @@ def incrementPeriodAfterReporting(branch):
     baseReporterQuantity = 2 * (3 * ONE + ((333 * percentAppealed)^3 / ONE^2)) / ONE
     CONSENSUS.setBaseReportersLastPeriod(branch, BRANCHES.getBaseReporters(branch))
     BRANCHES.setBaseReporters(branch, baseReporterQuantity)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 

--- a/src/functions/createBranch.se
+++ b/src/functions/createBranch.se
@@ -55,9 +55,9 @@ def init():
 
 def createSubbranch(description:str, periodLength, parent, fxpMinTradingFee, oracleOnly, mostRecentChildBranch):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     checkBranchCreationPreconditions()
@@ -83,21 +83,21 @@ def createSubbranch(description:str, periodLength, parent, fxpMinTradingFee, ora
     feePaid = parentEthContract.transferFrom(msg.sender, BRANCHES.getBranchWallet(parent, parentEthContract), 47 * ONE)
     if(!feePaid or !INFO.setInfo(branch, description, msg.sender, 47 * ONE, 0, 0) or !REPORTING.setInitialReporters(branch)):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(branch)
 
 macro checkBranchCreationPreconditions():
     # provided branch doesn't already exist, create it
     if(INFO.getCreator(branch)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-2)
     if(periodLength <= TWENTY_FOUR_HR or !BRANCHES.getPeriodLength(parent) or !len(description)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     if(fxpMinTradingFee <= 0 or fxpMinTradingFee > MAX_FEE or (oracleOnly != 0 and oracleOnly != 1)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)

--- a/src/functions/createMarket.se
+++ b/src/functions/createMarket.se
@@ -119,9 +119,9 @@ def init():
 
 def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numOutcomes, resolution: str, resolutionAddress, currency, forkResolveAddress):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -139,7 +139,7 @@ def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numO
     mcopy(eventInfo + 8 * 32, description, len(description))
     event = ripemd160(eventInfo, chars = len(eventInfo))
     if(INFO.getCreator(event)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
@@ -170,7 +170,7 @@ def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numO
             EVENTS.setExpiration(event, block.timestamp)
             EVENTS.setBond(event, validityBond)
             EVENTS.addPast24(period)
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(event)
     else:
@@ -196,9 +196,9 @@ def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numO
 # need at least 1.2M gas @ gas price to cover resolution & 500k per event to calc. num reports for it - this is passed as value to this function
 # need to check that it's an actual subcurrency upon market creation
 def createMarket(branch, description: str, fxpTradingFee, event, tag1, tag2, tag3, extraInfo: str, currency):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -241,7 +241,7 @@ def createMarket(branch, description: str, fxpTradingFee, event, tag1, tag2, tag
     market = ripemd160(marketInfo, chars = len(marketInfo))
     # if it's already been created return 0
     if(INFO.getCreator(market)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-4)
     events = array(1)
@@ -259,7 +259,7 @@ def createMarket(branch, description: str, fxpTradingFee, event, tag1, tag2, tag
     makeMarket()
 
     log(type = marketCreated, market)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(market)
 
@@ -386,9 +386,9 @@ def pushMarketForward(branch, market):
 # Errors:
     # -1: not allowed for events during a fork scenario for events that were created before the fork until the fork is over
 def putEventIntoReportingPeriod(event):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     # add events to the appropriate reporting period
     branch = EVENTS.getEventBranch(event)
@@ -403,20 +403,20 @@ def putEventIntoReportingPeriod(event):
         addEvent()
         EVENTS.setExpiration(event, block.timestamp)
         EVENTS.setChallenged(event)
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(1)
     else:
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
 # Errors:
     # -1: not allowed for events during a fork scenario for events that were created before the fork until the fork is over
 def challengeInitialResolution(event):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     # add events to the appropriate reporting period
     branch = EVENTS.getEventBranch(event)
@@ -434,11 +434,11 @@ def challengeInitialResolution(event):
         EVENTS.setExpiration(event, block.timestamp)
         EVENTS.setChallenged(event)
         payExtraBond()
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(1)
     else:
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
@@ -446,20 +446,20 @@ def challengeInitialResolution(event):
 # with oraclize.it do value = parseInt(result, 18) to get it in the proper 10**18 base, then do (value - min) * 10**18 / range to submit the result to augur
 # unethical is just a .5 outcome for scalar/categorical, 1.5 for binary as usual
 def resolveEarly(event, outcome):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     if(msg.sender == EVENTS.getResolutionAddress(event) && block.timestamp > EVENTS.getExpiration(event) && block.timestamp < (EVENTS.getExpiration(event) + THREE_DAYS)):
         # outcome of 1 is 1/10**18 or basically 0, but allows us to still check if outcome is 0 or not to see if an outcome has been set
         if(outcome == 0):
             outcome = 1
         EVENTS.setFirstPreliminaryOutcome(event, outcome)
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(1)
     else:
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
@@ -484,15 +484,15 @@ def addFees(market, fxpAmount):
 
 macro checkEventCreationPreconditions():
     if(!periodLength or !len(description) or !len(resolution) or expDate < block.timestamp or !resolutionAddress):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     if(fxpMaxValue < fxpMinValue or (fxpMaxValue - fxpMinValue) < ONE or (fxpMaxValue + fxpMinValue) < fxpMaxValue):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-2)
     if(numOutcomes < 2 or numOutcomes > 8):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-3)
     parent = BRANCHES.getParent(branch)
@@ -508,11 +508,11 @@ macro checkEventCreationPreconditions():
 macro checkMarketCreationPreconditions():
     # will need to get equivalent value in usd or eth or w/e via etherex exchange for subcurrency markets
     if(!periodLength or !len(description) or fxpTradingFee < BRANCHES.getMinTradingFee(branch) or fxpTradingFee > MAX_FEE or EVENTS.getEventBranch(event) != branch or !INFO.getCreator(event)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     if(expirationDate < block.timestamp):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-2)
     if(!BRANCHES.getCurrencyActive(branch, currency)):

--- a/src/functions/forking.se
+++ b/src/functions/forking.se
@@ -123,16 +123,16 @@ def moveEvent(event):
 # parent branch is branch here
 # If there's only 1 event and that's the one we forked over [rare edge case] we can call resolve fork manually if it hasn't been done yet within the time parameters which allows a fork to be resolved [2 periods after the start of the fork]
 def resolveFork(branch):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     forkPeriod = BRANCHES.getForkPeriod(branch)
     currentPeriod = block.timestamp / BRANCHES.getPeriodLength(branch)
     if(BACKSTOPS.getResolved(branch, forkPeriod)):
         throw()
     if(currentPeriod < (forkPeriod + 2)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
@@ -146,7 +146,7 @@ def resolveFork(branch):
     else:
         winner = fork
     BACKSTOPS.setResolved(branch, forkPeriod, winner)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(winner)
 

--- a/src/functions/offChainTrades.se
+++ b/src/functions/offChainTrades.se
@@ -32,26 +32,26 @@ def init():
 
 def trade(maker: address, v, r, s, tokenX: address, tokenY: address, orderSize, takerAmount, fxpPrice, expiration):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     orderHash = sha3([maker, tokenX, tokenY, orderSize, fxpPrice, expiration], items = 6)
     if(!checkSig(maker, orderHash, v, r, s)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
     if(block.timestamp > expiration):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     if(!checkHasAbilityToSpend(maker, tokenX, orderSize) || !checkHasAbilityToSpend(msg.sender, tokenY, safeFxpMul(takerAmount, fxpPrice))):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-2)
     if(safeAdd(self.amountFilled[orderHash], takerAmount) > orderSize):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-3)
 
@@ -62,7 +62,7 @@ def trade(maker: address, v, r, s, tokenX: address, tokenY: address, orderSize, 
     if(!tokenX.transferFrom(maker, msg.sender, takerAmount) || !tokenY.transferFrom(msg.sender, maker, safeFxpMul(takerAmount, fxpPrice))):
         throw()
     log(type = Trade, maker, msg.sender, tokenX, tokenY, amount, fxpPrice, orderHash)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -78,9 +78,9 @@ def onChainOrder(tokenX: address, orderSize, tokenY: address, fxpPrice, expirati
 
 def cancelOrder(tokenX: address, orderSize, tokenY: address, fxpPrice, expiration, v, r, s):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     orderHash = sha3([msg.sender, tokenX, tokenY, orderSize, fxpPrice, expiration], items = 6)
@@ -89,7 +89,7 @@ def cancelOrder(tokenX: address, orderSize, tokenY: address, fxpPrice, expiratio
     self.amountFilled[orderHash] = orderSize
     log(type = Cancel, tokenX, orderSize, tokenY, fxpPrice, expiration, msg.sender, v, r, s)
 
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 

--- a/src/functions/penalizationCatchup.se
+++ b/src/functions/penalizationCatchup.se
@@ -36,9 +36,9 @@ def init():
 
 def penalizationCatchup(branch, sender):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     if(sender != msg.sender):
         self.controller.checkWhitelist(msg.sender)
@@ -51,7 +51,7 @@ def penalizationCatchup(branch, sender):
     checkPenalizationCatchupPreconditions()
     redistributeRepFromNotReporting()
     CONSENSUS.setPenalizedUpTo(branch, sender, lastPeriod)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -63,14 +63,14 @@ macro checkPenalizationCatchupPreconditions():
     if(EXPEVENTS.getNumberEvents(branch, lastPeriod) == 0):
         delta -= 1
     if(delta <= 0):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     # provided user is at least one period behind and they didn't report in the last period
     alreadyPenalized = (lastPeriodPenalized == lastPeriod)
     reportedLastPeriod = EXPEVENTS.getNumReportsSubmitted(branch, lastPeriod, sender)
     if(alreadyPenalized or reportedLastPeriod):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-3)
 

--- a/src/functions/sendReputation.se
+++ b/src/functions/sendReputation.se
@@ -84,9 +84,9 @@ def init():
 
 def sendRepFrom(branch, from, receiver, fxpValue):
     checkInvariants(from)
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     senderIndex = REPORTING.repIDToIndex(branch, from)
@@ -101,7 +101,7 @@ def sendRepFrom(branch, from, receiver, fxpValue):
     if(!safeToSubtract(senderBalance, fxpValue) or !REPORTING.subtractRep(branch, senderIndex, fxpValue) or !safeToAdd(receiverBalance, fxpValue) or !REPORTING.addRep(branch, receiverIndex, fxpValue)):
         throw()
     log(type = Transfer, from, receiver, fxpValue)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -114,9 +114,9 @@ def sendRepFrom(branch, from, receiver, fxpValue):
 # fails unless from has authorized sender [either contract which was approved or the from address is the msg.sender]
 def transferFrom(branch, from, receiver, fxpValue):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     votePeriod = BRANCHES.getVotePeriod(branch)
@@ -129,7 +129,7 @@ def transferFrom(branch, from, receiver, fxpValue):
     if(!safeToSubtract(senderBalance, fxpValue) or !REPORTING.subtractDormantRep(branch, senderIndex, fxpValue) or !safeToAdd(receiverBalance, fxpValue) or !REPORTING.addDormantRep(branch, receiverIndex, fxpValue)):
        throw()
     log(type=Transfer, from, receiver, fxpValue)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -189,27 +189,27 @@ def convertToActiveRep(branch, fxpValue):
     return(1)
 
 def claimRep():
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     balance = REPCONTRACT.balanceOf(msg.sender)
     if(!REPCONTRACT.transferFrom(msg.sender, 0, balance) or !REPORTING.addReporter(1010101, msg.sender, 0, balance, 0)):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
 # Allows spender to withdraw from your dormant rep account
 def approve(branch, spender, fxpValue):
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     self.amountCanSpend[msg.sender][spender].branch[branch] = fxpValue
     log(type = Approval, msg.sender, spender, branch, fxpValue)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
@@ -230,11 +230,11 @@ macro checkInvariants($account):
     # Rep cannot be simultaneously spent (transferred) and used to vote
     atFirstHalfOfPeriod()
     if(delta > 1 and CATCHUP.penalizationCatchup(branch, $account) != 1):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-4)
     if(!CONSENSUS.getRepRedistributionDone(branch, $account)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(0)
 
@@ -262,12 +262,12 @@ macro checkSendRepInvariants():
                 throw()
         else:
             REPORTING.addReporter(branch, from)
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     # If a user hasn't claimed rep on the child branch yet and it's a fork scenario, don't allow sending rep on the parent branch until the receiver claims it
     if(REPORTING.getReporterID(branch, receiverIndex) != receiver or (child && !tooLateForChild && REPORTING.getReporterID(branch, REPORTING.repIDToIndex(child, receiver)) != receiver)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-3)
     # If a user hasn't claimed rep on the child branch yet and it's a fork scenario, don't allow sending rep on the parent branch until the sender claims it
@@ -276,7 +276,7 @@ macro checkSendRepInvariants():
             throw()
 
     if(senderBalance < fxpValue or fxpValue <= 0 or !(self.amountCanSpend[from][msg.sender].branch[branch] >= fxpValue or from == msg.sender)):
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-5)
     if(from != msg.sender):
@@ -295,7 +295,7 @@ macro checkRepConversionInvariants():
                 throw()
         else:
             REPORTING.addReporter(branch, msg.sender)
-        if(!mutexWhitelisted()):
+        if(!isCallerWhitelisted()):
             MUTEX.unsetMutex()
         return(-1)
     if(senderBalance < fxpValue or fxpValue <= 0):

--- a/src/functions/shareTokens.se
+++ b/src/functions/shareTokens.se
@@ -50,9 +50,9 @@ def init():
 
 def transfer(to: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     self.controller.checkWhitelist(msg.sender)
     senderBalance = self.accounts[msg.sender].balance
@@ -64,15 +64,15 @@ def transfer(to: address, value: uint256):
     self.accounts[msg.sender].balance -= value
     self.accounts[to].balance += value
     log(type = Transfer, msg.sender, to, value)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
 def transferFrom(from: address, to: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
     self.controller.checkWhitelist(msg.sender)
     senderBalance = self.accounts[from].balance
@@ -85,20 +85,20 @@ def transferFrom(from: address, to: address, value: uint256):
     self.accounts[from].balance -= value
     self.accounts[to].balance += value
     log(type = Transfer, from, to, value)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 
 def approve(spender: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !mutexWhitelisted()):
+    if(MUTEX.getMutex() && !isCallerWhitelisted()):
         throw()
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.setMutex()
 
     self.accounts[msg.sender].spenders[spender].maxValue = value
     log(type=Approval, msg.sender, spender, value)
-    if(!mutexWhitelisted()):
+    if(!isCallerWhitelisted()):
         MUTEX.unsetMutex()
     return(1)
 

--- a/src/macros/refund.sem
+++ b/src/macros/refund.sem
@@ -15,9 +15,9 @@ macro refund():
     if(msg.value > 0 and !send(msg.sender, msg.value)):
         throw()
 
-macro mutexWhitelisted():
-    inMutexWhitelist = self.controller.checkWhitelist(msg.sender)
-    if(inMutexWhitelist):
+macro isCallerWhitelisted():
+    inWhitelist = self.controller.checkWhitelist(msg.sender)
+    if(inWhitelist):
         1
     else:
         0


### PR DESCRIPTION
This change is for improved readability.  This macro doesn't have anything to do with mutexes, it just checks to see whether the caller is whitelisted or not.