### PR TITLE
add initial solium linter settings

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,22 @@
+{
+  "custom-rules-filename": null,
+  "rules": {
+    "imports-on-top": true,
+    "variable-declarations": true,
+    "array-declarations": true,
+    "operator-whitespace": true,
+    "lbrace": false,
+    "mixedcase": true,
+    "camelcase": true,
+    "uppercase": true,
+    "no-with": true,
+    "no-empty-blocks": true,
+    "no-unused-vars": true,
+    "double-quotes": true,
+    "blank-lines": true,
+    "indentation": false,
+    "whitespace": true,
+    "deprecated-suicide": true,
+    "pragma-on-top": true
+  }
+}


### PR DESCRIPTION
I used the defaults except for brace placement and indentation since everyone seems to prefer Allman style and solium enforces same-line style by default