### PR TITLE
Fix to avoid reuploading decentralized controller in tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,13 +106,13 @@ class ContractsFixture:
                 }
             },
             'settings': {
-                'remappings': [ 'ROOT=%s' % resolveRelativePath("../../augur-core/src") ]
+                'remappings': [ 'ROOT=%s' % resolveRelativePath("../src") ]
             },
             'outputSelection': {
                 '*': [ 'metadata', 'evm.bytecode', 'evm.sourceMap' ]
             }
         }
-        return compile_standard(compilerParameter, allow_paths=resolveRelativePath("../../augur-core/src"))['contracts'][filename][contractName]
+        return compile_standard(compilerParameter, allow_paths=resolveRelativePath("../src"))['contracts'][filename][contractName]
 
     @staticmethod
     def getAllDependencies(filePath, knownDependencies):
@@ -146,7 +146,6 @@ class ContractsFixture:
         config_metropolis['BLOCK_GAS_LIMIT'] = 2**60
         self.chain = tester.Chain(env=Env(config=config_metropolis))
         self.contracts = {}
-        self.originalContracts = {}
         self.controller = self.upload('../src/Controller.sol')
         assert self.controller.owner() == bytesToHexString(tester.a0)
         self.uploadAllContracts()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,13 +105,13 @@ class ContractsFixture:
                 }
             },
             'settings': {
-                'remappings': [ 'ROOT=/augur-core/src' ]
+                'remappings': [ 'ROOT=%' % resolveRelativePath("/augur-core/src") ]
             },
             'outputSelection': {
                 '*': [ 'metadata', 'evm.bytecode', 'evm.sourceMap' ]
             }
         }
-        return compile_standard(compilerParameter, allow_paths="/augur-core/src")['contracts'][filename][contractName]
+        return compile_standard(compilerParameter, allow_paths=resolveRelativePath("augur-core/src"))['contracts'][filename][contractName]
 
     @staticmethod
     def getAllDependencies(filePath, knownDependencies):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -37,8 +37,7 @@ def test_registry(controller, decentralizedController):
 
 def test_suicide(controller, decentralizedController, controllerUser):
     with raises(TransactionFailed): controller.suicide(controllerUser.address, tester.a0, sender = tester.k2)
-    assert decentralizedController.owner() == tester.a0
-    assert decentralizedController.assertIsWhitelisted(tester.a0)
+    assert decentralizedController.owner() == bytesToHexString(tester.a0)
     with raises(TransactionFailed): decentralizedController.suicide(controllerUser.address, tester.a0, sender = tester.k0)
     assert controller.suicide(controllerUser.address, tester.a0, sender = tester.k0)
     assert controllerUser.getSuicideFundsDestination() == bytesToLong(tester.a0)
@@ -54,7 +53,7 @@ def test_transferOwnership(controller, decentralizedController):
     assert controller.transferOwnership(tester.a1, sender = tester.k0)
     with raises(TransactionFailed): controller.assertIsWhitelisted(tester.a0, sender = tester.k2)
     assert controller.assertIsWhitelisted(tester.a1, sender = tester.k2)
-    assert controller.getOwner() == bytesToLong(tester.a1)
+    assert controller.owner() == bytesToLong(tester.a1)
 
     assert decentralizedController.transferOwnership(tester.a1, sender = tester.k0)
     with raises(TransactionFailed): decentralizedController.assertIsWhitelisted(tester.a0, sender = tester.k2)
@@ -84,11 +83,16 @@ def controller(contractsFixture):
 def controllerUser(contractsFixture):
     return contractsFixture.upload('serpent_test_helpers/controllerUser.se')
 
-@fixture
-def decentralizedController(contractsFixture):
-    decentralizedController = contractsFixture.upload('../src/Controller.sol', 'decentralizedController')
+@fixture(scope="session")
+def decentralizedControllerSnapShot(sessionFixture):
+    decentralizedController = sessionFixture.upload('../src/Controller.sol', 'decentralizedController')
     assert decentralizedController.foo()
     assert decentralizedController.assertIsWhitelisted(tester.a0)
     assert decentralizedController.owner() == bytesToHexString(tester.a0)
     decentralizedController.switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed(sender = tester.k0)
-    return decentralizedController
+    return sessionFixture.chain.snapshot()
+
+@fixture
+def decentralizedController(sessionFixture, decentralizedControllerSnapShot):
+    sessionFixture.chain.revert(decentralizedControllerSnapShot)
+    return sessionFixture.contracts['decentralizedController']

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -83,16 +83,11 @@ def controller(contractsFixture):
 def controllerUser(contractsFixture):
     return contractsFixture.upload('serpent_test_helpers/controllerUser.se')
 
-@fixture(scope="session")
-def decentralizedControllerSnapShot(sessionFixture):
-    decentralizedController = sessionFixture.upload('../src/Controller.sol', 'decentralizedController')
+@fixture
+def decentralizedController(contractsFixture):
+    decentralizedController = contractsFixture.upload('../src/Controller.sol', 'decentralizedController')
     assert decentralizedController.foo()
     assert decentralizedController.assertIsWhitelisted(tester.a0)
     assert decentralizedController.owner() == bytesToHexString(tester.a0)
     decentralizedController.switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed(sender = tester.k0)
-    return sessionFixture.chain.snapshot()
-
-@fixture
-def decentralizedController(sessionFixture, decentralizedControllerSnapShot):
-    sessionFixture.chain.revert(decentralizedControllerSnapShot)
-    return sessionFixture.contracts['decentralizedController']
+    return decentralizedController


### PR DESCRIPTION
Fix to avoid reuploading decentralized controller in tests. Retreiving the contract from the contractFixture for every individual test would fail as the chain is reset (I believe this was the cause of the error at least). I made it instead only upload once using a session based fixture.