### PR TITLE
Replaces legacy reputation contract with new contract.

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -8,7 +8,7 @@
     "lbrace": true,
     "mixedcase": true,
     "camelcase": true,
-    "uppercase": true,
+    "uppercase": false,
     "no-with": true,
     "no-empty-blocks": true,
     "no-unused-vars": true,

--- a/src/legacy_reputation/BasicToken.sol
+++ b/src/legacy_reputation/BasicToken.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.4.11;
+
+import 'ROOT/legacy_reputation/ERC20Basic.sol';
+import 'ROOT/legacy_reputation/SafeMath.sol';
+
+
+/**
+ * @title Basic token
+ * @dev Basic version of StandardToken, with no allowances. 
+ */
+contract BasicToken is ERC20Basic {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) balances;
+
+    /**
+     * @dev transfer token for a specified address
+     * @param _to The address to transfer to.
+     * @param _value The amount to be transferred.
+     */
+    function transfer(address _to, uint256 _value) returns (bool) {
+        balances[msg.sender] = balances[msg.sender].sub(_value);
+        balances[_to] = balances[_to].add(_value);
+        Transfer(msg.sender, _to, _value);
+        return true;
+    }
+
+    /**
+     * @dev Gets the balance of the specified address.
+     * @param _owner The address to query the the balance of. 
+     * @return An uint256 representing the amount owned by the passed address.
+     */
+    function balanceOf(address _owner) constant returns (uint256 balance) {
+        return balances[_owner];
+    }
+}

--- a/src/legacy_reputation/ERC20.sol
+++ b/src/legacy_reputation/ERC20.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.11;
+
+import 'ROOT/legacy_reputation/ERC20Basic.sol';
+
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+contract ERC20 is ERC20Basic {
+    function allowance(address owner, address spender) constant returns (uint256);
+    function transferFrom(address from, address to, uint256 value) returns (bool);
+    function approve(address spender, uint256 value) returns (bool);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/src/legacy_reputation/ERC20Basic.sol
+++ b/src/legacy_reputation/ERC20Basic.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title ERC20Basic
+ * @dev Simpler version of ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/179
+ */
+contract ERC20Basic {
+    uint256 public totalSupply;
+    function balanceOf(address who) constant returns (uint256);
+    function transfer(address to, uint256 value) returns (bool);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}

--- a/src/legacy_reputation/Initializable.sol
+++ b/src/legacy_reputation/Initializable.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.11;
+
+
+contract Initializable {
+    bool public initialized = false;
+
+    modifier afterInitialized {
+        require(initialized);
+        _;
+    }
+
+    modifier beforeInitialized {
+        require(!initialized);
+        _;
+    }
+
+    function endInitialization() internal beforeInitialized returns (bool) {
+        initialized = true;
+        return true;
+    }
+}

--- a/src/legacy_reputation/LegacyRepToken.sol
+++ b/src/legacy_reputation/LegacyRepToken.sol
@@ -1,0 +1,79 @@
+pragma solidity ^0.4.11;
+
+import 'ROOT/legacy_reputation/Initializable.sol';
+import 'ROOT/legacy_reputation/PausableToken.sol';
+import 'ROOT/legacy_reputation/ERC20Basic.sol';
+
+
+/**
+ * @title REP2 Token
+ * @dev REP2 Mintable Token with migration from legacy contract
+ */
+contract LegacyRepToken is Initializable, PausableToken {
+    ERC20Basic public legacyRepContract;
+    uint256 public targetSupply;
+
+    string public constant name = "Reputation";
+    string public constant symbol = "REP";
+    uint256 public constant decimals = 18;
+
+    event Migrated(address indexed holder, uint256 amount);
+
+    /**
+     * @dev Creates a new RepToken instance
+     * @param _legacyRepContract Address of the legacy ERC20Basic REP contract to migrate balances from
+     */
+    function LegacyRepToken(address _legacyRepContract, uint256 _amountUsedToFreeze, address _accountToSendFrozenRepTo) {
+        require(_legacyRepContract != 0);
+        legacyRepContract = ERC20Basic(_legacyRepContract);
+        targetSupply = legacyRepContract.totalSupply();
+        balances[_accountToSendFrozenRepTo] = _amountUsedToFreeze;
+        totalSupply = _amountUsedToFreeze;
+        pause();
+    }
+
+    /**
+     * @dev Copies the balance of a batch of addresses from the legacy contract
+     * @param _holders Array of addresses to migrate balance
+     * @return True if operation was completed
+     */
+    function migrateBalances(address[] _holders) onlyOwner beforeInitialized returns (bool) {
+        for (uint256 i = 0; i < _holders.length; i++) {
+            migrateBalance(_holders[i]);
+        }
+        return true;
+    }
+
+    /**
+     * @dev Copies the balance of a single addresses from the legacy contract
+     * @param _holder Address to migrate balance
+     * @return True if balance was copied, false if was already copied or address had no balance
+     */
+    function migrateBalance(address _holder) onlyOwner beforeInitialized returns (bool) {
+        if (balances[_holder] > 0) {
+            return false; // Already copied, move on
+        }
+
+        uint256 amount = legacyRepContract.balanceOf(_holder);
+        if (amount == 0) {
+            return false; // Has no balance in legacy contract, move on
+        }
+
+        balances[_holder] = amount;
+        totalSupply = totalSupply.add(amount);
+        Migrated(_holder, amount);
+
+        if (targetSupply == totalSupply) {
+            endInitialization();
+        }
+        return true;
+    }
+
+    /**
+     * @dev Unpauses the contract with the caveat added that it can only happen after initialization.
+     */
+    function unpause() onlyOwner whenPaused afterInitialized returns (bool) {
+        super.unpause();
+        return true;
+    }
+}

--- a/src/legacy_reputation/Ownable.sol
+++ b/src/legacy_reputation/Ownable.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+    address public owner;
+
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    function Ownable() {
+        owner = msg.sender;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) onlyOwner {
+        if (newOwner != address(0)) {
+            owner = newOwner;
+        }
+    }
+}

--- a/src/legacy_reputation/Pausable.sol
+++ b/src/legacy_reputation/Pausable.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.4.11;
+
+import "ROOT/legacy_reputation/Ownable.sol";
+
+
+/**
+ * @title Pausable
+ * @dev Base contract which allows children to implement an emergency stop mechanism.
+ */
+contract Pausable is Ownable {
+    event Pause();
+    event Unpause();
+
+    bool public paused = false;
+
+
+    /**
+     * @dev modifier to allow actions only when the contract IS paused
+     */
+    modifier whenNotPaused() {
+        require(!paused);
+        _;
+    }
+
+    /**
+     * @dev modifier to allow actions only when the contract IS NOT paused
+     */
+    modifier whenPaused {
+        require(paused);
+        _;
+    }
+
+    /**
+     * @dev called by the owner to pause, triggers stopped state
+     */
+    function pause() onlyOwner whenNotPaused returns (bool) {
+        paused = true;
+        Pause();
+        return true;
+    }
+
+    /**
+     * @dev called by the owner to unpause, returns to normal state
+     */
+    function unpause() onlyOwner whenPaused returns (bool) {
+        paused = false;
+        Unpause();
+        return true;
+    }
+}

--- a/src/legacy_reputation/PausableToken.sol
+++ b/src/legacy_reputation/PausableToken.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.4.11;
+
+import 'ROOT/legacy_reputation/StandardToken.sol';
+import 'ROOT/legacy_reputation/Pausable.sol';
+
+
+/**
+ * Pausable token
+ *
+ * Simple ERC20 Token example, with pausable token creation
+ **/
+contract PausableToken is StandardToken, Pausable {
+    function transfer(address _to, uint _value) whenNotPaused returns (bool) {
+        return super.transfer(_to, _value);
+    }
+
+    function transferFrom(address _from, address _to, uint _value) whenNotPaused returns (bool) {
+        return super.transferFrom(_from, _to, _value);
+    }
+}

--- a/src/legacy_reputation/SafeMath.sol
+++ b/src/legacy_reputation/SafeMath.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
+ */
+library SafeMath {
+    function mul(uint256 a, uint256 b) internal constant returns (uint256) {
+        uint256 c = a * b;
+        assert(a == 0 || c / a == b);
+        return c;
+    }
+
+    function div(uint256 a, uint256 b) internal constant returns (uint256) {
+        // assert(b > 0); // Solidity automatically throws when dividing by 0
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        return c;
+    }
+
+    function sub(uint256 a, uint256 b) internal constant returns (uint256) {
+        assert(b <= a);
+        return a - b;
+    }
+
+    function add(uint256 a, uint256 b) internal constant returns (uint256) {
+        uint256 c = a + b;
+        assert(c >= a);
+        return c;
+    }
+}

--- a/src/legacy_reputation/StandardToken.sol
+++ b/src/legacy_reputation/StandardToken.sol
@@ -1,0 +1,63 @@
+pragma solidity ^0.4.11;
+
+import 'ROOT/legacy_reputation/BasicToken.sol';
+import 'ROOT/legacy_reputation/ERC20.sol';
+
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * @dev https://github.com/ethereum/EIPs/issues/20
+ * @dev Based on code by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+contract StandardToken is ERC20, BasicToken {
+    mapping (address => mapping (address => uint256)) allowed;
+
+    /**
+     * @dev Transfer tokens from one address to another
+     * @param _from address The address which you want to send tokens from
+     * @param _to address The address which you want to transfer to
+     * @param _value uint256 the amout of tokens to be transfered
+     */
+    function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
+        var _allowance = allowed[_from][msg.sender];
+
+        // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
+        // require (_value <= _allowance);
+
+        balances[_to] = balances[_to].add(_value);
+        balances[_from] = balances[_from].sub(_value);
+        allowed[_from][msg.sender] = _allowance.sub(_value);
+        Transfer(_from, _to, _value);
+        return true;
+    }
+
+    /**
+     * @dev Aprove the passed address to spend the specified amount of tokens on behalf of msg.sender.
+     * @param _spender The address which will spend the funds.
+     * @param _value The amount of tokens to be spent.
+     */
+    function approve(address _spender, uint256 _value) returns (bool) {
+
+        // To change the approve amount you first have to reduce the addresses`
+        //  allowance to zero by calling `approve(_spender, 0)` if it is not
+        //  already 0 to mitigate the race condition described here:
+        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        require((_value == 0) || (allowed[msg.sender][_spender] == 0));
+
+        allowed[msg.sender][_spender] = _value;
+        Approval(msg.sender, _spender, _value);
+        return true;
+    }
+
+    /**
+     * @dev Function to check the amount of tokens that an owner allowed to a spender.
+     * @param _owner address The address which owns the funds.
+     * @param _spender address The address which will spend the funds.
+     * @return A uint256 specifing the amount of tokens still avaible for the spender.
+     */
+    function allowance(address _owner, address _spender) constant returns (uint256 remaining) {
+        return allowed[_owner][_spender];
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,8 @@ class ContractsFixture:
 
     def uploadAllContracts(self):
         for directory, _, filenames in walk(resolveRelativePath('../src')):
+            # skip the legacy reputation directory since it is unnecessary and we don't support uploads of contracts with constructors yet
+            if 'legacy_reputation' in directory: continue
             for filename in filenames:
                 name = path.splitext(filename)[0]
                 extension = path.splitext(filename)[1]


### PR DESCRIPTION
Retained old serpent legacyRep contract because a number of tests depend on it and I don't want to sink time into fixing them yet.

I put the code in `src/` so other contracts can reference it if necessary (e.g., for legacy rep migration process) but I have excluded it from being uploaded with everything else in the test suite.

Contracts should be byte-for-byte compatible with what is uploaded to main network (though I cleaned them up to match our team style and pass linter checks).