### PR TITLE
Switch travis to docker; use slim image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@
 **/*.pyc
 **/.cache/
 **/compilation_cache/
-src/macros/externs.sem
+.git/

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ local/*.py
 *build-*.json
 
 tests/compilation_cache/
+
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,16 @@
 dist: trusty
-sudo: false
+sudo: required
 
-cache:
-  - apt
-  - pip
+language: bash
 
-language: python
+services:
+  - docker
 
 notifications:
   email: false
 
-addons:
-  apt:
-    packages:
-      - libblas-dev
-      - liblapack-dev
-      - gfortran
+before_install: ./.travis/ci-setup.sh
+script: ./.travis/ci.sh
 
-install:
-  - pip install -U pip setuptools
-  - pip install -r requirements.txt
-
-script:
-  - travis_wait 60 pytest -vv tests
+git:
+  depth: 5

--- a/.travis/ci-setup.sh
+++ b/.travis/ci-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Upgrade Docker (trusty has 17.03.1~ce-0~ubuntu-trusty which is new enough)
+
+# sudo apt-get update
+# sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
+# Build the test image
+
+docker build --file Dockerfile-test --tag augur/test:latest .

--- a/.travis/ci.sh
+++ b/.travis/ci.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run augur/test:latest

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,42 +1,23 @@
-FROM python:2.7.13-alpine3.6
+FROM python:2.7.13
 
-# install a nice prompt
-RUN apk --no-cache --update add bash \
-	&& rm -rf /var/cache/apk/*
-
-# install Solidity compiler (solc)
-RUN apk --no-cache --update add build-base cmake boost-dev git ca-certificates wget openssl \
-	&& update-ca-certificates \
-	&& sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp \
-	&& mkdir /solidity \
-	&& wget -qO- https://github.com/ethereum/solidity/releases/download/v0.4.13/solidity_0.4.13.tar.gz | tar -xvz -C /solidity --strip 1 \
-	&& cd /solidity && cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSTATIC_LINKING=1 \
-	&& cd /solidity && make solc && install -s  solc/solc /usr/bin \
-	&& cd / && rm -rf solidity \
-	&& apk del sed build-base git make cmake gcc g++ musl-dev curl-dev boost-dev \
-	&& rm -rf /var/cache/apk/*
+RUN wget --quiet --output-document /usr/local/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.13/solc-static-linux \
+	&& chmod a+x /usr/local/bin/solc
 
 ENV PYTHONUNBUFFERED=1
 
 # install dependencies
-WORKDIR /app
 COPY requirements.txt /app/requirements.txt
-RUN apk --no-cache --update add gcc g++ openssl-dev \
-	&& pip install -U pip \
-	&& pip install -r requirements.txt \
-	&& apk del gcc g++ openssl-dev \
-	&& rm -rf /var/cache/apk/*
 
-# install runtime dependencies
-RUN apk --no-cache --update add libstdc++ libssl1.0 \
-	&& rm -rf /var/cache/apk/*
+RUN cd /app \
+	&& pip install --upgrade pip setuptools && \
+	&& pip install -r requirements.txt
 
 # copy over the source
-WORKDIR /app/src
 COPY src/ /app/src/
 
 # copy over the tests
-WORKDIR /app/tests
 COPY tests/ /app/tests/
+
+WORKDIR /app
 
 ENTRYPOINT ["pytest"]


### PR DESCRIPTION
Some tests succeed but most currently fail with:

```
E               {"contracts":{},"errors":[{"component":"general","formattedMessage":"Cannot import url (\"/app/src/Controller.sol\"): File outside of allowed directories.","message":"Cannot import url (\"/app/src/Controller.sol\"): File outside of allowed directories.","severity":"error","type":"IOError"}],"sources":{}}
```

Does the current image have the same issue?