### PR TITLE
removing some unused imports from tests

### DIFF
--- a/tests/libraries/math/test_safeMathInt256.py
+++ b/tests/libraries/math/test_safeMathInt256.py
@@ -2,7 +2,7 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture, mark, raises
 
 @fixture(scope='session')
 def testerSnapshot(sessionFixture):

--- a/tests/libraries/math/test_safeMathUint256.py
+++ b/tests/libraries/math/test_safeMathUint256.py
@@ -2,7 +2,7 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture, mark, raises
 
 @fixture(scope='session')
 def testerSnapshot(sessionFixture):

--- a/tests/libraries/test_arrays.py
+++ b/tests/libraries/test_arrays.py
@@ -2,11 +2,11 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture
 from ethereum.config import config_metropolis
 
 #config_metropolis['BLOCK_GAS_LIMIT'] = 2**128
- 
+
 @fixture(scope="session")
 def arraySnapshot(sessionFixture):
     arrayHelper = sessionFixture.upload('solidity_test_helpers/ArrayHelper.sol')

--- a/tests/libraries/test_delegator.py
+++ b/tests/libraries/test_delegator.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture, raises
 from utils import stringToBytes
 
 @fixture(scope="session")

--- a/tests/reporting/test_branch.py
+++ b/tests/reporting/test_branch.py
@@ -1,4 +1,3 @@
-from ethereum.tools import tester
 from utils import longToHexString, stringToBytes
 
 def test_branch_creation(contractsFixture):

--- a/tests/reporting/test_dispute_bond_token.py
+++ b/tests/reporting/test_dispute_bond_token.py
@@ -7,8 +7,8 @@
 # CONSIDER: Break up test_dispute_bond_tokens() into more functions
 
 from ethereum.tools import tester
-from pytest import raises, fixture, mark, lazy_fixture
-from utils import bytesToLong, bytesToHexString, fix
+from pytest import mark
+from utils import bytesToHexString
 
 REP_TOTAL = 11 * 10**6 # Total number of REP tokens in existence
 REP_DIVISOR = 10**18 # Amount by which a single REP token can be divided

--- a/tests/reporting/test_market.py
+++ b/tests/reporting/test_market.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
 from pytest import raises
-from utils import longToHexString, stringToBytes
+from utils import stringToBytes
 
 tester.STARTGAS = long(6.7 * 10**6)
 

--- a/tests/reporting/test_registration_token_redemption.py
+++ b/tests/reporting/test_registration_token_redemption.py
@@ -1,8 +1,7 @@
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
-from datetime import timedelta
-from reporting_utils import proceedToAutomatedReporting, proceedToLimitedReporting, proceedToAllReporting, proceedToForking, finalizeForkingMarket, initializeReportingFixture
+from pytest import fixture, mark, raises
+from reporting_utils import proceedToAutomatedReporting, proceedToLimitedReporting, initializeReportingFixture
 
 def test_automatedReportingNoReport(registrationTokenRedemptionFixture):
     market = registrationTokenRedemptionFixture.market1
@@ -191,7 +190,7 @@ def test_limitedReportingRedemptionMultipleMarketInsufficientReport(registration
 
     # Proceed to the LIMITED REPORTING phase
     proceedToLimitedReporting(registrationTokenRedemptionFixture, market, makeReport, tester.k1, [0,10**18])
-    
+
     # We need to report on 2 markets to satisfy reporting requirements
     assert reportingWindow.getRequiredReportsPerReporterForlimitedReporterMarkets() == 2
 

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -1,7 +1,6 @@
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
-from datetime import timedelta
+from pytest import fixture, mark, raises
 from reporting_utils import proceedToAutomatedReporting, proceedToLimitedReporting, proceedToAllReporting, proceedToForking, finalizeForkingMarket, initializeReportingFixture
 
 tester.STARTGAS = long(6.7 * 10**6)
@@ -57,7 +56,7 @@ def test_reportingFullHappyPath(reportingFixture):
     secondRegistrationToken = reportingFixture.applySignature('RegistrationToken', reportingWindow.getRegistrationToken())
     secondRegistrationToken.register(sender=tester.k2)
     assert secondRegistrationToken.balanceOf(tester.a2) == 1
-    assert reputationToken.balanceOf(tester.a2) == 1 * 10**6 * 10**18 - 2 * 10**18 
+    assert reputationToken.balanceOf(tester.a2) == 1 * 10**6 * 10**18 - 2 * 10**18
 
     # Tester 2 reports for the NO outcome
     reportingFixture.chain.head_state.timestamp = reportingWindow.getStartTime() + 1

--- a/tests/reporting/test_reputation.py
+++ b/tests/reporting/test_reputation.py
@@ -1,5 +1,4 @@
 from ethereum.tools import tester
-from utils import longToHexString
 
 def test_decimals(contractsFixture):
     reputationTokenFactory = contractsFixture.contracts['ReputationTokenFactory']

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,7 +3,7 @@
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
 from pytest import raises, fixture
-from utils import bytesToLong, longToHexString, bytesToHexString
+from utils import longToHexString, bytesToHexString
 
 def test_whitelists(controller):
     assert controller.assertIsWhitelisted(tester.a0, sender = tester.k2)

--- a/tests/test_legacyRep.py
+++ b/tests/test_legacyRep.py
@@ -1,6 +1,4 @@
 from ethereum.tools import tester
-from ethereum.tools.tester import TransactionFailed
-from pytest import raises
 
 def test_legacyRepFaucet(contractsFixture):
     legacyRep = contractsFixture.contracts['LegacyRepContract']

--- a/tests/trading/test_cancelOrder.py
+++ b/tests/trading/test_cancelOrder.py
@@ -2,8 +2,8 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import raises, fixture
-from utils import bytesToLong, longTo32Bytes, longToHexString, fix, unfix
+from pytest import raises
+from utils import longTo32Bytes, longToHexString, fix
 from constants import BID, ASK, YES, NO
 
 tester.STARTGAS = long(6.7 * 10**6)

--- a/tests/trading/test_completeSets.py
+++ b/tests/trading/test_completeSets.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-from datetime import timedelta
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
 from pytest import raises
-from utils import bytesToHexString, longToHexString, bytesToLong, fix, captureFilteredLogs
+from utils import bytesToHexString, fix, captureFilteredLogs
 from constants import YES, NO
 
 def test_publicBuyCompleteSets(fundedRepFixture):

--- a/tests/trading/test_orders.py
+++ b/tests/trading/test_orders.py
@@ -2,9 +2,8 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-import numpy as np
-from pytest import fixture, mark, lazy_fixture, raises
-from utils import fix, bytesToLong, bytesToHexString, longTo32Bytes, longToHexString, stringToBytes
+from pytest import mark, lazy_fixture, raises
+from utils import fix, bytesToHexString, longTo32Bytes, longToHexString
 from constants import BID, ASK, YES, NO
 
 WEI_TO_ETH = 10**18

--- a/tests/trading/test_wcl.py
+++ b/tests/trading/test_wcl.py
@@ -2,8 +2,8 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import raises, fixture, mark, lazy_fixture
-from utils import bytesToLong, longToHexString, longTo32Bytes, bytesToHexString, fix, unfix
+from pytest import raises, mark, lazy_fixture
+from utils import longTo32Bytes, fix
 from constants import BID, ASK, YES, NO
 
 tester.STARTGAS = long(6.7 * 10**6)


### PR DESCRIPTION
I was working on getting `test_wcl_fuzzy.py` to work, when I noticed that it was the last place we're using `bytesToLong`, yet we still import it in many tests. So I went through and removed a bunch of unused imports in tests.