### PR TITLE
Modify FIXMEs to note why the bare subtraction operation is safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,6 @@ target/
 *~
 \#*\#
 
-#vscode
-.vscode/
-
 bower_components
 serpent/ui
 .gitstats
@@ -75,7 +72,6 @@ python
 Downloads
 src-extern
 notes
-.pylintrc
 
 local/*.py
 *build-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ target/
 *~
 \#*\#
 
+#vscode
+.vscode/
+
 bower_components
 serpent/ui
 .gitstats
@@ -72,6 +75,7 @@ python
 Downloads
 src-extern
 notes
+.pylintrc
 
 local/*.py
 *build-*.json

--- a/src/trading/orders.se
+++ b/src/trading/orders.se
@@ -272,10 +272,10 @@ def fillOrder(orderId: address, orderType: int256, market: address, orderOutcome
     require(tx.gasprice <= self.orders[market][orderOutcome][orderType][orderId].gasPrice)
     fill = 0
     if orderType == BID:
-        # FIXME: we can't use safeSub here because we might be subtracting a negative, but we need to protect against overflows
+        # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
         fill = sharesFilled + safeFxpDiv(tokensFilled, self.orders[market][orderOutcome][orderType][orderId].fxpPrice - market.getMinDisplayPrice())
     if orderType == ASK:
-        # FIXME: we can't use safeSub here because we might be subtracting a negative, but we need to protect against overflows
+        # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
         fill = sharesFilled + safeFxpDiv(tokensFilled, market.getMaxDisplayPrice() - self.orders[market][orderOutcome][orderType][orderId].fxpPrice)
     require(fill <= self.orders[market][orderOutcome][orderType][orderId].fxpAmount)
     self.orders[market][orderOutcome][orderType][orderId].fxpAmount -= fill

--- a/src/trading/orders.se
+++ b/src/trading/orders.se
@@ -270,12 +270,15 @@ def fillOrder(orderId: address, orderType: int256, market: address, orderOutcome
     require(sharesFilled <= self.orders[market][orderOutcome][orderType][orderId].fxpSharesEscrowed)
     require(tokensFilled <= self.orders[market][orderOutcome][orderType][orderId].fxpMoneyEscrowed)
     require(tx.gasprice <= self.orders[market][orderOutcome][orderType][orderId].gasPrice)
+    require(self.orders[market][orderOutcome][orderType][orderId].fxpPrice <= market.getMaxDisplayPrice())
+    require(self.orders[market][orderOutcome][orderType][orderId].fxpPrice >= market.getMinDisplayPrice())
+    require(market.getMaxDisplayPrice() + market.getMinDisplayPrice() <= 2**254)
     fill = 0
     if orderType == BID:
-        # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
+        # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 as required above, which won't overflow
         fill = sharesFilled + safeFxpDiv(tokensFilled, self.orders[market][orderOutcome][orderType][orderId].fxpPrice - market.getMinDisplayPrice())
     if orderType == ASK:
-        # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
+        # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 as required above, which won't overflow
         fill = sharesFilled + safeFxpDiv(tokensFilled, market.getMaxDisplayPrice() - self.orders[market][orderOutcome][orderType][orderId].fxpPrice)
     require(fill <= self.orders[market][orderOutcome][orderType][orderId].fxpAmount)
     self.orders[market][orderOutcome][orderType][orderId].fxpAmount -= fill

--- a/src/trading/takeAskOrder.se
+++ b/src/trading/takeAskOrder.se
@@ -51,9 +51,9 @@ def takeAskOrder(taker: address, orderID: address, market: address, outcome: int
     makerSharesEscrowed = min(order[SHARES_ESCROWED], fxpAmountTakerWants)
     require(maker != taker)
 
-    # FIXME: we can't use safeSub here because it disallows subtracting negative numbers, but we need to protect against overflows
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
     sharePriceShort = market.getMaxDisplayPrice() - orderDisplayPrice
-    # FIXME: we can't use safeSub here because it disallows subtracting negative numbers, but we need to protect against overflows
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
     sharePriceLong = orderDisplayPrice - market.getMinDisplayPrice()
     shareToken = market.getShareToken(outcome)
     denominationToken = market.getDenominationToken()

--- a/src/trading/takeAskOrder.se
+++ b/src/trading/takeAskOrder.se
@@ -51,9 +51,13 @@ def takeAskOrder(taker: address, orderID: address, market: address, outcome: int
     makerSharesEscrowed = min(order[SHARES_ESCROWED], fxpAmountTakerWants)
     require(maker != taker)
 
-    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
+    require(orderDisplayPrice <= market.getMaxDisplayPrice())
+    require(orderDisplayPrice >= market.getMinDisplayPrice())
+    require(market.getMaxDisplayPrice() + market.getMinDisplayPrice() <= 2**254)
+
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 as required above, which won't overflow
     sharePriceShort = market.getMaxDisplayPrice() - orderDisplayPrice
-    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 as required above, which won't overflow
     sharePriceLong = orderDisplayPrice - market.getMinDisplayPrice()
     shareToken = market.getShareToken(outcome)
     denominationToken = market.getDenominationToken()

--- a/src/trading/takeBidOrder.se
+++ b/src/trading/takeBidOrder.se
@@ -54,9 +54,9 @@ def takeBidOrder(taker: address, orderID: address, market: address, outcome: int
     makerSharesEscrowed = min(order[SHARES_ESCROWED], fxpAmountTakerWants)
     require(maker != taker)
 
-    # FIXME: we can't use safeSub here because it disallows subtracting negative numbers, but we need to protect against overflows
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
     sharePriceShort = market.getMaxDisplayPrice() - orderDisplayPrice
-    # FIXME: we can't use safeSub here because it disallows subtracting negative numbers, but we need to protect against overflows
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
     sharePriceLong = orderDisplayPrice - market.getMinDisplayPrice()
     shareToken = market.getShareToken(outcome)
     denominationToken = market.getDenominationToken()

--- a/src/trading/takeBidOrder.se
+++ b/src/trading/takeBidOrder.se
@@ -54,9 +54,13 @@ def takeBidOrder(taker: address, orderID: address, market: address, outcome: int
     makerSharesEscrowed = min(order[SHARES_ESCROWED], fxpAmountTakerWants)
     require(maker != taker)
 
-    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
+    require(orderDisplayPrice <= market.getMaxDisplayPrice())
+    require(orderDisplayPrice >= market.getMinDisplayPrice())
+    require(market.getMaxDisplayPrice() + market.getMinDisplayPrice() <= 2**254)
+
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 as required above, which won't overflow
     sharePriceShort = market.getMaxDisplayPrice() - orderDisplayPrice
-    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 which won't overflow
+    # We can't use safeSub here because it disallows subtracting negative numbers. Worst case here is an operation of 2**254 - 1 as required above, which won't overflow
     sharePriceLong = orderDisplayPrice - market.getMinDisplayPrice()
     shareToken = market.getShareToken(outcome)
     denominationToken = market.getDenominationToken()


### PR DESCRIPTION
The worst case is even further from overflow than I said before. The difference between `minDisplayPrice` and `maxDisplayPrice` is further restricted implicitly by `reportingWindow.se:createNewMarket` in the `payoutDenominator` requirement to be inclusively between 0 and 2**254.

Since the max range is so restricted already additional tests seem like overkill IMO.