### PR TITLE
Handle fee migration during a fork

### DIFF
--- a/source/contracts/reporting/IReportingWindow.sol
+++ b/source/contracts/reporting/IReportingWindow.sol
@@ -29,10 +29,11 @@ contract IReportingWindow is Typed {
     function getNextReportingWindow() constant public returns (IReportingWindow);
     function getPreviousReportingWindow() constant public returns (IReportingWindow);
     function checkIn() public returns (bool);
+    function triggerMigrateFeesDueToFork(IReportingWindow _reportingWindow) public returns (bool);
+    function migrateFeesDueToFork() public returns (bool);
     function isContainerForRegistrationToken(IRegistrationToken _shadyRegistrationToken) public constant returns (bool);
     function isContainerForMarket(IMarket _shadyMarket) public constant returns (bool);
     function isDoneReporting(address _reporter) public constant returns (bool);
     function isForkingMarketFinalized() public constant returns (bool);
     function isDisputeActive() public constant returns (bool);
-    function receiveValidityBond() public payable returns (bool);
 }

--- a/source/contracts/reporting/IUniverse.sol
+++ b/source/contracts/reporting/IUniverse.sol
@@ -20,6 +20,7 @@ contract IUniverse is Typed {
     function getReportingPeriodDurationInSeconds() public constant returns (uint256);
     function getReportingWindowByTimestamp(uint256 _timestamp) public returns (IReportingWindow);
     function getReportingWindowByMarketEndTime(uint256 _endTime, bool _hasDesignatedReporter) public returns (IReportingWindow);
+    function getCurrentReportingWindow() public returns (IReportingWindow);
     function getNextReportingWindow() public returns (IReportingWindow);
     function getReportingWindowForForkEndTime() public constant returns (IReportingWindow);
     function getOpenInterestInAttoEth() public constant returns (uint256);

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -317,7 +317,7 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
         if (_toOwner) {
             getOwner().call.value(_amount)();
         } else {
-            getReportingWindow().receiveValidityBond.value(_amount)();
+            cash.depositEtherFor.value(_amount)(getReportingWindow());
         }
         return true;
     }

--- a/source/contracts/reporting/ReportingToken.sol
+++ b/source/contracts/reporting/ReportingToken.sol
@@ -75,8 +75,6 @@ contract ReportingToken is DelegationTarget, Typed, Initializable, VariableSuppl
     }
 
     // NOTE: UI should warn users about calling this before first calling `migrateLosingTokens` on all losing tokens with non-dust contents
-    // TODO: prevent calling this until all markets on the reporting window are finalized.
-    // TODO: add reporting fee distribution to this.
     function redeemWinningTokens() public afterInitialized returns (bool) {
         require(market.getReportingState() == IMarket.ReportingState.FINALIZED);
         require(market.isContainerForReportingToken(this));

--- a/source/contracts/reporting/ReportingToken.sol
+++ b/source/contracts/reporting/ReportingToken.sol
@@ -75,6 +75,8 @@ contract ReportingToken is DelegationTarget, Typed, Initializable, VariableSuppl
     }
 
     // NOTE: UI should warn users about calling this before first calling `migrateLosingTokens` on all losing tokens with non-dust contents
+    // TODO: prevent calling this until all markets on the reporting window are finalized.
+    // TODO: add reporting fee distribution to this.
     function redeemWinningTokens() public afterInitialized returns (bool) {
         require(market.getReportingState() == IMarket.ReportingState.FINALIZED);
         require(market.isContainerForReportingToken(this));

--- a/source/contracts/reporting/ReportingWindow.sol
+++ b/source/contracts/reporting/ReportingWindow.sol
@@ -244,8 +244,6 @@ contract ReportingWindow is DelegationTarget, Typed, Initializable, IReportingWi
         return true;
     }
 
-    // TODO: add reporting fee distribution function. Prevent calling it until all markets on the reporting window are finalized.
-
     function isActive() public afterInitialized constant returns (bool) {
         if (block.timestamp <= getStartTime()) {
             return false;

--- a/source/contracts/reporting/ReportingWindow.sol
+++ b/source/contracts/reporting/ReportingWindow.sol
@@ -239,7 +239,7 @@ contract ReportingWindow is DelegationTarget, Typed, Initializable, IReportingWi
         IUniverse _destinationUniverse = _shadyUniverse;
         IReportingWindow _destinationReportingWindow = _shadyReportingWindow;
         bytes32 _winningForkPayoutDistributionHash = universe.getForkingMarket().getFinalPayoutDistributionHash();
-        require(_destinationUniverse == universe.getOrCreateChildUniverse(_winningForkPayoutDistributionHash));
+        require(_destinationUniverse == universe.getChildUniverse(_winningForkPayoutDistributionHash));
         _cash.transfer(_destinationReportingWindow, _balance);
         return true;
     }

--- a/source/contracts/trading/Cash.sol
+++ b/source/contracts/trading/Cash.sol
@@ -30,14 +30,14 @@ contract Cash is Controlled, Typed, VariableSupplyToken, ICash {
     function withdrawEther(uint256 _amount) external returns(bool) {
         require(_amount > 0 && _amount <= balances[msg.sender]);
         burn(msg.sender, _amount);
-        msg.sender.transfer(_amount);
+        msg.sender.call.value(_amount)();
         return true;
     }
 
     function withdrawEtherTo(address _to, uint256 _amount) external returns(bool) {
         require(_amount > 0 && _amount <= balances[msg.sender]);
         burn(msg.sender, _amount);
-        _to.transfer(_amount);
+        _to.call.value(_amount)();
         return true;
     }
 


### PR DESCRIPTION
I also changed some code in `Cash` to be consistent with using `.call.value` instead of `transfer` and removed an inaccurate comment.