### PR TITLE
change to Travis trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty
 sudo: false
 
+cache:
+  apt: true
+  pip: true
+
 language: python
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: trusty
 sudo: false
 
 cache:
-  apt: true
-  pip: true
+  - apt
+  - pip
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+dist: trusty
+sudo: false
+
 language: python
 
 notifications:
   email: false
-
-python:
-  - "2.7"
 
 addons:
   apt:
@@ -14,8 +14,7 @@ addons:
       - gfortran
 
 install:
-  - pip install -U pip
-  - pip install pip-tools
+  - pip install -U pip setuptools
   - pip install -r requirements.txt
 
 script:


### PR DESCRIPTION
they're starting to deprecate the `precise` image tomorrow; this PR also adds caching which cuts about a minute (20%) off of every build