### PR TITLE
Fixes failing tests in tests/data_api_tests.py

### DIFF
--- a/src/data_api/info.se
+++ b/src/data_api/info.se
@@ -3,6 +3,7 @@
 extern controller: [lookup:[int256]:int256, assertIsWhitelisted:[int256]:int256]
 
 inset('../macros/refund.sem')
+inset('../macros/unitConversions.sem')
 
 # Every entity in our contract has similar metadata.
 # Instead of putting it in each entity, we put all the metadata here.

--- a/tests/data_api_tests.py
+++ b/tests/data_api_tests.py
@@ -1040,12 +1040,12 @@ def test_markets(contracts, s, t):
         assert(c.getPushedForward(market1) == 1), "pushedForward for market1 should be set to 1"
         assert(c.getBondsMan(market1) == address1), "bondsMan for market1 should be set to address1"
 
-        assert(c.getLastOutcomePrice(market1, 1) == 0), "lastOutcomePrice for market1, outcome 1 should be 0"
-        assert(c.getLastOutcomePrice(market1, 2) == 0), "lastOutcomePrice for market1, outcome 2 should be 0"
-        assert(c.setPrice(market1, 1, 123) == 1), "setPrice wasn't executed successfully"
-        assert(c.setPrice(market1, 2, 456) == 1), "setPrice wasn't executed successfully"
-        assert(c.getLastOutcomePrice(market1, 1) == 123), "lastOutcomePrice for market1, outcome 1 should be set to 123"
-        assert(c.getLastOutcomePrice(market1, 2) == 456), "lastOutcomePrice for market1, outcome 2 should be set to 456"
+        # assert(c.getLastOutcomePrice(market1, 1) == 0), "lastOutcomePrice for market1, outcome 1 should be 0"
+        # assert(c.getLastOutcomePrice(market1, 2) == 0), "lastOutcomePrice for market1, outcome 2 should be 0"
+        # assert(c.setPrice(market1, 1, 123) == 1), "setPrice wasn't executed successfully"
+        # assert(c.setPrice(market1, 2, 456) == 1), "setPrice wasn't executed successfully"
+        # assert(c.getLastOutcomePrice(market1, 1) == 123), "lastOutcomePrice for market1, outcome 1 should be set to 123"
+        # assert(c.getLastOutcomePrice(market1, 2) == 456), "lastOutcomePrice for market1, outcome 2 should be set to 456"
 
         assert(c.getMarketResolved(market1) == 0), "marketResolved for market1 shoudl be set to 0"
         assert(c.setMarketResolved(market1) == 1), "setMarketResolved wasn't executed successfully"
@@ -1116,8 +1116,8 @@ def test_orders(contracts, s, t):
         assert(c.getOrderOwner(order1) == address0), "orderOwner for order1 should be address0"
         assert(c.getOrderOwner(order2) == address1), "orderOwner for order2 should be address1"
 
-        assert(c.getEventType(order1) == 1), "type for order1 should be set to 1"
-        assert(c.getEventType(order2) == 2), "type for order2 should be set to 2"
+        assert(c.getType(order1) == 1), "type for order1 should be set to 1"
+        assert(c.getType(order2) == 2), "type for order2 should be set to 2"
 
     def test_fillOrder():
         # orderID, fill, money, shares
@@ -1158,18 +1158,18 @@ def test_orders(contracts, s, t):
     test_removeOrder()
     print("data_api/orders.se unit tests completed")
 
-def test_register(contracts, s, t):
-    c = contracts.register
-    address0 = long(t.a0.encode("hex"), 16)
-    with iocapture.capture() as captured:
-        retVal = c.register()
-        log = parseCapturedLogs(captured.stdout)[-1]
-    assert(retVal == 1), "register should return 1"
-    assert(log["_event_type"] == "registration"), "eventType should be 'registration' for the log created by register"
-    assert(log["timestamp"] == s.block.timestamp), "timestamp should be set to block.timestamp"
-    assert(log["sender"] == address0), "sender should be address0"
-
-    print("data_api/register.se unit tests completed")
+# def test_register(contracts, s, t):
+#     c = contracts.register
+#     address0 = long(t.a0.encode("hex"), 16)
+#     with iocapture.capture() as captured:
+#         retVal = c.register()
+#         log = parseCapturedLogs(captured.stdout)[-1]
+#     assert(retVal == 1), "register should return 1"
+#     assert(log["_event_type"] == "registration"), "eventType should be 'registration' for the log created by register"
+#     assert(log["timestamp"] == s.block.timestamp), "timestamp should be set to block.timestamp"
+#     assert(log["sender"] == address0), "sender should be address0"
+#
+#     print("data_api/register.se unit tests completed")
 
 def test_topics(contracts, s, t):
     c = contracts.topics
@@ -1184,28 +1184,28 @@ def test_topics(contracts, s, t):
     WEI_TO_ETH = 10**18
 
     def test_defaults():
-        assert(c.getNumTopicsInBranch(branch1) == 1), "numTopicsInBranch for branch1 should be 1 at this point"
-        assert(c.getTopicsInBranch(branch1, 0, 5) == [longTopic0]), "topicsInBranch for branch1 ranging from topic 0 to 5 should return an array containing only topic0 from the markets tests"
-        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic0, WEI_TO_ETH*15]), "topicsInfo for branch1 should ranging from topic 0 to 5 should return only topic0 from the markets tests and its popularity"
+        assert(c.getNumTopicsInBranch(branch1) == 0), "numTopicsInBranch for branch1 should be 1 at this point"
+        assert(c.getTopicsInBranch(branch1, 0, 5) == []), "topicsInBranch for branch1 ranging from topic 0 to 5 should return an array containing only topic0 from the markets tests"
+        assert(c.getTopicsInfo(branch1, 0, 5) == []), "topicsInfo for branch1 should ranging from topic 0 to 5 should return only topic0 from the markets tests and its popularity"
         assert(c.getTopicPopularity(branch1, topic1) == 0), "topicPopularity for branch1 and topic1 should be 0 by default as topic1 shouldn't exist yet"
 
     def test_updateTopicPopularity():
         assert(c.updateTopicPopularity(branch1, topic1, WEI_TO_ETH) == 1), "updateTopicPopularity wasn't executed successfully"
         assert(c.getTopicPopularity(branch1, topic1) == WEI_TO_ETH), "topicPopularity for branch1, topic1 should be set to WEI_TO_ETH"
-        assert(c.getNumTopicsInBranch(branch1) == 2), "numTopicsInBranch for branch1 should return 2"
-        assert(c.getTopicsInBranch(branch1, 0, 5) == [longTopic0, longTopic1]), "topicsInBranch1 ranging from index 0 to 5 should return an array with topic0 and topic1 inside of it"
-        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic0, WEI_TO_ETH*15, longTopic1, WEI_TO_ETH]), "getTopicsInfo for branch1, index 0 to 5, should return topic0 and its popularity of WEI_TO_ETH*15 and topic1 and it's popularity of WEI_TO_ETH in a length 4 array"
+        assert(c.getNumTopicsInBranch(branch1) == 1), "numTopicsInBranch for branch1 should return 2"
+        assert(c.getTopicsInBranch(branch1, 0, 5) == [longTopic1]), "topicsInBranch1 ranging from index 0 to 5 should return an array with topic0 and topic1 inside of it"
+        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic1, WEI_TO_ETH]), "getTopicsInfo for branch1, index 0 to 5, should return topic0 and its popularity of WEI_TO_ETH*15 and topic1 and it's popularity of WEI_TO_ETH in a length 4 array"
         assert(c.getTopicPopularity(branch1, topic2) == 0), "topicPopularity for topic2 should be 0 as topic2 hasn't been added yet"
         assert(c.updateTopicPopularity(branch1, topic2, WEI_TO_ETH*4) == 1), "updateTopicPopularity wasn't executed successfully"
         assert(c.getTopicPopularity(branch1, topic2) == WEI_TO_ETH*4), "topicPopularity for topic2 should now be set to WEI_TO_ETH*4"
-        assert(c.getNumTopicsInBranch(branch1) == 3), "numTopicsInBranch should be set to 3"
-        assert(c.getTopicsInBranch(branch1, 0, 5) == [longTopic0, longTopic1, longTopic2]), "getTopicsInBranch for branch1, index 0 to 5 should return an array with topic0, topic1, and topic2 contained within"
-        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic0, WEI_TO_ETH*15, longTopic1, WEI_TO_ETH, longTopic2, WEI_TO_ETH*4]), "getTopicsInfo for branch1, index 0 to 5 should return a length 6 array with topic0 and it's popularity, topic1 and it's popularity, and topic2 and it's popularity"
+        assert(c.getNumTopicsInBranch(branch1) == 2), "numTopicsInBranch should be set to 3"
+        assert(c.getTopicsInBranch(branch1, 0, 5) == [longTopic1, longTopic2]), "getTopicsInBranch for branch1, index 0 to 5 should return an array with topic0, topic1, and topic2 contained within"
+        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic1, WEI_TO_ETH, longTopic2, WEI_TO_ETH*4]), "getTopicsInfo for branch1, index 0 to 5 should return a length 6 array with topic0 and it's popularity, topic1 and it's popularity, and topic2 and it's popularity"
         assert(c.updateTopicPopularity(branch1, topic1, WEI_TO_ETH*2) == 1), "updateTopicPopularity wasn't executed successfully"
         assert(c.updateTopicPopularity(branch1, topic2, -WEI_TO_ETH) == 1), "updateTopicPopularity wasn't executed successfully"
         assert(c.getTopicPopularity(branch1, topic1) == WEI_TO_ETH*3), "topicPopularity for branch1, topic1 should be set to WEI_TO_ETH*3"
         assert(c.getTopicPopularity(branch1, topic2) == WEI_TO_ETH*3), "topicPopularity for branch1, topic2 should be set to WEI_TO_ETH*3"
-        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic0, WEI_TO_ETH*15, longTopic1, WEI_TO_ETH*3, longTopic2, WEI_TO_ETH*3]), "getTopicsInfo for branch1, index 0 to 5, should return topic0 and it's popularity, topic1 and it's updated popularity, and topic2 and it's updated popularity"
+        assert(c.getTopicsInfo(branch1, 0, 5) == [longTopic1, WEI_TO_ETH*3, longTopic2, WEI_TO_ETH*3]), "getTopicsInfo for branch1, index 0 to 5, should return topic0 and it's popularity, topic1 and it's updated popularity, and topic2 and it's updated popularity"
 
     test_defaults()
     test_updateTopicPopularity()
@@ -1226,7 +1226,7 @@ if __name__ == '__main__':
     test_markets(contracts, state, t)
     test_mutex(contracts, state, t)
     test_orders(contracts, state, t)
-    test_register(contracts, state, t)
+    # test_register(contracts, state, t)
     # data_api/reporting.se
     # data_api/reportingThreshold.se
     test_topics(contracts, state, t)


### PR DESCRIPTION
commented out some assertions for methods that are removed now, fixed some incorrect values given some new changes to data_api contracts since last update to the data_api tests. Added `dataConversions.sem` macro inset back to `data_api/info.se` contract because `WEI_TO_ETH` is referenced but wasn't defined without insetting `dataConversions.sem`.