### PR TITLE
Campsite.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,7 @@
             "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
             "cwd": "${workspaceRoot}",
             "args": [
-                "-r", "ts-node/register",
-                "source/tests-integration/**/*.ts",
+                "output/tests-integration/**/*.js",
                 "--no-timeouts"
             ],
             "protocol": "inspector",

--- a/source/contracts/Controlled.sol
+++ b/source/contracts/Controlled.sol
@@ -32,6 +32,10 @@ contract Controlled is IControlled {
         controller = IController(msg.sender);
     }
 
+    function getController() public constant returns(IController) {
+        return controller;
+    }
+
     function setController(IController _controller) public onlyControllerCaller returns(bool) {
         controller = _controller;
         return true;


### PR DESCRIPTION
The VSCode launch JSON changes are because VSCode was struggling to correctly set debug breakpoints again, and removing ts-node from the middle resolves it.