### PR TITLE
takeAskOrder fixes and tests

### DIFF
--- a/src/functions/takeAskOrder.se
+++ b/src/functions/takeAskOrder.se
@@ -34,7 +34,7 @@ inset('../macros/float.sem')
 
 data controller
 
-event FillAsk(market: indexed, sender: indexed, owner: indexed, type, fxpPrice, fxpAmount, timestamp, orderID, outcome, fxpAskerSharesFilled, fxpAskerMoneyFilled, fxpBidderMoneyFilled)
+event TakeAskOrder(market: address: indexed, sender: address: indexed, owner: address: indexed, type: uint256, fxpPrice, fxpAmount: uint256, timestamp: uint256, orderID: address, outcome: uint256, fxpAskerSharesFilled: uint256, fxpAskerMoneyFilled: uint256, fxpBidderMoneyFilled: uint256, fxpFee: uint256)
 
 macro MIN_TRADE_VALUE: 10000000000000000
 macro MAX_INT256_VALUE: 2**255 - 1
@@ -51,10 +51,9 @@ def init():
 
 # Filling an ask [aka buying shares]
 # Scenarios:
-#  - Asker escrowed maxValue - price and expects complete set minus the one they're selling
-#  - Asker had shares and escrowed them and expects to be paid price - minValue for them
-#  - Bidder owns all shares except the one they're buying and will pay price - minValue for the shares they're buying
-#  - Bidder will pay price - minValue for their shares
+#  - Asker (maker/owner) escrowed maxValue - price and expects complete set minus the one they're selling
+#  - Asker (maker/owner) had shares and escrowed them and expects to be paid price - minValue for them
+#  - Bidder (taker/sender) pays price - minValue for their shares
 # @internal
 def takeAskOrder(sender: address, orderID: address, fxpAmountTakerWants: uint256):
     refund()
@@ -164,14 +163,14 @@ def takeAskOrder(sender: address, orderID: address, fxpAmountTakerWants: uint256
 
     # Transfer (price - minValue) * fxpBidderMoneyFilled to market from bidder since market hasn't been paid yet
     if(fxpBidderMoneyFilled > 0):
-        if(!INFO.getCurrency(market).transferFrom(sender, market, safeFxpMul(safeSub(fxpPrice, fxpMinValue), fxpBidderMoneyFilled))):
+        if(!INFO.getCurrency(market).transferFrom(sender, INFO.getWallet(market), safeFxpMul(safeSub(fxpPrice, fxpMinValue), fxpBidderMoneyFilled))):
             ~invalid()
 
     # Transfer (price - minValue) * fxpAskerSharesFilled from the market to the asker, don't
     # need to send for fxpAskerMoneyFilled because asker only escrowed maxValue - price and thus
     # has "already been paid" for those shares.
     # Note: bidder has already sent their money to the market, so this money comes from the market.
-    if(fxpAskerSharesFilled):
+    if(fxpAskerSharesFilled > 0):
         if(!INFO.getWallet(market).transfer(owner, safeFxpMul(safeSub(fxpPrice, fxpMinValue), fxpAskerSharesFilled))):
             ~invalid()
 
@@ -186,17 +185,17 @@ def takeAskOrder(sender: address, orderID: address, fxpAmountTakerWants: uint256
         while(i <= MARKETS.getMarketNumOutcomes(market)):
             MARKETS.getOutcomeShareContract(market, i).destroyShares(owner, fxpSharesHeld)
             i += 1
-        fxpCost = safeFxpMul(fxpSharesHeld, fxpCumulativeScale)
+        fxpMoneyFromSellCompleteSets = safeFxpMul(fxpSharesHeld, fxpCumulativeScale)
         # Send funds from the market to the user's account
         fxpFee = safeFxpMul(safeFxpMul(MARKETS.getTradingFee(market), fxpSharesHeld), fxpCumulativeScale)
-        if(!INFO.getWallet(market).transfer(owner, safeSub(fxpCost, fxpFee))):
+        if(!INFO.getWallet(market).transfer(owner, safeSub(fxpMoneyFromSellCompleteSets, fxpFee))):
             ~invalid()
         # Send half of sell-complete-sets fees to the market creator
         if(!INFO.getWallet(market).transfer(INFO.getCreator(market), safeDiv(fxpFee, 2))):
             ~invalid()
 
     # Log transaction [BID b/c it's filling an ask so from trader's perspective they're bidding]
-    log(type=FillAsk, market, sender, owner, BID, fxpPrice, fxpSumOfFills, block.timestamp, orderID, outcome, fxpAskerSharesFilled, fxpAskerMoneyFilled, fxpBidderMoneyFilled)
+    log(type=TakeAskOrder, market, sender, owner, BID, fxpPrice, fxpSumOfFills, block.timestamp, orderID, outcome, fxpAskerSharesFilled, fxpAskerMoneyFilled, fxpBidderMoneyFilled, fxpFee)
 
     MARKETS.setPrice(market, outcome, fxpPrice)
     return(fxpAmountTakerWants: uint256)

--- a/src/functions/takeBidOrder.se
+++ b/src/functions/takeBidOrder.se
@@ -34,7 +34,7 @@ inset('../macros/float.sem')
 
 data controller
 
-event FillBid(market: indexed, sender: indexed, owner: indexed, type, fxpPrice, fxpAmount, timestamp, orderID, outcome, fxpAskerSharesFilled, fxpAskerMoneyFilled, fxpBidderSharesFilled, fxpBidderMoneyFilled)
+event TakeBidOrder(market: address: indexed, sender: address: indexed, owner: address: indexed, type: uint256, fxpPrice, fxpAmount: uint256, timestamp: uint256, orderID: address, outcome: uint256, fxpAskerSharesFilled: uint256, fxpAskerMoneyFilled: uint256, fxpBidderSharesFilled: uint256, fxpBidderMoneyFilled: uint256, fxpFee: uint256)
 
 macro MIN_TRADE_VALUE: 10000000000000000
 macro MAX_INT256_VALUE: 2**255 - 1
@@ -202,7 +202,7 @@ def takeBidOrder(sender: address, orderID: address, fxpAmountTakerWants: uint256
 
     # Transfer (price - minValue) * fxpBidderSharesFilled to market from bidder since market hasnt been paid yet after complete sets selling. The bidder has already paid for fxpBidderMoneyFilled by escrowing their money
     if(fxpBidderSharesFilled > 0):
-        if(!INFO.getCurrency(market).transferFrom(owner, market, safeFxpMul(safeSub(fxpPrice, minValue), fxpBidderSharesFilled))):
+        if(!INFO.getCurrency(market).transferFrom(owner, INFO.getWallet(market), safeFxpMul(safeSub(fxpPrice, minValue), fxpBidderSharesFilled))):
             ~invalid()
 
     # Transfer money from person who bid to the person here who is selling/asker [bidder has already sent/escrowed the cash to/with the market when submitting bid so this comes from the market]
@@ -211,7 +211,7 @@ def takeBidOrder(sender: address, orderID: address, fxpAmountTakerWants: uint256
 
     # Transfer range * fxpAskerMoneyFilled to the market from asker for the amount of shares in fxpAskerMoneyFilled, for fxpAskerSharesFilled the asker simply has sent their shares to the bidder and thus doesn't have to put up money
     if(fxpAskerMoneyFilled > 0):
-        if(!INFO.getCurrency(market).transferFrom(sender, market, safeFxpMul(fxpCumulativeScale, fxpAskerMoneyFilled))):
+        if(!INFO.getCurrency(market).transferFrom(sender, INFO.getWallet(market), safeFxpMul(fxpCumulativeScale, fxpAskerMoneyFilled))):
             ~invalid()
 
     # Sell taker's complete sets (if they have any)
@@ -224,7 +224,7 @@ def takeBidOrder(sender: address, orderID: address, fxpAmountTakerWants: uint256
         COMPLETESETS.sellCompleteSets(sender, market, fxpSharesHeld, call=delegate)
 
     # Log transaction [ASK b/c it's filling a bid so from trader's perspective they're asking]
-    log(type=FillBid, market, sender, owner, ASK, fxpPrice, fxpSumOfFills, block.timestamp, orderID, outcome, fxpAskerSharesFilled, fxpAskerMoneyFilled, fxpBidderSharesFilled, fxpBidderMoneyFilled)
+    log(type=TakeBidOrder, market, sender, owner, ASK, fxpPrice, fxpSumOfFills, block.timestamp, orderID, outcome, fxpAskerSharesFilled, fxpAskerMoneyFilled, fxpBidderSharesFilled, fxpBidderMoneyFilled, fxpFee)
 
     MARKETS.setPrice(market, outcome, fxpPrice)
     return(fxpAmountTakerWants: uint256)


### PR DESCRIPTION
Added detailed cash and shares balance assertions for all steps of takeAskOrder, for cases where order maker has shares escrowed and where order maker has cash escrowed.