### PR TITLE
Removes unnecessary complexity.

### DIFF
--- a/src/data_api/events.se
+++ b/src/data_api/events.se
@@ -116,9 +116,6 @@ def setEventPushedUp(event, val):
 
 # @return fxp
 def getForkOutcome(event):
-    whitelist = self.controller.checkWhitelist(msg.sender)
-    if(msg.sender == INFO.getCreator(event) or whitelist):
-        return(self.Events[event].forkOutcome)
     return(self.Events[event].forkOutcome)
 
 def setForkOutcome(event, value):

--- a/src/data_api/events.se
+++ b/src/data_api/events.se
@@ -116,7 +116,11 @@ def setEventPushedUp(event, val):
 
 # @return fxp
 def getForkOutcome(event):
-    return(self.Events[event].forkOutcome)
+    whitelist = self.controller.checkWhitelist(msg.sender)
+    if(msg.sender == INFO.getCreator(event) or whitelist):
+        return(self.Events[event].forkOutcome)
+    else:
+        log(type = logOutcome, event, self.Events[event].forkOutcome)
 
 def setForkOutcome(event, value):
     self.controller.checkWhitelist(msg.sender)


### PR DESCRIPTION
This function is a pure getter and both code paths return the same value (whitelist or not).  Perhaps the intent here was to instead make it so it will `log` if not the creator and/or not in the whitelist?