### PR TITLE
updated requirements to not put ethereum-serpent in src

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
--e git+https://github.com/ethereum/serpent.git@3ec98d01813167cc8725a951bd384c629158af2b#egg=ethereum-serpent
+git+https://github.com/ethereum/serpent.git@3ec98d01813167cc8725a951bd384c629158af2b#egg=ethereum-serpent
 bitcoin==1.1.42           # via ethereum
 cffi==1.10.0              # via secp256k1
 ethereum==1.6.1


### PR DESCRIPTION
﻿# Pull Request Template
### Overview

Stores ethereum-serpent with rest of python packages


### Changes proposed for this pull request

Removes it from src


### Notes






### Testing Instructions






### Examples (if necessary)