### PR TITLE
Only run pip-compile manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
 install:
   - pip install -U pip
   - pip install pip-tools
-  - pip-compile --output-file requirements.txt requirements.in
   - pip install -r requirements.txt
 
 script:


### PR DESCRIPTION
We should only run pip-compile manually when changing `requirements.txt`; this will ensure that when CI runs it will get the exact set of requirements we've been developing against.

(This should fix the current Travis breakage caused by `requirements.txt` ending up without `pycryptodome`)