### PR TITLE
Cleanup from the test rewrites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ language: python
 notifications:
   email: false
 
-python:
-  - "2.7.6"
-
 addons:
   apt:
     packages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from binascii import hexlify
 from datetime import timedelta
-from ethereum.tools import tester as tester
+from ethereum.tools import tester
 from ethereum.abi import ContractTranslator
 from ethereum.tools.tester import ABIContract
 from ethereum import utils as u

--- a/tests/delegation_sandbox.py
+++ b/tests/delegation_sandbox.py
@@ -1,4 +1,4 @@
-from ethereum.tools import tester as tester
+from ethereum.tools import tester
 from ethereum.abi import ContractTranslator
 from ethereum.tools.tester import ABIContract
 from ethereum import utils as u

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -1,6 +1,6 @@
 import os
 import serpent
-from ethereum.tools import tester as tester
+from ethereum.tools import tester
 from ethereum.abi import ContractTranslator
 from ethereum.tools.tester import ABIContract
 from ethereum import utils as u

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,7 +3,7 @@
 # Test the functions in src/functions/controller.se
 # Uses tests/controller_test.se as a helper (to set the controller, etc.)
 
-from ethereum.tools import tester as tester
+from ethereum.tools import tester
 from ethereum.abi import ContractTranslator
 from ethereum.tools.tester import ABIContract
 from ethereum import utils as u

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from ethereum.tools import tester as tester
+from ethereum.tools import tester
 from ethereum.abi import ContractTranslator
 from ethereum.tools.tester import ABIContract
 from ethereum import utils as u


### PR DESCRIPTION
- remove redundant `import tester as tester`
- don't set Python 2.7.6 on travis (that version is 4 years old and with the new Trusty image we get 2.7.13 by default)