### PR TITLE
Simplifies the mutex and changes naming to match convention found in other languages.

### DIFF
--- a/src/data_api/mutex.se
+++ b/src/data_api/mutex.se
@@ -7,15 +7,14 @@ data controller
 def init():
     self.controller = 0x0
 
-def setMutex():
+def acquire():
+    if (self.mutex == 1):
+        throw()
     self.controller.checkWhitelist(msg.sender)
     self.mutex = 1
     return(1)
 
-def unsetMutex():
+def release():
     self.controller.checkWhitelist(msg.sender)
     self.mutex = 0
     return(1)
-
-def getMutex():
-    return(self.mutex)

--- a/src/functions/bidAndAsk.se
+++ b/src/functions/bidAndAsk.se
@@ -82,12 +82,10 @@ def init():
 
 def placeOrder(type, fxpAmount, fxpPrice, market, outcome):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     saveOrder(type, fxpAmount, fxpPrice, market, outcome, msg.sender)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(bidAndAskLogReturn, FAILURE)
 
 #
@@ -97,16 +95,14 @@ def placeOrder(type, fxpAmount, fxpPrice, market, outcome):
 # 200k gas
 def cancel(orderID):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     # user can cancel anytime
     # Get order
     fetchOrderCancelInfo()
     # Check the owner
     if(msg.sender != owner):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(bidAndAskLogReturn, FAILURE)
 
     # Clear the order first
@@ -114,7 +110,7 @@ def cancel(orderID):
     refundOrder()
     # Log cancellation
     log(type = logCancel, market, msg.sender, fxpPrice, fxpAmount, orderID, outcome, type, moneyEscrowed, sharesEscrowed)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(bidAndAskLogReturn, SUCCESS)
 
 macro saveOrder($type, $fxpAmount, $fxpPrice, $market, $outcome, $sender):
@@ -142,7 +138,7 @@ macro saveOrder($type, $fxpAmount, $fxpPrice, $market, $outcome, $sender):
     MARKETS.addOrder($market, $orderID)
 
     log(type = logAddTx, $market, $sender, $type, $fxpPrice, $initialAmount, $outcome, $orderID, $moneyEscrowed, $sharesEscrowed)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(bidAndAskLogReturn, $orderID)
 
 macro refundOrder():
@@ -173,7 +169,7 @@ macro fetchOrderCancelInfo():
     order = array(ORDER_FIELDS)
     order = ORDERS.getOrder(orderID, outitems = ORDER_FIELDS)
     if(!order[0]):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     type = order[1]
     market = order[2]
@@ -186,10 +182,10 @@ macro fetchOrderCancelInfo():
 
 macro checkOrderPreconditions():
     if(!$branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     if(BRANCHES.getOracleOnly($branch)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
 
 macro placeAsk():
@@ -212,7 +208,7 @@ macro placeAsk():
         $price = $fxpPrice - $minValue
         $cost = safeFxpMul($fxpAmount, $price)
         if($price > $cumulativeScale or $cost < MIN_ORDER_VALUE or $cost >= MAX_ORDER_VALUE):
-            MUTEX.unsetMutex()
+            MUTEX.release()
             return(-1)
         $fill = min($sharesHeld, $fxpAmount)
         $fxpAmount -= $fill
@@ -229,7 +225,7 @@ macro placeAsk():
         $costPerShareShorting = $maxValue - $fxpPrice
         $orderCost = safeFxpMul($fxpAmount, $costPerShareShorting)
         if($costPerShareShorting > $cumulativeScale or $orderCost < MIN_ORDER_VALUE or $orderCost >= MAX_ORDER_VALUE):
-            MUTEX.unsetMutex()
+            MUTEX.release()
             return(-1)
         $moneyEscrowed += $orderCost
         $paidOrderCost = INFO.getCurrency($market).transferFrom($sender, INFO.getWallet($market), $orderCost)
@@ -261,7 +257,7 @@ macro placeBid():
         $price = $fxpPrice - $minValue
         $cost = safeFxpMul($fxpAmount, $price)
         if($price > $cumulativeScale or $cost < MIN_ORDER_VALUE or $cost >= MAX_ORDER_VALUE):
-            MUTEX.unsetMutex()
+            MUTEX.release()
             return(-1)
         $fill = min($sharesHeld, $fxpAmount)
         $fxpAmount -= $fill
@@ -283,7 +279,7 @@ macro placeBid():
         $cost = safeFxpMul($fxpAmount, $price)
         $moneyEscrowed += $cost
         if($price > $cumulativeScale or $cost < MIN_ORDER_VALUE or $cost >= MAX_ORDER_VALUE):
-            MUTEX.unsetMutex()
+            MUTEX.release()
             return(-1)
         $paidOrderCost = INFO.getCurrency($market).transferFrom($sender, INFO.getWallet($market), $cost)
         if(!$paidOrderCost):

--- a/src/functions/claimInitialRep.se
+++ b/src/functions/claimInitialRep.se
@@ -77,9 +77,7 @@ def init():
     # -3: only behind one period and not caught up / penalized yet
 def claimInitialRep(parent, branch):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     # auto increment vote period if needed
     INCREMENTPERIOD.incrementPeriodAfterReporting(parent)
     parentPeriod = BRANCHES.getParentPeriod(branch)
@@ -116,26 +114,26 @@ def claimInitialRep(parent, branch):
         CONSENSUS.setPenalizedUpTo(branch, msg.sender, (BRANCHES.getVotePeriod(branch) - 1))
         CONSENSUS.setRepCollected(branch, msg.sender, (BRANCHES.getVotePeriod(branch) - 1))
     REPORTING.addReporter(branch, msg.sender, rep, dormantRep, repDecrease)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkRepClaimPreconditions():
     if(BRANCHES.getParent(branch) != parent && parent && branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     tooLate = block.timestamp > (BRANCHES.getCreationDate(branch) + ONE_MONTH)
     alreadyClaimed = REPORTING.repIDToIndex(branch, msg.sender)
     if(alreadyClaimed or tooLate):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     lastPeriodPenalized = CONSENSUS.getPenalizedUpTo(parent, msg.sender)
     lastPeriod = BRANCHES.getVotePeriod(parent) - 1
     delta = lastPeriod - lastPeriodPenalized
     if(delta > 1 and CATCHUP.penalizationCatchup(parent, msg.sender) != 1):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
     if(!CONSENSUS.getRepRedistributionDone(parent, msg.sender)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
 
 macro removeRepFromThoseWhoReportedWrong():

--- a/src/functions/claimMarketProceeds.se
+++ b/src/functions/claimMarketProceeds.se
@@ -68,9 +68,7 @@ def init():
 
 def claimProceeds(market):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     event = MARKETS.getMarketEvent(market, 0)
     winningOutcomes = array(MAX_WINNING_OUTCOMES)
     winningOutcomes = MARKET.getWinningOutcomes(market, outitems = MAX_WINNING_OUTCOMES)
@@ -80,11 +78,11 @@ def claimProceeds(market):
     expiryPeriod = MARKETS.getLastExpDate(market) / periodLength
     if(currentPeriodMinus3Days <= expiryPeriod):
         # can't withdraw funds until 3 days after market resolves
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     # market not resolved
     if(!winningOutcomes[0]):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     scalar = winningOutcomes[1]
     if(scalar):
@@ -97,5 +95,5 @@ def claimProceeds(market):
         # claims winnings for a regular binary or categorical market
         else:
             success = CLOSEONE.oneOutcome(market, winningOutcomes[0], msg.sender, 0, EVENTS.getNumOutcomes(event))
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(success)

--- a/src/functions/closeMarket.se
+++ b/src/functions/closeMarket.se
@@ -73,10 +73,8 @@ def init():
 
 def closeMarket(market, sender):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     event = MARKETS.getMarketEvent(market, 0)
     branch = EVENTS.getEventBranch(event)
     expiration = EVENTS.getExpiration(event)
@@ -98,31 +96,31 @@ def closeMarket(market, sender):
     marketWallet.transfer(BRANCHES.getBranchWallet(branch, marketCurrency), marketCurrency.balanceOf(marketWallet) - safeFxpMul(MARKETS.getSharesPurchased(market, 1), MARKETS.getCumulativeScale(market)))
 
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     logReturn(closeMarketLogReturn, 1)
 
 macro checkCloseMarketPreconditions():
     # as long as resolved and not challenged we can then resolve, i.e. if not challenged and > 6 days then can take prelim outcome and make it final outcome
     if(period <= votingPeriodEvent || (!EVENTS.getChallenged(event) && block.timestamp < expiration + SIX_DAYS)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(closeMarketLogReturn, 0)
     if(MARKETS.getOneWinningOutcome(market, 0)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(closeMarketLogReturn, -1)
     if(!EVENTS.getUncaughtOutcome(event) && !EVENTS.getFirstPreliminaryOutcome(event)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(closeMarketLogReturn, -2)
     if(BACKSTOPS.getRoundTwo(event) and !BACKSTOPS.getFinal(event)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(closeMarketLogReturn, -3)
     # if an event is one from before a fork and hasn't been moved yet or it's the event the fork occurred over and it's not over yet don't resolve it
     if((EVENTS.getForked(event) and !EVENTS.getForkedDone(event)) or eventCreatedPriorToFork(eventID)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(closeMarketLogReturn, -4)
 
 macro resolveEventsInMarket():
@@ -138,7 +136,7 @@ macro resolveEventsInMarket():
         throw()
     if(resolution == -1):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(closeMarketLogReturn, -5)
 
 def closeChallengeBond(event):

--- a/src/functions/collectFees.se
+++ b/src/functions/collectFees.se
@@ -35,9 +35,8 @@ def init():
     self.controller = 0x0
 
 def collectRep(branch, sender):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     periodLength = BRANCHES.getPeriodLength(branch)
     votePeriod = BRANCHES.getVotePeriod(branch)
     lastPeriod = votePeriod - 1
@@ -49,12 +48,12 @@ def collectRep(branch, sender):
     if(newRep < ONE):
         prepareInfoForConsensus()
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(2)
     collectRedistributedRep()
     prepareInfoForConsensus()
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 # Allows a user to collect trading fees earned at the end of a period
@@ -65,9 +64,8 @@ def collectRep(branch, sender):
     # -3: rep not collected yet
 # 2 means no errors but didnt report last period
 def collectFees(branch, sender, currency):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     periodLength = BRANCHES.getPeriodLength(branch)
     votePeriod = BRANCHES.getVotePeriod(branch)
     lastPeriod = votePeriod - 1
@@ -78,11 +76,11 @@ def collectFees(branch, sender, currency):
     # need 1 rep to claim fees
     if(newRep < ONE):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(2)
     collectTradeFees()
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 macro checkCollectRepPreconditions():
@@ -90,11 +88,11 @@ macro checkCollectRepPreconditions():
     if(!CONSENSUS.getRepRedistributionDone(branch, sender)):
         # need to call penalize for all events and penalize for too lazy to report or catchup if necessary
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     if(repCollected):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
 macro checkCollectFeesPreconditions():
@@ -102,12 +100,12 @@ macro checkCollectFeesPreconditions():
     if(!CONSENSUS.getRepRedistributionDone(branch, sender)):
         # need to call penalize for all events and penalize for too lazy to report or catchup if necessary
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     feesCollected = CONSENSUS.getFeesCollected(branch, sender, lastPeriod, currency)
     if(feesCollected):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
     if(!repCollected):
         return(-3)

--- a/src/functions/completeSets.se
+++ b/src/functions/completeSets.se
@@ -59,9 +59,7 @@ def init():
 
 def buyCompleteSets(market, fxpAmount):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     branch = MARKETS.getBranch(market)
     numOutcomes = MARKETS.getMarketNumOutcomes(market)
     cumulativeScale = MARKETS.getCumulativeScale(market)
@@ -85,7 +83,7 @@ def buyCompleteSets(market, fxpAmount):
         MARKETS.addFees(market, feesInWei)
         EXPEVENTS.adjustPeriodFeeValue(branch, MARKETS.getTradingPeriod(market), feesInWei)
 
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(completeSetsLogReturn, 1)
 
 # Sells fxpAmount of every outcome [if user owns it]
@@ -95,9 +93,7 @@ def buyCompleteSets(market, fxpAmount):
     # -2: user hasn't specified a large enough amount
 def sellCompleteSets(market, fxpAmount):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     branch = MARKETS.getBranch(market)
     numOutcomes = MARKETS.getMarketNumOutcomes(market)
     cumulativeScale = MARKETS.getCumulativeScale(market)
@@ -120,32 +116,32 @@ def sellCompleteSets(market, fxpAmount):
     currency = INFO.getCurrency(market)
     if(!INFO.getWallet(market).transfer(INFO.getCreator(market), safeDiv(fee, 2))):
         throw()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(completeSetsLogReturn, 1)
 
 macro checkBuyCompleteSetsPreconditions():
     if(!MARKETS.getMarketNumOutcomes(market)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(completeSetsLogReturn, 0)
     if(BRANCHES.getOracleOnly(branch)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(completeSetsLogReturn, -1)
     if(fxpAmount <= 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(completeSetsLogReturn, -3)
     # send money from user acc. to market address/account
     if(!INFO.getCurrency(market).transferFrom(msg.sender, INFO.getWallet(market), cost)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(completeSetsLogReturn, -2)
 
 macro checkSellCompleteSetsPreconditions():
     if(fxpAmount <= 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(completeSetsLogReturn, -2)
     n = 1
     while(n <= numOutcomes):
         if(MARKETS.getParticipantSharesPurchased(market, msg.sender, n) < fxpAmount):
-            MUTEX.unsetMutex()
+            MUTEX.release()
             logReturn(completeSetsLogReturn, -1)
         n += 1
     n = 1

--- a/src/functions/consensus.se
+++ b/src/functions/consensus.se
@@ -81,9 +81,7 @@ def init():
 
 def penalizeWrong(branch, event):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     repBalance = REPORTING.getRepBalance(branch, msg.sender)
     currentVotePeriod = BRANCHES.getVotePeriod(branch)
@@ -126,38 +124,38 @@ def penalizeWrong(branch, event):
     # once penalized for all events actually get rid of net rep lost and send it to the branch for redistribution
     if(numReportedOn == CONSENSUS.getPenalizedNum(branch, lastPeriod, msg.sender)):
         sendRedistributedRepToBranch()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(consensusLogReturn, 1)
 
 macro checkPenalizeWrongPreconditions():
     if(EVENTS.getEventBranch(event) != branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -7)
     if(repBalance < ONE):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, 0)
     p = proportionCorrect(event, 0)
     if(roundTwo and outcome != 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -1)
     atFirstHalfOfPeriod()
     tooLateToPenalize = (block.timestamp / periodLength - 2) != lastPeriod
     if(tooLateToPenalize):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -2)
     if(CONSENSUS.getPenalizedUpTo(branch, msg.sender) == lastPeriod):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -3)
     if(EVENTS.getForked(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -4)
     # if no outcome / event not resolved yet, resolve it [as long as it wasn't an event that was pushed fwd and got rejected and thus hasn't actually resolved yet]
     eventNotResolvedAndNeedsToBe = !EVENTS.getOutcome(event) and !(rejected and EVENTS.getRejectedPeriod(event) == lastPeriod)
     if(eventNotResolvedAndNeedsToBe and CLOSEMARKET.closeMarket(EVENTS.getMarket(event, 0), msg.sender) != 1):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -5)
     if(!CONSENSUS.getRepCollected(branch, msg.sender, lastPeriod - 1)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(consensusLogReturn, -6)
 
 macro countAsPenalized():

--- a/src/functions/controller.se
+++ b/src/functions/controller.se
@@ -116,7 +116,7 @@ def addToWhitelist(address):
 #     if(hasreported) throw
 #     if(!CONSENSUS.getRepCollected(branch, msg.sender, votePeriod - 1)):
 #     if(COLLECTFEES.collectRep(branch, msg.sender, value = msg.value) < 0):
-#         MUTEX.unsetMutex()
+#         MUTEX.release()
 #         logReturn(makeReportsLogReturn, -8)
 
 # def getProposals(start, end):

--- a/src/functions/convertRep.se
+++ b/src/functions/convertRep.se
@@ -105,9 +105,7 @@ def init():
             # say you lost rep in round 1, if it was an invalid round 2 you have incentive to convert to dormant
             # say you gained rep in round 1, if it was an invalid round 2 you have incentive _to_ not convert to dormant or send rep b/c you want to keep it
 def convertToDormantRep(branch, fxpValue):
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     checkInvariants(msg.sender)
     refund()
     # auto increment vote period if needed
@@ -123,11 +121,11 @@ def convertToDormantRep(branch, fxpValue):
 
     if(delta > 1 and CATCHUP.penalizationCatchup(branch, $account) != 1):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-4)
     if(!CONSENSUS.getRepRedistributionDone(branch, $account)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
     senderIndex = REPORTING.repIDToIndex(branch, msg.sender)
@@ -141,7 +139,7 @@ def convertToDormantRep(branch, fxpValue):
     if(!safeToSubtract(senderBalance, fxpValue) or !safeToAdd(senderDormantBalance, fxpValue) or !REPORTING.subtractRep(branch, senderIndex, fxpValue) or !REPORTING.addDormantRep(branch, senderIndex, fxpValue)):
         throw()
     REPORTING.adjustActiveRep(branch, -fxpValue)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 # Convert dormant rep to active rep
@@ -152,9 +150,7 @@ def convertToDormantRep(branch, fxpValue):
     # -4: couldn't catchup automatically
     # -5: not enough rep
 def convertToActiveRep(branch, fxpValue):
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     checkInvariants(msg.sender)
     senderIndex = REPORTING.repIDToIndex(branch, msg.sender)
     senderBalance = REPORTING.balanceOfReporter(branch, msg.sender)
@@ -164,7 +160,7 @@ def convertToActiveRep(branch, fxpValue):
     if(!safeToSubtract(senderBalance, fxpValue) or !safeToAdd(senderActiveBalance, fxpValue) or !REPORTING.subtractDormantRep(branch, senderIndex, fxpValue) or !REPORTING.addRep(branch, senderIndex, fxpValue)):
         throw()
     REPORTING.adjustActiveRep(branch, fxpValue)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkInvariants($account):
@@ -182,11 +178,11 @@ macro checkInvariants($account):
 
     if(delta > 1 and CATCHUP.penalizationCatchup(branch, $account) != 1):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-4)
     if(!CONSENSUS.getRepRedistributionDone(branch, $account)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
 macro checkConversionDuringForkInvariants():
@@ -211,9 +207,9 @@ macro checkRepConversionInvariants():
         else:
             REPORTING.addReporter(branch, msg.sender)
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     if(senderBalance < fxpValue or fxpValue <= 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-5)
     checkConversionDuringForkInvariants()

--- a/src/functions/createBranch.se
+++ b/src/functions/createBranch.se
@@ -55,10 +55,8 @@ def init():
 
 def createSubbranch(description:str, periodLength, parent, fxpMinTradingFee, oracleOnly, mostRecentChildBranch):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     checkBranchCreationPreconditions()
     parentPeriod = BRANCHES.getVotePeriod(parent)
@@ -84,20 +82,20 @@ def createSubbranch(description:str, periodLength, parent, fxpMinTradingFee, ora
     if(!feePaid or !INFO.setInfo(branch, description, msg.sender, 47 * ONE, 0, 0) or !REPORTING.setInitialReporters(branch)):
         throw()
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(branch)
 
 macro checkBranchCreationPreconditions():
     # provided branch doesn't already exist, create it
     if(INFO.getCreator(branch)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-2)
     if(periodLength <= TWENTY_FOUR_HR or !BRANCHES.getPeriodLength(parent) or !len(description)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     if(fxpMinTradingFee <= 0 or fxpMinTradingFee > MAX_FEE or (oracleOnly != 0 and oracleOnly != 1)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)

--- a/src/functions/createEvent.se
+++ b/src/functions/createEvent.se
@@ -114,10 +114,8 @@ def init():
 
 def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numOutcomes, resolution: str, resolutionAddress, currency, forkResolveAddress):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
     if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+        MUTEX.acquire()
 
     periodLength = BRANCHES.getPeriodLength(branch)
     checkEventCreationPreconditions()
@@ -135,7 +133,7 @@ def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numO
     event = ripemd160(eventInfo, chars = len(eventInfo))
     if(INFO.getCreator(event)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
     checkSubcurrencyIsValid(currency)
@@ -166,7 +164,7 @@ def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numO
             EVENTS.setBond(event, validityBond)
             EVENTS.addPast24(period)
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(event)
     else:
         throw()
@@ -174,15 +172,15 @@ def createEvent(branch, description:str, expDate, fxpMinValue, fxpMaxValue, numO
 macro checkEventCreationPreconditions():
     if(!periodLength or !len(description) or !len(resolution) or expDate < block.timestamp or !resolutionAddress):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     if(fxpMaxValue < fxpMinValue or (fxpMaxValue - fxpMinValue) < ONE or (fxpMaxValue + fxpMinValue) < fxpMaxValue):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-2)
     if(numOutcomes < 2 or numOutcomes > 8):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-3)
     parent = BRANCHES.getParent(branch)
     parentLastForked = BRANCHES.getForkPeriod(parent)

--- a/src/functions/createMarket.se
+++ b/src/functions/createMarket.se
@@ -132,10 +132,8 @@ def init():
 # need at least 1.2M gas @ gas price to cover resolution & 500k per event to calc. num reports for it - this is passed as value to this function
 # need to check that it's an actual subcurrency upon market creation
 def createMarket(branch, description: str, fxpTradingFee, event, tag1, tag2, tag3, extraInfo: str, currency):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     periodLength = BRANCHES.getPeriodLength(branch)
     baseReporters = BRANCHES.getBaseReporters(branch)
@@ -178,7 +176,7 @@ def createMarket(branch, description: str, fxpTradingFee, event, tag1, tag2, tag
     # if it's already been created return 0
     if(INFO.getCreator(market)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-4)
     events = array(1)
     events[0] = event
@@ -196,7 +194,7 @@ def createMarket(branch, description: str, fxpTradingFee, event, tag1, tag2, tag
 
     log(type = marketCreated, market)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(market)
 
 # initialize market and send money to pay for resolution
@@ -224,11 +222,11 @@ macro checkMarketCreationPreconditions():
     # will need to get equivalent value in usd or eth or w/e via etherex exchange for subcurrency markets
     if(!periodLength or !len(description) or fxpTradingFee < BRANCHES.getMinTradingFee(branch) or fxpTradingFee > MAX_FEE or EVENTS.getEventBranch(event) != branch or !INFO.getCreator(event)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     if(expirationDate < block.timestamp):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-2)
     if(!BRANCHES.getCurrencyActive(branch, currency)):
         return(-5)

--- a/src/functions/eventModifiers.se
+++ b/src/functions/eventModifiers.se
@@ -116,10 +116,8 @@ def init():
     # -1: not allowed for events during a fork scenario for events that were created before the fork until the fork is over
 # Called when first resolver hasn't resolved an event within 3 days
 def putEventIntoReportingPeriod(event):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
     if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+        MUTEX.acquire()
     # add events to the appropriate reporting period
     branch = EVENTS.getEventBranch(event)
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -134,21 +132,19 @@ def putEventIntoReportingPeriod(event):
         EVENTS.setExpiration(event, block.timestamp)
         EVENTS.setChallenged(event)
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(1)
     else:
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
 # Errors:
     # -1: not allowed for events during a fork scenario for events that were created before the fork until the fork is over
 # Used to challenge a first resolution within 3 days after it's been resolved [or more accurately, 3 days after the last point it can be resolved]
 def challengeInitialResolution(event):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
     if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+        MUTEX.acquire()
     # add events to the appropriate reporting period
     branch = EVENTS.getEventBranch(event)
     currency = INFO.getCurrency(event)
@@ -166,32 +162,30 @@ def challengeInitialResolution(event):
         EVENTS.setChallenged(event)
         payExtraBond()
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(1)
     else:
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
 # could create a contract which is the sender which uses ecrecover to verify a realitykeys signature on a hash + result, 0 goes to 10**18, 1 goes to 2**65
 # with oraclize.it do value = parseInt(result, 18) to get it in the proper 10**18 base, then do (value - min) * 10**18 / range to submit the result to augur
 # unethical is just a .5 outcome for scalar/categorical, 1.5 for binary as usual
 def resolveEarly(event, outcome):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
     if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+        MUTEX.acquire()
     if(msg.sender == EVENTS.getResolutionAddress(event) && block.timestamp > EVENTS.getExpiration(event) && block.timestamp < (EVENTS.getExpiration(event) + THREE_DAYS)):
         # outcome of 1 is 1/10**18 or basically 0, but allows us to still check if outcome is 0 or not to see if an outcome has been set
         if(outcome == 0):
             outcome = 1
         EVENTS.setFirstPreliminaryOutcome(event, outcome)
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(1)
     else:
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
 # Allows a user to directly add fees / effectively pay for oracle usage w/o having to trade using the default contracts

--- a/src/functions/fillAskLibrary.se
+++ b/src/functions/fillAskLibrary.se
@@ -64,7 +64,7 @@ def fillAsk(orderID, amountTakerWants):
     order = array(ORDER_FIELDS)
     order = ORDERS.getOrder(orderID, outitems = ORDER_FIELDS)
     if(!order[0]):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([0]: arr)
     type = order[1]
     market = order[2]
@@ -85,7 +85,7 @@ def fillAsk(orderID, amountTakerWants):
     orderInfo[3] = msg.sender
     orderHash = sha3(orderInfo, items = 4)
     if(ORDERS.checkHash(orderHash, msg.sender) == -1):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([-1]: arr)
     maxValue = EVENTS.getMaxValue(MARKETS.getMarketEvent(market, 0))
     minValue = 0
@@ -219,9 +219,9 @@ macro accountForRegularBuyerBiddingWithCash():
 
 macro checkTradePreconditions():
     if(owner == msg.sender):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([-3]: arr)
     # Make sure the order has been mined, obvious HFT prevention
     if(block.number <= order[6]):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([-2]: arr)

--- a/src/functions/fillBidLibrary.se
+++ b/src/functions/fillBidLibrary.se
@@ -65,7 +65,7 @@ def fillBid(orderID, amountTakerWants):
     order = array(ORDER_FIELDS)
     order = ORDERS.getOrder(orderID, outitems = ORDER_FIELDS)
     if(!order[0]):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([0]: arr)
     type = order[1]
     market = order[2]
@@ -86,7 +86,7 @@ def fillBid(orderID, amountTakerWants):
     orderInfo[3] = msg.sender
     orderHash = sha3(orderInfo, items = 4)
     if(ORDERS.checkHash(orderHash, msg.sender) == -1):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([-1]: arr)
     maxValue = EVENTS.getMaxValue(MARKETS.getMarketEvent(market, 0))
     minValue = 0
@@ -224,9 +224,9 @@ macro accountForShortSelling():
 
 macro checkTradePreconditions():
     if(owner == msg.sender):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([-3]: arr)
     # Make sure the order has been mined, obvious HFT prevention
     if(block.number <= order[6]):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return([-2]: arr)

--- a/src/functions/forkPenalize.se
+++ b/src/functions/forkPenalize.se
@@ -53,9 +53,7 @@ def init():
 
 def penalizeOnForkedEvent(branch, event):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     repBalance = REPORTING.getRepBalance(branch, msg.sender)
     lastPeriodVotedOn = BRANCHES.getVotePeriod(branch) - 1
     lastPeriod = lastPeriodVotedOn
@@ -79,30 +77,30 @@ def penalizeOnForkedEvent(branch, event):
     # once penalized for all events actually get rid of net rep lost
     if(numReportedOn == CONSENSUS.getPenalizedNum(branch, lastPeriodVotedOn, msg.sender)):
         sendRedistributedRepToBranch()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkForkPenalizationPreconditions():
     if(repBalance < ONE):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     if((block.timestamp / periodLength - 2) != lastPeriodVotedOn):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     atFirstHalfOfPeriod()
     # means event / fork isn't resolved
     if(!EVENTS.getForkedDone(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
     if(CONSENSUS.getPenalizedUpTo(branch, msg.sender) == lastPeriodVotedOn):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-4)
     if(!CONSENSUS.getRepCollected(branch, msg.sender, lastPeriodVotedOn - 1)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-5)
     branchIsParent = BRANCHES.getEventForkedOver(branch) == event
     if(branchIsParent):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-6)
 
 macro penalizeOrRewardReporter():

--- a/src/functions/forkResolution.se
+++ b/src/functions/forkResolution.se
@@ -96,10 +96,8 @@ def init():
 # parent branch is branch here
 # If there's only 1 event and that's the one we forked over [rare edge case] we can call resolve fork manually if it hasn't been done yet within the time parameters which allows a fork to be resolved [2 periods after the start of the fork]
 def resolveFork(branch):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
     if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+        MUTEX.acquire()
     forkPeriod = BRANCHES.getForkPeriod(branch)
     currentPeriod = block.timestamp / BRANCHES.getPeriodLength(branch)
     winner = BACKSTOPS.getResolved(branch, forkPeriod)
@@ -109,7 +107,7 @@ def resolveFork(branch):
         throw()
     if(currentPeriod < (forkPeriod + 2)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
     forkPeriod = BRANCHES.getForkPeriod(EVENTS.getEventBranch(event))
@@ -123,7 +121,7 @@ def resolveFork(branch):
         winner = fork
     BACKSTOPS.setResolved(branch, forkPeriod, winner)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(winner)
 
 # Resolve fork method that gets exchange rate

--- a/src/functions/forking.se
+++ b/src/functions/forking.se
@@ -102,9 +102,7 @@ def init():
     # -2: no fork allowed for 1 period after a forking event
     # -3: invalid branch
 def fork(event, branch, forkedOverEthicality):
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     forkPeriod = BRANCHES.getForkPeriod(branch)
     currentPeriod = block.timestamp / BRANCHES.getPeriodLength(branch)
@@ -125,27 +123,27 @@ def fork(event, branch, forkedOverEthicality):
     makeFork()
     # return round 2 bond on orig. branch
     returnRoundTwoBond()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkForkPreconditions():
     if(!EVENTS.getRoundTwo(event) or BACKSTOPS.getFinal(event) or EVENTS.getForked(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     if(forkPeriod == currentVotePeriod or currentVotePeriod == (forkPeriod + 1) or currentVotePeriod == (forkPeriod + 2)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
     if(EVENTS.getEventBranch(event) != branch or !branch or !event):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
     if(msg.value < 350000 * tx.gasprice):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     CONSENSUSDATA.setRefund(event, msg.value)
     last48HoursOfPeriod = (block.timestamp / BRANCHES.getPeriodLength(branch) != ((block.timestamp + 2 * TWENTY_FOUR_HR) / BRANCHES.getPeriodLength(branch)))
     reportedOnInRoundTwo = EVENTS.getUncaughtOutcome(event)
     if(!last48HoursOfPeriod or !reportedOnInRoundTwo):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
 
 macro makeFork():

--- a/src/functions/incrementPeriod.se
+++ b/src/functions/incrementPeriod.se
@@ -29,14 +29,12 @@ def init():
 # ui has to call this to stay cheap / not check it elsewhere
 def incrementPeriodAfterReporting(branch):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
     if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+        MUTEX.acquire()
     # do this after reporting is finished
     if(!periodOver(branch)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
     periodVotingOnNow = block.timestamp / BRANCHES.getPeriodLength($branch) - 1
     lastPeriod = periodVotingOnNow - 1
@@ -50,7 +48,7 @@ def incrementPeriodAfterReporting(branch):
     CONSENSUS.setBaseReportersLastPeriod(branch, BRANCHES.getBaseReporters(branch))
     BRANCHES.setBaseReporters(branch, baseReporterQuantity)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 macro periodOver($branch):

--- a/src/functions/makeReports.se
+++ b/src/functions/makeReports.se
@@ -93,9 +93,7 @@ def init():
     # -8: fees couldn't be collected
 def submitReport(event, salt, fxpReport, fxpEthics):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     branch = EVENTS.getBranch(event)
     balance = REPORTING.getRepBalance(branch, msg.sender)
@@ -109,7 +107,7 @@ def submitReport(event, salt, fxpReport, fxpEthics):
 
     saveUsersReportAndHandleEthicality()
     coverGasCostIfPossible()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(makeReportsLogReturn, 1)
 
 def makeHash(salt, fxpReport, event, sender, ethics):
@@ -128,33 +126,33 @@ macro checkSubmitReportPreconditions():
     if(roundTwo or forkedOverThisEvent):
         weight = balance
     if(balance < ONE):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, 0)
     if(EXPEVENTS.getReport(branch, votePeriod, event, msg.sender)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -1)
     atSecondHalfOfPeriod()
     realHash = EXPEVENTS.getReportHash(branch, votePeriod, msg.sender, event)
     if(self.makeHash(salt, fxpReport, event, msg.sender, fxpEthics) != realHash or !realHash):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -3)
     if(fxpEthics != ONE and fxpEthics != 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -5)
     if(EVENTS.getOutcome(event) != 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -6)
     # commented out for easy testing
     # if(block.timestamp / periodLength != ((block.timestamp + 2 * TWENTY_FOUR_HR) / periodLength)):
     #    logReturn(makeReportsLogReturn, -7)
     # ensures user has collected fees for last reporting period
     if(!CONSENSUS.getRepCollected(branch, msg.sender, votePeriod - 1) and COLLECTFEES.collectRep(branch, msg.sender, value = msg.value) < 0):
-        MUTEX.unsetMutex()
+            MUTEX.release()
         logReturn(makeReportsLogReturn, -8)
     # actual submitting of fxpReport and ethicality
     validatedFxpReport = VALIDATEREPORTS.validateReport(event, branch, votePeriod, fxpReport, forkedOverEthicality, forkedOverThisEvent, weight)
     if(validatedFxpReport == -4):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -4)
 
 macro saveUsersReportAndHandleEthicality():

--- a/src/functions/marketModifiers.se
+++ b/src/functions/marketModifiers.se
@@ -118,12 +118,10 @@ def init():
     # -2: invalid new trading fee
 def updateTradingFee(market, fxpTradingFee):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     branch = MARKETS.getBranch(market)
     if(msg.sender != INFO.getCreator(market)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     oldFee = MARKETS.getTradingFee(market)
     currency = INFO.getCurrency(market)
@@ -131,12 +129,12 @@ def updateTradingFee(market, fxpTradingFee):
     oldCreationFee = safeFxpMul(safeFxpDiv(POINT_ZERO_SIX * baseReporters, oldFee), BRANCHES.getCurrencyRate(branch, currency))
     newCreationFee = safeFxpMul(safeFxpDiv(POINT_ZERO_SIX * baseReporters, fxpTradingFee), BRANCHES.getCurrencyRate(branch, currency))
     if(fxpTradingFee < BRANCHES.getMinTradingFee(branch) or fxpTradingFee > oldFee):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
     if(!currency.transferFrom(msg.sender, BRANCHES.getBranchWallet(branch, currency), newCreationFee - oldCreationFee) or !MARKETS.setTradingFee(market, fxpTradingFee)):
         throw()
     log(type = tradingFeeUpdated, market, fxpTradingFee)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 # Anyone can post an "Early Resolution Bond"
@@ -155,17 +153,15 @@ def updateTradingFee(market, fxpTradingFee):
     # -4: event isn't in a regular reporting cycle yet
 def pushMarketForward(branch, market):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     periodLength = BRANCHES.getPeriodLength(branch)
     currentPeriod = block.timestamp / periodLength
     if(MARKETS.getOneWinningOutcome(market, 0) or MARKETS.getPushedForward(market)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
     if(MARKETS.getBranch(market) != branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     event = MARKETS.getMarketEvent(market, 0)
     if(eventCreatedPriorToFork(event)):
@@ -175,7 +171,7 @@ def pushMarketForward(branch, market):
     beingReportedOnNow = (expiration / periodLength == block.timestamp / periodLength)
     alreadyPushedForward = EVENTS.getRejectedPeriod(event) or expiration != EVENTS.getOriginalExpiration(event)
     if(alreadyPushedForward or beingReportedOnNow or EVENTS.getOutcome(event) or BACKSTOPS.getRoundTwo(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
     if(EXPEVENTS.getEvent(branch, expiration / periodLength, EXPEVENTS.getEventIndex(branch, expiration / periodLength, event)) != event):
         return(-4)
@@ -198,5 +194,5 @@ def pushMarketForward(branch, market):
     payEarlyResolutionBond = INFO.getCurrency(market).transferFrom(msg.sender, INFO.getWallet(market), bond)
     if(!payEarlyResolutionBond or !EVENTS.setEarlyResolutionBond(event, bond)):
         throw()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)

--- a/src/functions/moveEventAfterFork.se
+++ b/src/functions/moveEventAfterFork.se
@@ -96,9 +96,7 @@ def init():
 
 def moveEvent(event):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     forkPeriod = BRANCHES.getForkPeriod(EVENTS.getEventBranch(event))
     branch = EVENTS.getEventBranch(event)
@@ -109,7 +107,7 @@ def moveEvent(event):
     currentVotePeriod = BRANCHES.getVotePeriod(branch)
     checkMoveEventPreconditions()
     if(event == eventForkedOver):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(1)
     # leave event here in same branch
     elif(winner == EVENTS.getEventBranch(event)):
@@ -118,12 +116,12 @@ def moveEvent(event):
     else:
         moveEventToWinningBranch()
     BACKSTOPS.setMoved(event)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkMoveEventPreconditions():
     if(!branch or !event or currentVotePeriod < (forkPeriod + 2) or EVENTS.getOutcome(event) or BACKSTOPS.getMoved(event) or !eventCreatedPriorToFork(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     winner = BACKSTOPS.getResolved(branch, forkPeriod)
     if(!winner):

--- a/src/functions/offChainTrades.se
+++ b/src/functions/offChainTrades.se
@@ -32,27 +32,25 @@ def init():
 
 def trade(maker: address, v, r, s, tokenX: address, tokenY: address, orderSize, takerAmount, fxpPrice, expiration):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     orderHash = sha3([maker, tokenX, tokenY, orderSize, fxpPrice, expiration], items = 6)
     if(!checkSig(maker, orderHash, v, r, s)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
     if(block.timestamp > expiration):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     if(!checkHasAbilityToSpend(maker, tokenX, orderSize) || !checkHasAbilityToSpend(msg.sender, tokenY, safeFxpMul(takerAmount, fxpPrice))):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-2)
     if(safeAdd(self.amountFilled[orderHash], takerAmount) > orderSize):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-3)
 
     self.amountFilled[orderHash] += takerAmount
@@ -63,7 +61,7 @@ def trade(maker: address, v, r, s, tokenX: address, tokenY: address, orderSize, 
         throw()
     log(type = Trade, maker, msg.sender, tokenX, tokenY, amount, fxpPrice, orderHash)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 # fxpPrice is tokens of y per token of x
@@ -78,10 +76,8 @@ def onChainOrder(tokenX: address, orderSize, tokenY: address, fxpPrice, expirati
 
 def cancelOrder(tokenX: address, orderSize, tokenY: address, fxpPrice, expiration, v, r, s):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     orderHash = sha3([msg.sender, tokenX, tokenY, orderSize, fxpPrice, expiration], items = 6)
     if(ecrecover(orderHash, v, r, s) != msg.sender):
@@ -90,7 +86,7 @@ def cancelOrder(tokenX: address, orderSize, tokenY: address, fxpPrice, expiratio
     log(type = Cancel, tokenX, orderSize, tokenY, fxpPrice, expiration, msg.sender, v, r, s)
 
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 def getAmountFilled(orderHash):

--- a/src/functions/penalizationCatchup.se
+++ b/src/functions/penalizationCatchup.se
@@ -36,10 +36,8 @@ def init():
 
 def penalizationCatchup(branch, sender):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     if(sender != msg.sender):
         self.controller.checkWhitelist(msg.sender)
 
@@ -52,7 +50,7 @@ def penalizationCatchup(branch, sender):
     redistributeRepFromNotReporting()
     CONSENSUS.setPenalizedUpTo(branch, sender, lastPeriod)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 macro checkPenalizationCatchupPreconditions():
@@ -64,14 +62,14 @@ macro checkPenalizationCatchupPreconditions():
         delta -= 1
     if(delta <= 0):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     # provided user is at least one period behind and they didn't report in the last period
     alreadyPenalized = (lastPeriodPenalized == lastPeriod)
     reportedLastPeriod = EXPEVENTS.getNumReportsSubmitted(branch, lastPeriod, sender)
     if(alreadyPenalized or reportedLastPeriod):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-3)
 
 macro redistributeRepFromNotReporting():

--- a/src/functions/penalizeNotEnoughReports.se
+++ b/src/functions/penalizeNotEnoughReports.se
@@ -57,9 +57,7 @@ def init():
 
 def proveReporterDidntReportEnough(branch, reporter, eventExample):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     expectedEventsForReporterIncludingRequired = 0
     lastPeriod = BRANCHES.getVotePeriod(branch) - 1
@@ -84,16 +82,16 @@ def proveReporterDidntReportEnough(branch, reporter, eventExample):
     redistributeNotEnoughReportsRep()
     # refund gas cost for the sender
     CONSENSUS.doRefund(msg.sender, reporter)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkProveReporterDidntReportEnoughPreconditions():
     if(CONSENSUS.getNotEnoughPenalized(branch, reporter, lastPeriod)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     atFirstHalfOfPeriod()
     if(EVENTS.getEventBranch(eventExample) != branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
 
 macro ensureReporterCouldveReportedOnMoreButDidnt():
@@ -102,7 +100,7 @@ macro ensureReporterCouldveReportedOnMoreButDidnt():
     couldveReported = THRESHOLD.getEventCouldveReportedOn(branch, lastPeriod, reporter, eventExample)
     reportedOnLessThanShouldve = expectedEventsForReporterIncludingRequired / 2 > safeMul(numReportsSubmitted, ONE) and couldveReported
     if(!reportedOnLessThanShouldve):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-4)
 
 macro redistributeNotEnoughReportsRep():
@@ -111,7 +109,7 @@ macro redistributeNotEnoughReportsRep():
     oldRep = safeFxpMul(originalRep, POINT_NINE)
     repChange = safeAdd(oldRep, newRep) - originalRep
     if(repChange > 0):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(1)
     repBalance = REPORTING.getRepBalance(branch, reporter)
     if(repBalance + repChange <= 0):

--- a/src/functions/resolveForkEvent.se
+++ b/src/functions/resolveForkEvent.se
@@ -69,15 +69,13 @@ def init():
 
 def resolveForkedEvent(branch, event):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     # checks for orig. branch
     if(EVENTS.getEventBranch(event) != branch or BRANCHES.getEventForkedOver(branch) != event or !branch or !event):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     if(!EVENTS.getForked(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     if(EVENTS.getOutcome(event)):
         return(-3)
@@ -86,11 +84,11 @@ def resolveForkedEvent(branch, event):
         EVENTS.setForkDone(event)
         EVENTS.setCreationTime(event)
         CONSENSUSDATA.doRefund(msg.sender, event)
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(1)
     # fork not done yet
     else:
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
 
 # once winning fork decided this sets fork done and sets the event outcome to the forkoutcome + ethicality if the fork won, or to the resolved round 2 outcome + ethicality if the original parent won

--- a/src/functions/roundTwo.se
+++ b/src/functions/roundTwo.se
@@ -64,9 +64,7 @@ def ok():
     return(2)
 
 def roundTwoPostBond(branch, event, eventIndex, overEthicality):
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     votePeriod = BRANCHES.getVotePeriod(branch)
     roundTwoBondCheckPreconditions()
     BACKSTOPS.setRoundTwoRefund(event, msg.value)
@@ -80,7 +78,7 @@ def roundTwoPostBond(branch, event, eventIndex, overEthicality):
     validEvent = (event != 0 and event == eventID)
     # if so, we're not in the final 48 hours or event isn't in this branch + votePeriod, or it's already been put into a backstop
     if(currentPeriod == currentPlus48Hr or !validEvent or BACKSTOPS.getRoundTwo(event) or EVENTS.getForked(event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     # pays money to cover resolution cost
     if(!send(BACKSTOPS, msg.value)):
@@ -119,15 +117,13 @@ def roundTwoPostBond(branch, event, eventIndex, overEthicality):
     EVENTS.setEthics(event, 0)
     if(overEthicality):
         BACKSTOPS.setDisputedOverEthics(event)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 # Resolves a round 2 event scenario
 def roundTwoResolve(branch, event, eventIndex, sender):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     if(!branch):
         throw()
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -161,7 +157,7 @@ def roundTwoResolve(branch, event, eventIndex, sender):
     # same as original consensus and bond poster was wrong [or malicious]
     elif(votedOnAgain and !forked and roundTwoEventWithBondNotReturned):
         loseBond()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 # Actually sets the outcome for a round 2 event
@@ -191,12 +187,12 @@ macro roundTwoBondCheckPreconditions():
     forkPeriod = BRANCHES.getForkPeriod(branch)
     # means an event was created prior to a fork and hasn't been moved after the fork yet
     if(!eventCreatedPriorToFork(eventID)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     if(noVotes()):
         return(-3)
     if(msg.value < 1000000 * tx.gasprice):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
 
 macro loseBond():

--- a/src/functions/roundTwoPenalize.se
+++ b/src/functions/roundTwoPenalize.se
@@ -66,9 +66,7 @@ def init():
 
 def penalizeRoundTwoWrong(branch, event):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     lastPeriodVotedOn = BRANCHES.getVotePeriod(branch) - 1
     lastPenalizationPeriod = lastPeriodVotedOn - 1
     lastPeriod = lastPeriodVotedOn
@@ -133,34 +131,34 @@ def penalizeRoundTwoWrong(branch, event):
             repBalance = x[1]
             CONSENSUS.increasePenalizedNum(branch, lastPeriodVotedOn, msg.sender, 1)
     else:
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-7)
     # once penalized for all events actually get rid of net rep lost
     if(numReportedOn == CONSENSUS.getPenalizedNum(branch, lastPeriodVotedOn, msg.sender)):
         sendRedistributedRepToBranch()
         return(1)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkPenalizeWrongRoundTwoPreconditions():
     if(repBalance < ONE):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(0)
     if(EVENTS.getEventBranch(event) != branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-6)
     # makes sure we're actually still able to report on the last vote period and that we're in 1st half of current period
     atFirstHalfOfPeriod()
     if((block.timestamp / periodLength - 2) != lastPeriodVotedOn):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     # if no outcome / event not resolved yet, resolve it [as long as it wasn't an event that was pushed fwd and got rejected and thus hasn't actually resolved yet]
     if(!EVENTS.getOutcome(event) and !ROUNDTWO.roundTwoResolve(branch, event, EXPEVENTS.getEventIndex(branch, lastPeriodVotedOn, event), msg.sender)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
     if(CONSENSUS.getPenalizedUpTo(branch, msg.sender) == lastPeriodVotedOn):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-4)
     if(!CONSENSUS.getRepCollected(branch, msg.sender, lastPeriodVotedOn - 1)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-5)

--- a/src/functions/sendReputation.se
+++ b/src/functions/sendReputation.se
@@ -93,10 +93,8 @@ def init():
 
 def sendRepFrom(branch, from, receiver, fxpValue):
     # checkInvariants(from)
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     senderIndex = REPORTING.repIDToIndex(branch, from)
     receiverIndex = REPORTING.repIDToIndex(branch, receiver)
@@ -111,7 +109,7 @@ def sendRepFrom(branch, from, receiver, fxpValue):
         throw()
     log(type = Transfer, from, receiver, fxpValue)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 # Transfer dormant rep
@@ -123,10 +121,8 @@ def sendRepFrom(branch, from, receiver, fxpValue):
 # fails unless from has authorized sender [either contract which was approved or the from address is the msg.sender]
 def transferFrom(branch, from, receiver, fxpValue):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     votePeriod = BRANCHES.getVotePeriod(branch)
     senderIndex = REPORTING.repIDToIndex(branch, from)
@@ -139,32 +135,28 @@ def transferFrom(branch, from, receiver, fxpValue):
       throw()
     log(type=Transfer, from, receiver, fxpValue)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 def claimRep():
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     balance = REPCONTRACT.balanceOf(msg.sender)
     if(!REPCONTRACT.transferFrom(msg.sender, 0, balance) or !REPORTING.addReporter(1010101, msg.sender, 0, balance, 0)):
         throw()
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 # Allows spender to withdraw from your dormant rep account
 def approve(branch, spender, fxpValue):
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     self.amountCanSpend[msg.sender][spender].branch[branch] = fxpValue
     log(type = Approval, msg.sender, spender, branch, fxpValue)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 # Returns amount spender can withdraw from owner
@@ -187,11 +179,11 @@ macro checkInvariants($account):
 
     if(delta > 1 and CATCHUP.penalizationCatchup(branch, $account) != 1):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-4)
     if(!CONSENSUS.getRepRedistributionDone(branch, $account)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(0)
 
 macro checkSendRepInvariants():
@@ -211,12 +203,12 @@ macro checkSendRepInvariants():
         else:
             REPORTING.addReporter(branch, from)
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-1)
     # If a user hasn't claimed rep on the child branch yet and it's a fork scenario, don't allow sending rep on the parent branch until the receiver claims it
     if(REPORTING.getReporterID(branch, receiverIndex) != receiver or (child && !tooLateForChild && REPORTING.getReporterID(branch, REPORTING.repIDToIndex(child, receiver)) != receiver)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-3)
     # If a user hasn't claimed rep on the child branch yet and it's a fork scenario, don't allow sending rep on the parent branch until the sender claims it
     if(!tooLateForChild && child && REPORTING.getReporterID(branch, REPORTING.repIDToIndex(child, from)) != from):
@@ -225,7 +217,7 @@ macro checkSendRepInvariants():
 
     if(senderBalance < fxpValue or fxpValue <= 0 or !(self.amountCanSpend[from][msg.sender].branch[branch] >= fxpValue or from == msg.sender)):
         if(!isCallerWhitelisted()):
-            MUTEX.unsetMutex()
+            MUTEX.release()
         return(-5)
     if(from != msg.sender):
         self.amountCanSpend[from][msg.sender].branch[branch] -= fxpValue

--- a/src/functions/shareTokens.se
+++ b/src/functions/shareTokens.se
@@ -50,10 +50,8 @@ def init():
 
 def transfer(to: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     self.controller.checkWhitelist(msg.sender)
     senderBalance = self.accounts[msg.sender].balance
     if(senderBalance < value):
@@ -65,15 +63,13 @@ def transfer(to: address, value: uint256):
     self.accounts[to].balance += value
     log(type = Transfer, msg.sender, to, value)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 def transferFrom(from: address, to: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
     self.controller.checkWhitelist(msg.sender)
     senderBalance = self.accounts[from].balance
     if(senderBalance < value or value > self.accounts[from].spenders[msg.sender].maxValue):
@@ -86,20 +82,18 @@ def transferFrom(from: address, to: address, value: uint256):
     self.accounts[to].balance += value
     log(type = Transfer, from, to, value)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 def approve(spender: address, value: uint256):
     refund()
-    if(MUTEX.getMutex() && !isCallerWhitelisted()):
-        throw()
-    if(!isCallerWhitelisted()):
-        MUTEX.setMutex()
+    if (!isCallerWhitelisted()):
+        MUTEX.acquire()
 
     self.accounts[msg.sender].spenders[spender].maxValue = value
     log(type=Approval, msg.sender, spender, value)
     if(!isCallerWhitelisted()):
-        MUTEX.unsetMutex()
+        MUTEX.release()
     return(1)
 
 # Returns amount spender can withdraw from owner

--- a/src/functions/slashRep.se
+++ b/src/functions/slashRep.se
@@ -38,9 +38,7 @@ def init():
 
 def slashRep(branch, salt, report, ethics, reporter, event):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
 
     periodLength = BRANCHES.getPeriodLength(branch)
     votePeriod = BRANCHES.getVotePeriod(branch)
@@ -70,21 +68,21 @@ def slashRep(branch, salt, report, ethics, reporter, event):
     REPORTING.addRep(branch, trutherIndex, halfOfBalance)
     # other half sent to branch
     REPORTING.addRep(branch, REPORTING.repIDToIndex(branch, branch), halfOfBalance)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     return(1)
 
 macro checkSlashRepInvariants():
     if(votePeriodShouldBe != votePeriod):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-1)
     atFirstHalfOfPeriod()
     reporterIndex = REPORTING.repIDToIndex(branch, reporter)
     if(reportHash != realHash):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-3)
     if(EVENTS.getEventBranch(event) != branch):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-4)
     if(alreadySlashed):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-5)

--- a/src/functions/submitReportHash.se
+++ b/src/functions/submitReportHash.se
@@ -94,9 +94,7 @@ def makeHash(salt, fxpReport, event, sender, ethics):
 # Error -4: not caught up on penalizations [>1 period behind] and auto catchup failed
 def submitReportHash(event, reportHash, saltyEncryptedHash):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     branch = EVENTS.getBranch(event)
     votePeriod = BRANCHES.getVotePeriod(branch)
     periodLength = BRANCHES.getPeriodLength(branch)
@@ -115,24 +113,24 @@ def submitReportHash(event, reportHash, saltyEncryptedHash):
     shaHash = shaHash / 57896044618658091106304 * ONE
     # shaHash must be <= to the threshold for that user to be able to fxpReport on the given event
     if(shaHash > reportingThresholdForUser):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -3)
     EXPEVENTS.setReportHash(branch, votePeriod, msg.sender, reportHash, event)
     EXPEVENTS.setSaltyEncryptedHash(branch, votePeriod, msg.sender, saltyEncryptedHash, event)
-    MUTEX.unsetMutex()
+    MUTEX.release()
     logReturn(makeReportsLogReturn, 1)
 
 ### Helper macros and functions:
 macro checkSubmitReportHashPreconditions():
     if(!eventIndex and (!event or eventID != event)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -1)
     atFirstHalfOfPeriod()
     if(delta > 1 and CATCHUP.penalizationCatchup(branch, msg.sender) != 1):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, -4)
     if(!CONSENSUS.getRepRedistributionDone(branch, msg.sender)):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         logReturn(makeReportsLogReturn, 0)
     # if first fxpReport of period, num events not set
     if(!EXPEVENTS.getNumEventsToReportOn(branch, votePeriod)):

--- a/src/functions/trade.se
+++ b/src/functions/trade.se
@@ -113,9 +113,7 @@ def init():
 
 def trade(orderID, amountTakerWants):
     refund()
-    if(MUTEX.getMutex()):
-        throw()
-    MUTEX.setMutex()
+    MUTEX.acquire()
     if(amountTakerWants <= 0):
         throw()
     type = ORDERS.getType(orderID)
@@ -127,6 +125,6 @@ def trade(orderID, amountTakerWants):
         returnValue = FILLASK.fillAsk(orderID, amountTakerWants, call = delegate, outitems = 2)
     else:
         throw()
-    MUTEX.unsetMutex()
+    MUTEX.release()
     log(type=tradeLogArrayReturn, returnValue)
     return(returnValue: arr)

--- a/src/macros/periodStage.sem
+++ b/src/macros/periodStage.sem
@@ -1,11 +1,11 @@
 macro atSecondHalfOfPeriod():
     residual = block.timestamp % periodLength
     if(residual <= periodLength / 2):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)
 
 macro atFirstHalfOfPeriod():
     residual = block.timestamp % periodLength
     if(residual > periodLength / 2):
-        MUTEX.unsetMutex()
+        MUTEX.release()
         return(-2)


### PR DESCRIPTION
Note: This PR is on top of #113, that should be merged first.  If #113 is rejected, then I'll update this PR to use the old function name.

This makes the mutex have two methods, `acquire` and `release`.  Calling `acquire` will either get you the mutex or it will throw and calling `release` will simply release the mutex.  This makes its usage much simpler in the common case as you only need to call `acquire`, you don't need to check the result or do a `get` first.

**NOTE**: There were a few places in the code where it was acquiring a mutex even if the caller was whitelisted.  I assumed that these were mistakes and replaced them with the pattern of "either you are whitelisted or you acquire, never both" but perhaps there is a legitimate reason that functions have the contract acquire a mutex even when whitelisted?  An example of this can be seen in the old code in `collectFees.se`

There may be value in a future improvement in creating a macro for `if (!whitelisted): MUTEX.acquire()` but I wanted to keep this PR as simple as possible.