### PR TITLE
Fix-ContractLoader

### DIFF
--- a/upload_contracts/upload_contracts.py
+++ b/upload_contracts/upload_contracts.py
@@ -404,9 +404,9 @@ class ContractLoader(object):
         self.__contracts = {}
         self.__temp_dir = TempDirCopy(source_dir)
         try:
-            self.__state.block_number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
+            self.__state.block.number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
         except:
-            self.__state.state.block_number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
+            self.__state.state.block.number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
         self.__source_dir = source_dir
 
         serpent_files = self.__temp_dir.find_files(SERPENT_EXT)

--- a/upload_contracts/upload_contracts.py
+++ b/upload_contracts/upload_contracts.py
@@ -406,7 +406,7 @@ class ContractLoader(object):
         try:
             self.__state.block.number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
         except:
-            self.__state.state.block.number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
+            self.__state.state.block_number += HOMESTEAD_BLOCK_NUMBER # enable DELEGATECALL opcode
         self.__source_dir = source_dir
 
         serpent_files = self.__temp_dir.find_files(SERPENT_EXT)


### PR DESCRIPTION
fixed an error in ContractLoader.__init__ where we attempted to reference state.block_number when it should be state.block.number