### PR TITLE
Adds reentrancy guard.

### DIFF
--- a/src/Mutex.sol
+++ b/src/Mutex.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.13;
 import 'ROOT/Controller.sol';
 
 
+// DEPRECATED: Use libraries/ReentrancyGuard.sol
 contract Mutex is Controlled {
     bool public mutex = false;
 

--- a/src/libraries/ReentrancyGuard.sol
+++ b/src/libraries/ReentrancyGuard.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.13;
+
+
+/**
+ * @title Helps contracts guard agains rentrancy attacks.
+ * @author Remco Bloemen <remco@2π.com>
+ * @notice If you mark a function `nonReentrant`, you should also mark it `external`.
+ */
+contract ReentrancyGuard {
+    /**
+     * @dev We use a single lock for the whole contract.
+     */
+    bool private rentrancyLock = false;
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * @notice If you mark a function `nonReentrant`, you should also mark it `external`. Calling one nonReentrant function from another is not supported. Instead, you can implement a `private` function doing the actual work, and a `external` wrapper marked as `nonReentrant`.
+     */
+    modifier nonReentrant() {
+        require(!rentrancyLock);
+        rentrancyLock = true;
+        _;
+        rentrancyLock = false;
+    }
+}


### PR DESCRIPTION
Deprecates but doesn't delete Mutex as it is still referenced by Serpent code.