### PR TITLE
Makes it so VSCode functions without Python/PIP available on the path  (for workflows that involve running in Docker).

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
             "prefix": "ROOT",
             "target": "./src"
         }
-    ]
+    ],
+    "python.linting.pylintEnabled": false
 }


### PR DESCRIPTION
I have been carting this around for a while, would be nice to get it merged so I can stop manually re-adding it every time I change branches.
