### PR TITLE
Left-pad longToHexString

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,9 +9,9 @@ def fix(n, m = 1):
 def unfix(n):
     return n // 10**18
 
-def longToHexString(value):
+def longToHexString(value, leftPad=40):
     hexstr = hex(value)[2:-1]
-    if len(hexstr) % 2 != 0:
+    while len(hexstr) < leftPad:
         hexstr = '0' + hexstr
     return hexstr
 


### PR DESCRIPTION
### Overview

Left-pads the output of the `longToHexString` method (in tests/utils.py) with zeros, to 40 characters by default since all this method appears to be used for at the moment is formatting addresses.  Optional 2nd parameter lets you pick whatever padding you want though.