### PR TITLE
Fee calc todos

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ethereum-augur-temp==2.1.0
+ethereum-augur-temp==2.1.2
 pycryptodome==3.4.6
 numpy==1.13.0
 pytest==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-ethereum-augur-temp==2.1.0
+ethereum-augur-temp==2.1.2
 numpy==1.13.0
 pbkdf2==1.3               # via ethereum-augur-temp
 py-ecc==1.1.1             # via ethereum-augur-temp

--- a/source/contracts/extensions/MarketFeeCalculator.sol
+++ b/source/contracts/extensions/MarketFeeCalculator.sol
@@ -43,20 +43,25 @@ contract MarketFeeCalculator {
         
         uint256 _targetIndeterminateMarkets = _totalMarkets.div(_targetIndeterminateMarketsDivisor);
 
+        // Modify the validity bond based on the previous amount and the number of indeterminate markets. We want the bond to be somewhere in the range of 0.5 to 2 times its previous value where ALL markets being indeterminate results in 2x and 0 indeterminate results in 0.5x.
         if (_indeterminateMarkets <= _targetIndeterminateMarkets) {
+            // FXP formula: previous_bond * percent_invalid / (2 * target_percent_invalid) + 0.5;
             return _indeterminateMarkets
                 .mul(_previousValidityBondInAttoeth)
                 .mul(_targetIndeterminateMarketsDivisor)
                 .div(_totalMarkets)
                 .div(2)
-            .add(_previousValidityBondInAttoeth.div(2));
+                .add(_previousValidityBondInAttoeth.div(2))
+            ; // FIXME: This is here due to a solium bug
         } else {
+            // FXP formula: previous_bond * (1/(1 - target_percent_invalid)) * (percent_invalid - target_percent_invalid) + 1;
             return _targetIndeterminateMarketsDivisor
                 .mul(_previousValidityBondInAttoeth.mul(_indeterminateMarkets)
                 .div(_totalMarkets)
                 .sub(_previousValidityBondInAttoeth.div(_targetIndeterminateMarketsDivisor)))
                 .div(_targetIndeterminateMarketsDivisor - 1)
-            .add(_previousValidityBondInAttoeth);
+                .add(_previousValidityBondInAttoeth)
+            ; // FIXME: This is here due to a solium bug
         }
     }
 

--- a/source/contracts/extensions/MarketFeeCalculator.sol
+++ b/source/contracts/extensions/MarketFeeCalculator.sol
@@ -4,6 +4,7 @@ import 'reporting/IReputationToken.sol';
 import 'reporting/IUniverse.sol';
 import 'reporting/IReportingWindow.sol';
 import 'libraries/math/SafeMathUint256.sol';
+import 'reporting/Reporting.sol';
 
 
 contract MarketFeeCalculator {
@@ -62,8 +63,7 @@ contract MarketFeeCalculator {
         IReportingWindow _previousReportingWindow = getPreviousReportingWindow(_reportingWindow);
         uint256 _estimatedReportsPerMarket = _previousReportingWindow.getAvgReportsPerMarket();
         uint256 _avgGasCost = _previousReportingWindow.getAvgReportingGasCost();
-        // Estimate based on test usage data on 09/29/2017
-        _gasToReport = 700000;
+        _gasToReport = Reporting.gasToReport();
         // we double it to try and ensure we have more than enough rather than not enough
         targetReporterGasCosts[_reportingWindow] = _gasToReport * _estimatedReportsPerMarket * _avgGasCost * 2;
         return targetReporterGasCosts[_reportingWindow];

--- a/source/contracts/extensions/MarketFeeCalculator.sol
+++ b/source/contracts/extensions/MarketFeeCalculator.sol
@@ -47,16 +47,10 @@ contract MarketFeeCalculator {
         uint256 _fxpMultiple = _fxpBase;
 
         if (_indeterminateMarkets <= _targetIndeterminateMarkets) {
-            _fxpMultiple = _fxpPercentIndeterminate
-                .mul(_targetIndeterminateMarketsDivisor)
-                .div(2)
-                .add(_fxpBase.div(2));
+            _fxpMultiple = _fxpPercentIndeterminate.mul(_targetIndeterminateMarketsDivisor).div(2).add(_fxpBase.div(2));
         } else {
             uint256 _fxpTargetIndeterminateMarkets = _fxpBase.div(_targetIndeterminateMarketsDivisor);
-            _fxpMultiple = _fxpBase
-                .mul(_fxpPercentIndeterminate.sub(_fxpTargetIndeterminateMarkets))
-                .div(_fxpBase.sub(_fxpTargetIndeterminateMarkets))
-                .add(_fxpBase);
+            _fxpMultiple = _fxpBase.mul(_fxpPercentIndeterminate.sub(_fxpTargetIndeterminateMarkets)).div(_fxpBase.sub(_fxpTargetIndeterminateMarkets)).add(_fxpBase);
         }
 
         return _previousValidityBondInAttoeth.fxpMul(_fxpMultiple, _fxpBase);

--- a/source/contracts/extensions/MarketFeeCalculator.sol
+++ b/source/contracts/extensions/MarketFeeCalculator.sol
@@ -41,19 +41,23 @@ contract MarketFeeCalculator {
             _previousValidityBondInAttoeth = DEFAULT_VALIDITY_BOND;
         }
         
-        uint256 _fxpBase = uint256(1 ether);
-        uint256 _fxpPercentIndeterminate = _indeterminateMarkets.fxpDiv(_totalMarkets, _fxpBase);
         uint256 _targetIndeterminateMarkets = _totalMarkets.div(_targetIndeterminateMarketsDivisor);
-        uint256 _fxpMultiple = _fxpBase;
 
         if (_indeterminateMarkets <= _targetIndeterminateMarkets) {
-            _fxpMultiple = _fxpPercentIndeterminate.mul(_targetIndeterminateMarketsDivisor).div(2).add(_fxpBase.div(2));
+            return _indeterminateMarkets
+                .mul(_previousValidityBondInAttoeth)
+                .mul(_targetIndeterminateMarketsDivisor)
+                .div(_totalMarkets)
+                .div(2)
+            .add(_previousValidityBondInAttoeth.div(2));
         } else {
-            uint256 _fxpTargetIndeterminateMarkets = _fxpBase.div(_targetIndeterminateMarketsDivisor);
-            _fxpMultiple = _fxpBase.mul(_fxpPercentIndeterminate.sub(_fxpTargetIndeterminateMarkets)).div(_fxpBase.sub(_fxpTargetIndeterminateMarkets)).add(_fxpBase);
+            return _targetIndeterminateMarketsDivisor
+                .mul(_previousValidityBondInAttoeth.mul(_indeterminateMarkets)
+                .div(_totalMarkets)
+                .sub(_previousValidityBondInAttoeth.div(_targetIndeterminateMarketsDivisor)))
+                .div(_targetIndeterminateMarketsDivisor - 1)
+            .add(_previousValidityBondInAttoeth);
         }
-
-        return _previousValidityBondInAttoeth.fxpMul(_fxpMultiple, _fxpBase);
     }
 
     function getTargetReporterGasCosts(IReportingWindow _reportingWindow) constant public returns (uint256) {

--- a/source/contracts/libraries/math/RunningAverage.sol
+++ b/source/contracts/libraries/math/RunningAverage.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.13;
+
+
+library RunningAverage {
+    struct Data {
+        uint256 sum;
+        uint128 count;
+    }
+
+    function currentAverage(Data storage _this) internal returns (uint256) {
+        return _this.sum / _this.count;
+    }
+
+    function record(Data storage _this, uint256 _input) internal returns (bool) {
+        _this.count++;
+        _this.sum += _input;
+        return true;
+    }
+}

--- a/source/contracts/reporting/IMarket.sol
+++ b/source/contracts/reporting/IMarket.sol
@@ -49,4 +49,5 @@ contract IMarket is Typed, IOwnable {
     function isContainerForReportingToken(Typed _shadyTarget) public constant returns (bool);
     function isContainerForDisputeBondToken(Typed _shadyTarget) public constant returns (bool);
     function isContainerForShareToken(Typed _shadyTarget) public constant returns (bool);
+    function isIndeterminate() public constant returns (bool);
 }

--- a/source/contracts/reporting/IReportingToken.sol
+++ b/source/contracts/reporting/IReportingToken.sol
@@ -10,4 +10,5 @@ contract IReportingToken is Typed, ERC20 {
     function getMarket() public constant returns (IMarket);
     function getPayoutNumerator(uint8 index) public constant returns (uint256);
     function getPayoutDistributionHash() public constant returns (bytes32);
+    function isIndeterminate() public constant returns (bool);
 }

--- a/source/contracts/reporting/IReportingWindow.sol
+++ b/source/contracts/reporting/IReportingWindow.sol
@@ -26,6 +26,8 @@ contract IReportingWindow is Typed {
     function getMaxReportsPerLimitedReporterMarket() public constant returns (uint256);
     function getAvgReportingGasCost() public constant returns (uint256);
     function getAvgReportsPerMarket() public constant returns (uint256);
+    function getNextReportingWindow() constant public returns (IReportingWindow);
+    function getPreviousReportingWindow() constant public returns (IReportingWindow);
     function checkIn() public returns (bool);
     function isContainerForRegistrationToken(IRegistrationToken _shadyRegistrationToken) public constant returns (bool);
     function isContainerForMarket(IMarket _shadyMarket) public constant returns (bool);

--- a/source/contracts/reporting/IReportingWindow.sol
+++ b/source/contracts/reporting/IReportingWindow.sol
@@ -21,6 +21,8 @@ contract IReportingWindow is Typed {
     function getRegistrationToken() public constant returns (IRegistrationToken);
     function getStartTime() public constant returns (uint256);
     function getEndTime() public constant returns (uint256);
+    function getNumMarkets() public constant returns (uint256);
+    function getNumIndeterminateMarkets() public constant returns (uint256);
     function checkIn() public returns (bool);
     function isContainerForRegistrationToken(IRegistrationToken _shadyRegistrationToken) public constant returns (bool);
     function isContainerForMarket(IMarket _shadyMarket) public constant returns (bool);

--- a/source/contracts/reporting/IReportingWindow.sol
+++ b/source/contracts/reporting/IReportingWindow.sol
@@ -23,6 +23,9 @@ contract IReportingWindow is Typed {
     function getEndTime() public constant returns (uint256);
     function getNumMarkets() public constant returns (uint256);
     function getNumIndeterminateMarkets() public constant returns (uint256);
+    function getMaxReportsPerLimitedReporterMarket() public constant returns (uint256);
+    function getAvgReportingGasCost() public constant returns (uint256);
+    function getAvgReportsPerMarket() public constant returns (uint256);
     function checkIn() public returns (bool);
     function isContainerForRegistrationToken(IRegistrationToken _shadyRegistrationToken) public constant returns (bool);
     function isContainerForMarket(IMarket _shadyMarket) public constant returns (bool);

--- a/source/contracts/reporting/IUniverse.sol
+++ b/source/contracts/reporting/IUniverse.sol
@@ -21,10 +21,13 @@ contract IUniverse is Typed {
     function getReportingWindowByMarketEndTime(uint256 _endTime, bool _hasDesignatedReporter) public returns (IReportingWindow);
     function getNextReportingWindow() public returns (IReportingWindow);
     function getReportingWindowForForkEndTime() public constant returns (IReportingWindow);
+    function getOpenInterestInAttoEth() public constant returns (uint256);
     function isParentOf(IUniverse _shadyChild) constant returns (bool);
     function isContainerForReportingWindow(Typed _shadyTarget) public constant returns (bool);
     function isContainerForRegistrationToken(Typed _shadyTarget) public constant returns (bool);
     function isContainerForMarket(Typed _shadyTarget) public constant returns (bool);
     function isContainerForReportingToken(Typed _shadyTarget) public constant returns (bool);
     function isContainerForShareToken(Typed _shadyTarget) public constant returns (bool);
+    function decrementOpenInterest(uint256 _amount) public returns (bool);
+    function incrementOpenInterest(uint256 _amount) public returns (bool);
 }

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -440,6 +440,12 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
         return false;
     }
 
+    function isIndeterminate() public constant returns (bool) {
+        IReportingToken _winningReportingToken = getFinalWinningReportingToken();
+        require(address(_winningReportingToken) != NULL_ADDRESS);
+        return _winningReportingToken.isIndeterminate();
+    }
+
     function getDesignatedReportDueTimestamp() public constant returns (uint256) {
         if (designatedReportReceivedTime != 0) {
             return designatedReportReceivedTime;

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -440,6 +440,7 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
         return false;
     }
 
+    // CONSIDER: Would it be helpful to add modifiers for this contract like "onlyAfterFinalized" that could protect a function such as this?
     function isIndeterminate() public constant returns (bool) {
         IReportingToken _winningReportingToken = getFinalWinningReportingToken();
         require(address(_winningReportingToken) != NULL_ADDRESS);

--- a/source/contracts/reporting/Reporting.sol
+++ b/source/contracts/reporting/Reporting.sol
@@ -8,10 +8,15 @@ library Reporting {
     uint256 private constant REPORTING_DISPUTE_DURATION_SECONDS = 3 days;
     uint256 private constant CLAIM_PROCEEDS_WAIT_TIME = 3 days;
     uint256 private constant REGISTRATION_TOKEN_BOND_AMOUNT = 1 ether;
+
     // CONSIDER: figure out approprate values for these
     uint256 private constant DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT = 11 * 10**20;
     uint256 private constant LIMITED_REPORTERS_DISPUTE_BOND_AMOUNT = 11 * 10**21;
     uint256 private constant ALL_REPORTERS_DISPUTE_BOND_AMOUNT = 11 * 10**22;
+
+    uint256 private constant GAS_TO_REPORT = 568333;
+    uint256 private constant DEFAULT_REPORTING_GAS_PRICE = 5;
+    uint256 private constant DEFAULT_REPORTS_PER_MARKET = 10;
 
     function designatedReportingDurationSeconds() internal constant returns (uint256) { return DESIGNATED_REPORTING_DURATION_SECONDS; }
     function designatedReportingDisputeDurationSeconds() internal constant returns (uint256) { return DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS; }
@@ -22,4 +27,7 @@ library Reporting {
     function designatedReporterDisputeBondAmount() internal constant returns (uint256) { return DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT; }
     function limitedReportersDisputeBondAmount() internal constant returns (uint256) { return LIMITED_REPORTERS_DISPUTE_BOND_AMOUNT; }
     function allReportersDisputeBondAmount() internal constant returns (uint256) { return ALL_REPORTERS_DISPUTE_BOND_AMOUNT; }
+    function gasToReport() internal constant returns (uint256) { return GAS_TO_REPORT; }
+    function defaultReportingGasPrice() internal constant returns (uint256) { return DEFAULT_REPORTING_GAS_PRICE; }
+    function defaultReportsPerMarket() internal constant returns (uint256) { return DEFAULT_REPORTS_PER_MARKET; }
 }

--- a/source/contracts/reporting/Reporting.sol
+++ b/source/contracts/reporting/Reporting.sol
@@ -14,7 +14,7 @@ library Reporting {
     uint256 private constant LIMITED_REPORTERS_DISPUTE_BOND_AMOUNT = 11 * 10**21;
     uint256 private constant ALL_REPORTERS_DISPUTE_BOND_AMOUNT = 11 * 10**22;
 
-    uint256 private constant GAS_TO_REPORT = 568918;
+    uint256 private constant GAS_TO_REPORT = 567796;
     uint256 private constant DEFAULT_REPORTING_GAS_PRICE = 5;
     uint256 private constant DEFAULT_REPORTS_PER_MARKET = 10;
 

--- a/source/contracts/reporting/Reporting.sol
+++ b/source/contracts/reporting/Reporting.sol
@@ -14,7 +14,7 @@ library Reporting {
     uint256 private constant LIMITED_REPORTERS_DISPUTE_BOND_AMOUNT = 11 * 10**21;
     uint256 private constant ALL_REPORTERS_DISPUTE_BOND_AMOUNT = 11 * 10**22;
 
-    uint256 private constant GAS_TO_REPORT = 568333;
+    uint256 private constant GAS_TO_REPORT = 568918;
     uint256 private constant DEFAULT_REPORTING_GAS_PRICE = 5;
     uint256 private constant DEFAULT_REPORTS_PER_MARKET = 10;
 

--- a/source/contracts/reporting/ReportingToken.sol
+++ b/source/contracts/reporting/ReportingToken.sol
@@ -163,4 +163,13 @@ contract ReportingToken is DelegationTarget, Typed, Initializable, VariableSuppl
         require(index < market.getNumberOfOutcomes());
         return payoutNumerators[index];
     }
+
+    function isIndeterminate() public constant returns (bool) {
+        for (uint8 i = 1; i < payoutNumerators.length; i++) {
+            if (payoutNumerators[0] != payoutNumerators[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/source/contracts/reporting/ReportingWindow.sol
+++ b/source/contracts/reporting/ReportingWindow.sol
@@ -34,6 +34,7 @@ contract ReportingWindow is DelegationTarget, Typed, Initializable, IReportingWi
     Set.Data private markets;
     Set.Data private limitedReporterMarkets;
     Set.Data private allReporterMarkets;
+    uint256 private indeterminateMarketCount;
     mapping(address => ReportingStatus) private reporterStatus;
     mapping(address => uint256) private numberOfReportsByMarket;
     uint256 private constant BASE_MINIMUM_REPORTERS_PER_MARKET = 7;
@@ -105,6 +106,12 @@ contract ReportingWindow is DelegationTarget, Typed, Initializable, IReportingWi
             limitedReporterMarkets.remove(_market);
         }
 
+        if (_state == IMarket.ReportingState.FINALIZED) {
+            if (_market.isIndeterminate()) {
+                indeterminateMarketCount++;
+            }
+        }
+
         return true;
     }
 
@@ -146,6 +153,14 @@ contract ReportingWindow is DelegationTarget, Typed, Initializable, IReportingWi
 
     function getEndTime() public afterInitialized constant returns (uint256) {
         return getDisputeEndTime();
+    }
+
+    function getNumMarkets() public constant returns (uint256) {
+        return markets.count;
+    }
+
+    function getNumIndeterminateMarkets() public constant returns (uint256) {
+        return indeterminateMarketCount;
     }
 
     function getReportingStartTime() public afterInitialized constant returns (uint256) {

--- a/source/contracts/reporting/ReportingWindow.sol
+++ b/source/contracts/reporting/ReportingWindow.sol
@@ -50,9 +50,9 @@ contract ReportingWindow is DelegationTarget, Typed, Initializable, IReportingWi
         RegistrationTokenFactory _registrationTokenFactory = RegistrationTokenFactory(controller.lookup("RegistrationTokenFactory"));
         registrationToken = _registrationTokenFactory.createRegistrationToken(controller, this);
         // Initialize these to some reasonable value to handle the first market ever created without branching code 
-        reportingGasPriceSum = 5;
+        reportingGasPriceSum = Reporting.defaultReportingGasPrice();
+        marketReportsSum = Reporting.defaultReportsPerMarket();
         numReports = 1;
-        marketReportsSum = 10;
         numFinalizedMarkets = 1;
         return true;
     }

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -27,6 +27,7 @@ contract Universe is DelegationTarget, Typed, Initializable, IUniverse {
     uint256 private forkEndTime;
     mapping(uint256 => IReportingWindow) private reportingWindows;
     mapping(bytes32 => IUniverse) private childUniverses;
+    uint256 private openInterestInAttoEth;
 
     function initialize(IUniverse _parentUniverse, bytes32 _parentPayoutDistributionHash) external beforeInitialized returns (bool) {
         endInitialization();
@@ -221,5 +222,17 @@ contract Universe is DelegationTarget, Typed, Initializable, IUniverse {
 
     function getReportingWindowForForkEndTime() public constant returns (IReportingWindow) {
         return getReportingWindowByTimestamp(getForkEndTime());
+    }
+
+    function decrementOpenInterest(uint256 _amount) public onlyWhitelistedCallers returns (bool) {
+        openInterestInAttoEth = openInterestInAttoEth.sub(_amount); 
+    }
+
+    function incrementOpenInterest(uint256 _amount) public onlyWhitelistedCallers returns (bool) {
+        openInterestInAttoEth = openInterestInAttoEth.add(_amount); 
+    }
+
+    function getOpenInterestInAttoEth() public constant returns (uint256) {
+        return openInterestInAttoEth;
     }
 }

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -14,9 +14,12 @@ import 'reporting/IDisputeBond.sol';
 import 'reporting/IRegistrationToken.sol';
 import 'reporting/IReportingWindow.sol';
 import 'reporting/Reporting.sol';
+import 'libraries/math/SafeMathUint256.sol';
 
 
 contract Universe is DelegationTarget, Typed, Initializable, IUniverse {
+    using SafeMathUint256 for uint256;
+
     IUniverse private parentUniverse;
     bytes32 private parentPayoutDistributionHash;
     IReputationToken private reputationToken;

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -228,6 +228,7 @@ contract Universe is DelegationTarget, Typed, Initializable, IUniverse {
         openInterestInAttoEth = openInterestInAttoEth.sub(_amount); 
     }
 
+    // CONSIDER: It would be more correct to decrease open interest for all outstanding shares in a market when it is finalized. We aren't doing this currently since securely and correctly writing this code would require updating the Market contract, which is currently at its size limit.
     function incrementOpenInterest(uint256 _amount) public onlyWhitelistedCallers returns (bool) {
         openInterestInAttoEth = openInterestInAttoEth.add(_amount); 
     }

--- a/source/contracts/trading/ClaimProceeds.sol
+++ b/source/contracts/trading/ClaimProceeds.sol
@@ -28,7 +28,11 @@ contract ClaimProceeds is CashAutoConverter, ReentrancyGuard, IClaimProceeds {
         for (uint8 _outcome = 0; _outcome < _market.getNumberOfOutcomes(); ++_outcome) {
             IShareToken _shareToken = _market.getShareToken(_outcome);
             uint256 _numberOfShares = _shareToken.balanceOf(msg.sender);
-            var (_shareHolderShare, _creatorShare, _reporterShare) = divideUpWinnings(_market, _winningReportingToken, _outcome, _numberOfShares);
+            var (_proceeds, _shareHolderShare, _creatorShare, _reporterShare) = divideUpWinnings(_market, _winningReportingToken, _outcome, _numberOfShares);
+
+            if (_proceeds > 0) {
+                _market.getUniverse().decrementOpenInterest(_proceeds);
+            }
 
             // always destroy shares as it gives a minor gas refund and is good for the network
             if (_numberOfShares > 0) {
@@ -52,12 +56,12 @@ contract ClaimProceeds is CashAutoConverter, ReentrancyGuard, IClaimProceeds {
         return true;
     }
 
-    function divideUpWinnings(IMarket _market, IReportingToken _winningReportingToken, uint8 _outcome, uint256 _numberOfShares) public constant returns (uint256 _shareHolderShare, uint256 _creatorShare, uint256 _reporterShare) {
-        uint256 _proceeds = calculateProceeds(_winningReportingToken, _outcome, _numberOfShares);
+    function divideUpWinnings(IMarket _market, IReportingToken _winningReportingToken, uint8 _outcome, uint256 _numberOfShares) public constant returns (uint256 _proceeds, uint256 _shareHolderShare, uint256 _creatorShare, uint256 _reporterShare) {
+        _proceeds = calculateProceeds(_winningReportingToken, _outcome, _numberOfShares);
         _creatorShare = calculateMarketCreatorFee(_market, _proceeds);
         _reporterShare = calculateReportingFee(_market, _proceeds);
         _shareHolderShare = _proceeds.sub(_creatorShare).sub(_reporterShare);
-        return (_shareHolderShare, _creatorShare, _reporterShare);
+        return (_proceeds, _shareHolderShare, _creatorShare, _reporterShare);
     }
 
     function calculateProceeds(IReportingToken _winningReportingToken, uint8 _outcome, uint256 _numberOfShares) public constant returns (uint256) {

--- a/source/contracts/trading/CompleteSets.sol
+++ b/source/contracts/trading/CompleteSets.sol
@@ -37,6 +37,8 @@ contract CompleteSets is Controlled, CashAutoConverter, ReentrancyGuard, IComple
             _market.getShareToken(_outcome).createShares(_sender, _amount);
         }
 
+        _market.getUniverse().incrementOpenInterest(_cost);
+
         IOrders(controller.lookup("Orders")).buyCompleteSetsLog(_sender, _market, _amount, _numOutcomes);
         return true;
     }
@@ -53,6 +55,7 @@ contract CompleteSets is Controlled, CashAutoConverter, ReentrancyGuard, IComple
         ICash _denominationToken = _market.getDenominationToken();
         uint256 _marketCreatorFeeRate = _market.getMarketCreatorSettlementFeeInAttoethPerEth();
         uint256 _payout = _amount.mul(_market.getNumTicks());
+        _market.getUniverse().decrementOpenInterest(_payout);
         uint256 _marketCreatorFee = _payout.mul(_marketCreatorFeeRate).div(1 ether);
         IReportingWindow _reportingWindow = _market.getReportingWindow();
         uint256 _reportingFeeRate = MarketFeeCalculator(controller.lookup("MarketFeeCalculator")).getReportingFeeInAttoethPerEth(_reportingWindow);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,8 +139,14 @@ class ContractsFixture:
     ####
 
     def __init__(self):
-        tester.GASPRICE = 0
+        config_metropolis['GASLIMIT_ADJMAX_FACTOR'] = .000000000001
+        config_metropolis['GENESIS_GAS_LIMIT'] = 2**60
+        config_metropolis['MIN_GAS_LIMIT'] = 2**60
         config_metropolis['BLOCK_GAS_LIMIT'] = 2**60
+
+        for a in range(10):
+            tester.base_alloc[getattr(tester, 'a%i' % a)] = {'balance': 10**24}
+
         self.chain = tester.Chain(env=Env(config=config_metropolis))
         self.contracts = {}
         self.controller = self.upload('../source/contracts/Controller.sol')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,14 +300,16 @@ class ContractsFixture:
         return self.createCategoricalMarket(universe, 2, endTime, feePerEthInWei, denominationToken, designatedReporterAddress, numTicks)
 
     def createCategoricalMarket(self, universe, numOutcomes, endTime, feePerEthInWei, denominationToken, designatedReporterAddress, numTicks):
-        marketCreationFee = self.contracts['MarketFeeCalculator'].getValidityBond(universe.getCurrentReportingWindow()) + self.contracts['MarketFeeCalculator'].getTargetReporterGasCosts()
+        reportingWindowAddress = universe.getCurrentReportingWindow()
+        marketCreationFee = self.contracts['MarketFeeCalculator'].getValidityBond(reportingWindowAddress) + self.contracts['MarketFeeCalculator'].getTargetReporterGasCosts(reportingWindowAddress)
         marketAddress = self.contracts['MarketCreation'].createMarket(universe.address, endTime, numOutcomes, feePerEthInWei, denominationToken.address, numTicks, designatedReporterAddress, value = marketCreationFee, startgas=long(6.7 * 10**6))
         assert marketAddress
         market = ABIContract(self.chain, ContractTranslator(ContractsFixture.signatures['Market']), marketAddress)
         return market
 
     def createScalarMarket(self, universe, endTime, feePerEthInWei, denominationToken, numTicks, designatedReporterAddress):
-        marketCreationFee = self.contracts['MarketFeeCalculator'].getValidityBond(universe.getCurrentReportingWindow()) + self.contracts['MarketFeeCalculator'].getTargetReporterGasCosts()
+        reportingWindowAddress = universe.getCurrentReportingWindow()
+        marketCreationFee = self.contracts['MarketFeeCalculator'].getValidityBond(reportingWindowAddress) + self.contracts['MarketFeeCalculator'].getTargetReporterGasCosts(reportingWindowAddress)
         marketAddress = self.contracts['MarketCreation'].createMarket(universe.address, endTime, 2, feePerEthInWei, denominationToken.address, numTicks, designatedReporterAddress, value = marketCreationFee)
         assert marketAddress
         market = ABIContract(self.chain, ContractTranslator(ContractsFixture.signatures['Market']), marketAddress)

--- a/tests/extensions/test_market_fee_calculator.py
+++ b/tests/extensions/test_market_fee_calculator.py
@@ -12,14 +12,13 @@ ONE = 10 ** 18
 
     # Maximum Decrease
     (0, 1, 2 * ONE, ONE),
-    (0, 99, 2 * ONE, ONE),
+    (0, 50, 2 * ONE, ONE),
     (0, 1, 10 * ONE, 5 * ONE),
 
     # Maximum Increase
-    (100, 1, ONE, 2 * ONE - 1), # Small rounding errors
-    (100, 0, ONE, 2 * ONE),
-    (100, 99, ONE, 2 * ONE),
-    (100, 1, 10 * ONE, 20 * ONE - 10), # Small rounding errors
+    (100, 1, ONE, 2 * ONE),
+    (100, 50, ONE, 2 * ONE),
+    (100, 1, 10 * ONE, 20 * ONE),
 
     # Decrease
     (1, 10, 10 * ONE, 5.5 * ONE),
@@ -37,8 +36,8 @@ ONE = 10 ** 18
 ])
 def test_validity_bond_calculation(numIndeterminate, targetIndeterminatePerHundred, previousBond, expectedValue, contractsFixture):
     feeCalculator = contractsFixture.contracts["MarketFeeCalculator"]
-    targetIndeterminate = targetIndeterminatePerHundred * 10 ** 18 / 100
-    newBond = feeCalculator.calculateValidityBond(numIndeterminate, 100, targetIndeterminate, previousBond)
+    targetIndeterminateDivisor = 100 / targetIndeterminatePerHundred
+    newBond = feeCalculator.calculateValidityBond(numIndeterminate, 100, targetIndeterminateDivisor, previousBond)
     assert newBond == expectedValue
 
 def test_default_target_reporter_gas_costs(contractsFixture):

--- a/tests/extensions/test_market_fee_calculator.py
+++ b/tests/extensions/test_market_fee_calculator.py
@@ -50,7 +50,7 @@ def test_default_target_reporter_gas_costs(contractsFixture):
     expectedTargetReporterGasCost *= contractsFixture.constants.DEFAULT_REPORTING_GAS_PRICE()
     expectedTargetReporterGasCost *= contractsFixture.constants.DEFAULT_REPORTS_PER_MARKET()
     expectedTargetReporterGasCost *= 2
-    assert targetReporterGasCosts == expectedTargetReporterGasCost 
+    assert targetReporterGasCosts == expectedTargetReporterGasCost
 
 @mark.parametrize('numReports, gasPrice', [
     (1, 1),

--- a/tests/extensions/test_market_fee_calculator.py
+++ b/tests/extensions/test_market_fee_calculator.py
@@ -1,4 +1,6 @@
-from pytest import mark
+from ethereum.tools import tester
+from pytest import fixture, mark
+from reporting_utils import proceedToLimitedReporting, initializeReportingFixture
 
 ONE = 10 ** 18
 
@@ -39,8 +41,86 @@ def test_validity_bond_calculation(numIndeterminate, targetIndeterminatePerHundr
     newBond = feeCalculator.calculateValidityBond(numIndeterminate, 100, targetIndeterminate, previousBond)
     assert newBond == expectedValue
 
-def test_getTargetReporterGasCosts(contractsFixture):
-    pass
+def test_default_target_reporter_gas_costs(contractsFixture):
+    # The target reporter gas cost is an attempt to charge the market creator for the estimated cost of reporting that may occur for their market. With no previous reporting window to base costs off of it assumes basic default values
+    feeCalculator = contractsFixture.contracts["MarketFeeCalculator"]
+    market = contractsFixture.binaryMarket
 
-def test_getReportingFeeInAttoethPerEth(contractsFixture):
-    pass
+    targetReporterGasCosts = feeCalculator.getTargetReporterGasCosts(market.getReportingWindow())
+    expectedTargetReporterGasCost = contractsFixture.constants.GAS_TO_REPORT()
+    expectedTargetReporterGasCost *= contractsFixture.constants.DEFAULT_REPORTING_GAS_PRICE()
+    expectedTargetReporterGasCost *= contractsFixture.constants.DEFAULT_REPORTS_PER_MARKET()
+    expectedTargetReporterGasCost *= 2
+    assert targetReporterGasCosts == expectedTargetReporterGasCost 
+
+@mark.parametrize('numReports, gasPrice', [
+    (1, 1),
+    (2, 1),
+    (3, 1),
+    (4, 1),
+    (2, 10),
+    (2, 20),
+    (2, 100),
+])
+def test_target_reporter_gas_costs(numReports, gasPrice, reportingFixture):
+    # The target reporter gas cost is an attempt to charge the market creator for the estimated cost of reporting that may occur for their market. It will use the previous reporting window's data to estimate costs if it is available
+    feeCalculator = reportingFixture.contracts["MarketFeeCalculator"]
+    market = reportingFixture.binaryMarket
+    universe = reportingFixture.universe
+    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
+
+    # We'll have a market go through basic reporting and then make its reporting window over.
+    proceedToLimitedReporting(reportingFixture, market, False, tester.k1, [0,10**18])
+
+    reportingTokenYes = reportingFixture.getReportingToken(market, [0,10**18])
+    for i in range(0,numReports):
+        assert reportingTokenYes.buy(1, sender=getattr(tester, 'k%i' % i), gasprice=gasPrice)
+
+    # Now we'll skip ahead in time and finalzie the market
+    reportingFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
+    assert market.tryFinalize()
+
+    actualAvgReportsPerMarket = reportingWindow.getAvgReportsPerMarket()
+    expectedAvgReportsPerMarket = (reportingFixture.constants.DEFAULT_REPORTS_PER_MARKET() + numReports) / 2
+    assert actualAvgReportsPerMarket == expectedAvgReportsPerMarket
+
+    actualAvgGasPrice = reportingWindow.getAvgReportingGasCost()
+    expectedAvgReportingGasCost = (reportingFixture.constants.DEFAULT_REPORTING_GAS_PRICE() + gasPrice * numReports) / (numReports + 1)
+    assert actualAvgGasPrice == expectedAvgReportingGasCost
+
+    # Confirm our estimated gas cost is caluclated as expected
+    expectedTargetReporterGasCost = reportingFixture.constants.GAS_TO_REPORT()
+    expectedTargetReporterGasCost *= expectedAvgReportingGasCost
+    expectedTargetReporterGasCost *= expectedAvgReportsPerMarket
+    expectedTargetReporterGasCost *= 2
+    targetReporterGasCosts = feeCalculator.getTargetReporterGasCosts(universe.getCurrentReportingWindow())
+    assert targetReporterGasCosts == expectedTargetReporterGasCost 
+
+def test_gas_to_report(reportingFixture):
+    # Confirm that the gas to report fee is consistent with out stored value. This test will fail if the gas cost changes.
+    market = reportingFixture.binaryMarket
+    universe = reportingFixture.universe
+    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reputationToken = reportingFixture.applySignature('ReputationToken', universe.getReputationToken())
+
+    # Proceed to the LIMITED REPORTING phase
+    proceedToLimitedReporting(reportingFixture, market, True, tester.k1, [0,10**18])
+
+    # We make a report and record gas cost
+    reportingTokenYes = reportingFixture.getReportingToken(market, [0,10**18])
+    startingGas = reportingFixture.chain.head_state.gas_used
+    reportingTokenYes.buy(1, sender=tester.k2)
+    gasUsed = reportingFixture.chain.head_state.gas_used - startingGas
+
+    # Confirm the estimated gas cost equals this value
+    assert gasUsed == reportingFixture.constants.GAS_TO_REPORT()
+
+@fixture(scope="session")
+def reportingSnapshot(sessionFixture):
+    sessionFixture.resetSnapshot()
+    return initializeReportingFixture(sessionFixture, sessionFixture.binaryMarket)
+
+@fixture
+def reportingFixture(sessionFixture, reportingSnapshot):
+    sessionFixture.chain.revert(reportingSnapshot)
+    return sessionFixture

--- a/tests/extensions/test_market_fee_calculator.py
+++ b/tests/extensions/test_market_fee_calculator.py
@@ -38,3 +38,9 @@ def test_validity_bond_calculation(numIndeterminate, targetIndeterminatePerHundr
     targetIndeterminate = targetIndeterminatePerHundred * 10 ** 18 / 100
     newBond = feeCalculator.calculateValidityBond(numIndeterminate, 100, targetIndeterminate, previousBond)
     assert newBond == expectedValue
+
+def test_getTargetReporterGasCosts(contractsFixture):
+    pass
+
+def test_getReportingFeeInAttoethPerEth(contractsFixture):
+    pass

--- a/tests/extensions/test_market_fee_calculator.py
+++ b/tests/extensions/test_market_fee_calculator.py
@@ -1,0 +1,40 @@
+from pytest import mark
+
+ONE = 10 ** 18
+
+@mark.parametrize('numIndeterminate, targetIndeterminatePerHundred, previousBond, expectedValue', [
+    # No change
+    (1, 1, ONE, ONE),
+    (5, 5, ONE, ONE),
+    (1, 1, 5 * ONE, 5 * ONE),
+
+    # Maximum Decrease
+    (0, 1, 2 * ONE, ONE),
+    (0, 99, 2 * ONE, ONE),
+    (0, 1, 10 * ONE, 5 * ONE),
+
+    # Maximum Increase
+    (100, 1, ONE, 2 * ONE - 1), # Small rounding errors
+    (100, 0, ONE, 2 * ONE),
+    (100, 99, ONE, 2 * ONE),
+    (100, 1, 10 * ONE, 20 * ONE - 10), # Small rounding errors
+
+    # Decrease
+    (1, 10, 10 * ONE, 5.5 * ONE),
+    (2, 10, 10 * ONE, 6 * ONE),
+    (4, 10, 10 * ONE, 7 * ONE),
+    (8, 10, 10 * ONE, 9 * ONE),
+    (9, 10, 10 * ONE, 9.5 * ONE),
+
+    # Increase
+    (51, 50, 10 * ONE, 10.2 * ONE),
+    (55, 50, 10 * ONE, 11 * ONE),
+    (60, 50, 10 * ONE, 12 * ONE),
+    (80, 50, 10 * ONE, 16 * ONE),
+    (90, 50, 10 * ONE, 18 * ONE),
+])
+def test_validity_bond_calculation(numIndeterminate, targetIndeterminatePerHundred, previousBond, expectedValue, contractsFixture):
+    feeCalculator = contractsFixture.contracts["MarketFeeCalculator"]
+    targetIndeterminate = targetIndeterminatePerHundred * 10 ** 18 / 100
+    newBond = feeCalculator.calculateValidityBond(numIndeterminate, 100, targetIndeterminate, previousBond)
+    assert newBond == expectedValue

--- a/tests/reporting_utils.py
+++ b/tests/reporting_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
 from pytest import fixture, mark, lazy_fixture, raises

--- a/tests/solidity_test_helpers/Constants.sol
+++ b/tests/solidity_test_helpers/Constants.sol
@@ -28,6 +28,10 @@ contract Constants {
 
     uint256 public constant REGISTRATION_TOKEN_BOND_AMOUNT = Reporting.getRegistrationTokenBondAmount();
 
+    uint256 public constant GAS_TO_REPORT = Reporting.gasToReport();
+    uint256 public constant DEFAULT_REPORTING_GAS_PRICE = Reporting.defaultReportingGasPrice();
+    uint256 public constant DEFAULT_REPORTS_PER_MARKET = Reporting.defaultReportsPerMarket();
+
     uint8 public constant BID = uint8(Order.TradeTypes.Bid);
     uint8 public constant ASK = uint8(Order.TradeTypes.Ask);
     uint8 public constant LONG = uint8(Order.TradeDirections.Long);

--- a/tests/trading/test_claimProceeds.py
+++ b/tests/trading/test_claimProceeds.py
@@ -68,7 +68,8 @@ def test_helpers(fundedRepFixture):
     assert claimProceeds.calculateReportingFee(market.address, fix('5')) == fix('0.0005')
     assert claimProceeds.calculateProceeds(market.getFinalWinningReportingToken(), YES, 7) == 7 * market.getNumTicks()
     assert claimProceeds.calculateProceeds(market.getFinalWinningReportingToken(), NO, fix('11')) == fix('0')
-    (shareholderShare, creatorShare, reporterShare) = claimProceeds.divideUpWinnings(market.address, market.getFinalWinningReportingToken(), YES, 13)
+    (proceeds, shareholderShare, creatorShare, reporterShare) = claimProceeds.divideUpWinnings(market.address, market.getFinalWinningReportingToken(), YES, 13)
+    assert proceeds == 13.0 * market.getNumTicks()
     assert reporterShare == 13.0 * market.getNumTicks() * 0.0001
     assert creatorShare == 13.0 * market.getNumTicks() * .01
     assert shareholderShare == 13.0 * market.getNumTicks() * 0.9899

--- a/tests/trading/test_claimProceeds.py
+++ b/tests/trading/test_claimProceeds.py
@@ -77,6 +77,7 @@ def test_helpers(fundedRepFixture):
 def test_redeem_shares_in_binary_market(fundedRepFixture):
     cash = fundedRepFixture.cash
     market = fundedRepFixture.binaryMarket
+    universe = fundedRepFixture.universe
     claimProceeds = fundedRepFixture.contracts['ClaimProceeds']
     yesShareToken = fundedRepFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = fundedRepFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -84,10 +85,14 @@ def test_redeem_shares_in_binary_market(fundedRepFixture):
     expectedFees = expectedValue * 0.0101
     expectedPayout = long(expectedValue - expectedFees)
 
+    assert universe.getOpenInterestInAttoEth() == 0
+
     # get YES shares with a1
     acquireLongShares(fundedRepFixture, market, YES, 1, claimProceeds.address, sender = tester.k1)
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
     # get NO shares with a2
     acquireShortShareSet(fundedRepFixture, market, YES, 1, claimProceeds.address, sender = tester.k2)
+    assert universe.getOpenInterestInAttoEth() == 2 * market.getNumTicks()
     finalizeMarket(fundedRepFixture.chain.head_state, market, [0,10**18])
 
     # redeem shares with a1
@@ -104,10 +109,12 @@ def test_redeem_shares_in_binary_market(fundedRepFixture):
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 0
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks() # The corresponding share for tester2's complete set has not been redeemed
 
 def test_redeem_shares_in_categorical_market(fundedRepFixture):
     cash = fundedRepFixture.cash
     market = fundedRepFixture.categoricalMarket
+    universe = fundedRepFixture.universe
     claimProceeds = fundedRepFixture.contracts['ClaimProceeds']
     shareToken2 = fundedRepFixture.applySignature('ShareToken', market.getShareToken(2))
     shareToken1 = fundedRepFixture.applySignature('ShareToken', market.getShareToken(1))
@@ -116,10 +123,14 @@ def test_redeem_shares_in_categorical_market(fundedRepFixture):
     expectedFees = expectedValue * 0.0101
     expectedPayout = long(expectedValue - expectedFees)
 
+    assert universe.getOpenInterestInAttoEth() == 0
+
     # get long shares with a1
     acquireLongShares(fundedRepFixture, market, 2, 1, claimProceeds.address, sender = tester.k1)
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
     # get short shares with a2
     acquireShortShareSet(fundedRepFixture, market, 2, 1, claimProceeds.address, sender = tester.k2)
+    assert universe.getOpenInterestInAttoEth() == 2 * market.getNumTicks()
     finalizeMarket(fundedRepFixture.chain.head_state, market, [0, 0, 3 * 10 ** 17])
 
     # redeem shares with a1
@@ -138,10 +149,12 @@ def test_redeem_shares_in_categorical_market(fundedRepFixture):
     assert shareToken1.balanceOf(tester.a2) == 0
     assert shareToken0.balanceOf(tester.a1) == 0
     assert shareToken0.balanceOf(tester.a2) == 0
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
 def test_redeem_shares_in_scalar_market(fundedRepFixture):
     cash = fundedRepFixture.cash
     market = fundedRepFixture.scalarMarket
+    universe = fundedRepFixture.universe
     claimProceeds = fundedRepFixture.contracts['ClaimProceeds']
     yesShareToken = fundedRepFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = fundedRepFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -149,10 +162,14 @@ def test_redeem_shares_in_scalar_market(fundedRepFixture):
     expectedFees = expectedValue * 0.0101
     expectedPayout = long(expectedValue - expectedFees)
 
+    assert universe.getOpenInterestInAttoEth() == 0
+
     # get YES shares with a1
     acquireLongShares(fundedRepFixture, market, YES, 1, claimProceeds.address, sender = tester.k1)
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
     # get NO shares with a2
     acquireShortShareSet(fundedRepFixture, market, YES, 1, claimProceeds.address, sender = tester.k2)
+    assert universe.getOpenInterestInAttoEth() == 2 * market.getNumTicks()
     finalizeMarket(fundedRepFixture.chain.head_state, market, [10**19, 3*10**19])
 
     # redeem shares with a1
@@ -169,6 +186,7 @@ def test_redeem_shares_in_scalar_market(fundedRepFixture):
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 0
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
 def test_reedem_failure(fundedRepFixture):
     cash = fundedRepFixture.cash

--- a/tests/trading/test_completeSets.py
+++ b/tests/trading/test_completeSets.py
@@ -20,6 +20,7 @@ def test_publicBuyCompleteSets(fundedRepFixture):
     assert not cash.balanceOf(market.address)
     assert not yesShareToken.totalSupply()
     assert not noShareToken.totalSupply()
+    assert universe.getOpenInterestInAttoEth() == 0
 
     cost = 10 * market.getNumTicks()
     captureFilteredLogs(fundedRepFixture.chain.head_state, orders, logs)
@@ -40,6 +41,7 @@ def test_publicBuyCompleteSets(fundedRepFixture):
     assert cash.balanceOf(market.address) == cost, "Increase in market's cash should equal the cost to purchase the complete set"
     assert yesShareToken.totalSupply() == 10, "Increase in yes shares purchased for this market should be 10"
     assert noShareToken.totalSupply() == 10, "Increase in yes shares purchased for this market should be 10"
+    assert universe.getOpenInterestInAttoEth() == cost, "Open interest in the universe increases by the cost in ETH of the sets purchased"
 
 def test_publicBuyCompleteSets_failure(fundedRepFixture):
     universe = fundedRepFixture.universe
@@ -77,11 +79,14 @@ def test_publicSellCompleteSets(fundedRepFixture):
     assert not noShareToken.totalSupply()
 
     cost = 10 * market.getNumTicks()
+    assert universe.getOpenInterestInAttoEth() == 0
     completeSets.publicBuyCompleteSets(market.address, 10, sender = tester.k1, value = cost)
+    assert universe.getOpenInterestInAttoEth() == 10 * market.getNumTicks()
     captureFilteredLogs(fundedRepFixture.chain.head_state, orders, logs)
     initialTester1ETH = fundedRepFixture.utils.getETHBalance(tester.a1)
     initialTester0ETH = fundedRepFixture.utils.getETHBalance(tester.a0)
     result = completeSets.publicSellCompleteSets(market.address, 9, sender=tester.k1)
+    assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
     assert logs == [
         {


### PR DESCRIPTION
Addresses all but one of the TODOs in the `MarketFeeCalculator`. Namely the one about getting the market value of REP in ETH:

> get this from an auto-generated market or some other special contract

I figure that one will require its own story and a significant amount of work to implement depending on how exactly we choose to do it.

One decision I made here which may be bad is that the default gas price to report and the default average reports per market are factored into the real value calculations. This was done to avoid branching code since the methods will be called relatively frequently and these are just estimates anyway. It'd be easy to make these instead just branch on `numReports < 0` and return "true" values.