### PR TITLE
Test infrastructure improvements.

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -15,6 +15,7 @@ RUN npm install npx
 RUN npm install
 COPY requirements.txt /app/requirements.txt
 RUN pip install --upgrade pip setuptools \
+	&& pip install --upgrade pip-tools \
 	&& pip install -r requirements.txt
 
 COPY .soliumignore /app/.soliumignore

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,5 @@
-ethereum-augur-temp==2.1.4
+ethereum-augur-temp==2.1.10
 pycryptodome==3.4.6
 numpy==1.13.0
 pytest==3.1.2
-pytest-lazy-fixture==0.3.0
 py-solc==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@
 asn1crypto==0.23.0        # via coincurve
 cffi==1.11.1              # via coincurve
 coincurve==6.0.0          # via ethereum-augur-temp
-ethereum-augur-temp==2.1.4
+ethereum-augur-temp==2.1.10
 numpy==1.13.0
+pbkdf2==1.3               # via ethereum-augur-temp
 py-ecc==1.1.1             # via ethereum-augur-temp
 py-solc==1.4.0
 py==1.4.34                # via pytest
@@ -16,7 +17,6 @@ pycparser==2.18           # via cffi
 pycryptodome==3.4.6
 pyethash==0.1.27          # via ethereum-augur-temp
 pysha3==1.0.2             # via ethereum-augur-temp
-pytest-lazy-fixture==0.3.0
 pytest==3.1.2
 pyyaml==3.12              # via ethereum-augur-temp
 repoze.lru==0.6           # via ethereum-augur-temp

--- a/source/contracts/IControlled.sol
+++ b/source/contracts/IControlled.sol
@@ -6,6 +6,7 @@ import 'libraries/token/ERC20Basic.sol';
 
 
 contract IControlled {
+    function getController() public constant returns (IController);
     function setController(IController _controller) public returns(bool);
     function suicideFunds(address _target, ERC20Basic[] _tokens) public returns(bool);
 }

--- a/source/contracts/libraries/CashAutoConverter.sol
+++ b/source/contracts/libraries/CashAutoConverter.sol
@@ -16,7 +16,7 @@ contract CashAutoConverter is Controlled {
     modifier convertToAndFromCash() {
         ethToCash();
         _;
-        cashToETH();
+        cashToEth();
     }
 
     function ethToCash() private returns (bool) {
@@ -26,11 +26,12 @@ contract CashAutoConverter is Controlled {
         return true;
     }
 
-    function cashToETH() private returns (bool) {
+    function cashToEth() private returns (bool) {
         ICash _cash = ICash(controller.lookup("Cash"));
         uint256 _tokenBalance = _cash.balanceOf(msg.sender);
         if (_tokenBalance > 0) {
-            Augur(controller.lookup("Augur")).trustedTransfer(_cash, msg.sender, this, _tokenBalance);
+            Augur augur = Augur(controller.lookup("Augur"));
+            augur.trustedTransfer(_cash, msg.sender, this, _tokenBalance);
             _cash.withdrawEtherTo(msg.sender, _tokenBalance);
         }
         return true;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,18 @@
 from binascii import hexlify
 from datetime import timedelta
+from ethereum.state import State
 from ethereum.tools import tester
+from ethereum.tools.tester import Chain
 from ethereum.abi import ContractTranslator
 from ethereum.tools.tester import ABIContract
 from ethereum.config import config_metropolis, Env
 from io import open as io_open
 from json import dump as json_dump, load as json_load
 from os import path, walk, makedirs, listdir
-from pytest import fixture
+import pytest
 from re import findall
 from solc import compile_standard
-from utils import bytesToHexString, bytesToLong, longToHexString
+from utils import bytesToHexString, bytesToLong, longToHexString, stringToBytes
 from copy import deepcopy
 
 # used to resolve relative paths
@@ -167,35 +169,14 @@ class ContractsFixture:
         for a in range(10):
             tester.base_alloc[getattr(tester, 'a%i' % a)] = {'balance': 10**24}
 
-        self.chain = tester.Chain(env=Env(config=config_metropolis))
+        self.chain = Chain(env=Env(config=config_metropolis))
         self.contracts = {}
-        self.controller = self.upload('../source/contracts/Controller.sol')
-        assert self.controller.owner() == bytesToHexString(tester.a0)
-        self.uploadAllContracts()
-        self.whitelistTradingContracts()
-        self.initializeAllContracts()
-        self.approveCentralAuthority()
-        self.universe = self.createUniverse(0, "")
-        self.cash = self.getSeededCash()
-        self.augur = self.contracts['Augur']
-        self.utils = self.upload("solidity_test_helpers/Utils.sol")
-        self.distributeRep()
-        self.binaryMarket = self.createReasonableBinaryMarket(self.universe, self.cash)
-        startingGas = self.chain.head_state.gas_used
-        self.categoricalMarket = self.createReasonableCategoricalMarket(self.universe, 3, self.cash)
-        print 'Gas Used: %s' % (self.chain.head_state.gas_used - startingGas)
-        self.scalarMarket = self.createReasonableScalarMarket(self.universe, 40, self.cash)
-        self.constants = self.uploadAndAddToController("solidity_test_helpers/Constants.sol")
-        self.chain.mine(1)
-        self.originalContracts = deepcopy(self.contracts)
-        self.captured = self.createSnapshot()
         self.testerAddress = self.generateTesterMap('a')
         self.testerKey = self.generateTesterMap('k')
 
-    def distributeRep(self):
+    def distributeRep(self, universe):
         legacyRepContract = self.contracts['LegacyRepContract']
         legacyRepContract.faucet(11 * 10**6 * 10**18)
-        universe = self.universe
 
         # Get the reputation token for this universe and migrate legacy REP to it
         reputationToken = self.applySignature('ReputationToken', universe.getReputationToken())
@@ -212,7 +193,7 @@ class ContractsFixture:
         lookupKey = lookupKey if lookupKey else path.splitext(path.basename(relativeFilePath))[0]
         contract = self.upload(relativeFilePath, lookupKey, signatureKey, constructorArgs)
         if not contract: return None
-        self.controller.setValue(lookupKey.ljust(32, '\x00'), contract.address)
+        self.contracts['Controller'].setValue(lookupKey.ljust(32, '\x00'), contract.address)
         return(contract)
 
     def upload(self, relativeFilePath, lookupKey = None, signatureKey = None, constructorArgs=[]):
@@ -245,19 +226,22 @@ class ContractsFixture:
         contract = ABIContract(self.chain, translator, address)
         return contract
 
-    def resetSnapshot(self):
-        self.resetToSnapshot(self.captured)
-
     def createSnapshot(self):
-        return  { 'block': self.chain.block, 'head_state': self.chain.head_state, 'snapshot': self.chain.snapshot(), 'contracts': deepcopy(self.contracts) }
+        self.chain.tx(sender=tester.k0, to=tester.a1, value=0)
+        self.chain.mine(1)
+        contractsCopy = {}
+        for contractName in self.contracts:
+            contractsCopy[contractName] = dict(translator = self.contracts[contractName].translator, address = self.contracts[contractName].address)
+        return  { 'state': self.chain.head_state.to_snapshot(), 'contracts': contractsCopy }
 
-    def resetToSnapshot(self, captured):
-        if len(captured) < 4:
-            raise "captured snapshot doesn't have all parameters in dictionary, need to call createSnapshot"
-        self.chain.block = captured['block']
-        self.chain.head_state = captured['head_state']
-        self.chain.revert(captured['snapshot'])
-        self.contracts = deepcopy(captured['contracts'])
+    def resetToSnapshot(self, snapshot):
+        if not 'state' in snapshot: raise "snapshot is missing 'state'"
+        if not 'contracts' in snapshot: raise "snapshot is missing 'contracts'"
+        self.chain = Chain(genesis=snapshot['state'], env=Env(config=config_metropolis))
+        self.contracts = {}
+        for contractName in snapshot['contracts']:
+            contract = snapshot['contracts'][contractName]
+            self.contracts[contractName] = ABIContract(self.chain, contract['translator'], contract['address'])
 
     ####
     #### Bulk Operations
@@ -276,7 +260,7 @@ class ContractsFixture:
                 if name in contractsToDelegate:
                     delegationTargetName = "".join([name, "Target"])
                     self.uploadAndAddToController(path.join(directory, filename), delegationTargetName, name)
-                    self.uploadAndAddToController("../source/contracts/libraries/Delegator.sol", name, "delegator", constructorArgs=[self.controller.address, delegationTargetName.ljust(32, '\x00')])
+                    self.uploadAndAddToController("../source/contracts/libraries/Delegator.sol", name, "delegator", constructorArgs=[self.contracts['Controller'].address, delegationTargetName.ljust(32, '\x00')])
                     self.contracts[name] = self.applySignature(name, self.contracts[name].address)
                 else:
                     self.uploadAndAddToController(path.join(directory, filename))
@@ -287,15 +271,15 @@ class ContractsFixture:
             extension = path.splitext(filename)[1]
             if extension != '.sol': continue
             if not name in self.contracts: continue
-            self.controller.addToWhitelist(self.contracts[name].address)
-    
+            self.contracts['Controller'].addToWhitelist(self.contracts[name].address)
+
     def initializeAllContracts(self):
         contractsToInitialize = ['Augur','Cash','CompleteSets','CreateOrder','FillOrder','CancelOrder','Trade','ClaimProceeds','OrdersFetcher']
         for contractName in contractsToInitialize:
             if getattr(self.contracts[contractName], "setController", None):
-                self.contracts[contractName].setController(self.controller.address)
+                self.contracts[contractName].setController(self.contracts['Controller'].address)
             elif getattr(self.contracts[contractName], "initialize", None):
-                self.contracts[contractName].initialize(self.controller.address)
+                self.contracts[contractName].initialize(self.contracts['Controller'].address)
             else:
                 raise "contract has neither 'initialize' nor 'setController' method on it."
 
@@ -317,15 +301,16 @@ class ContractsFixture:
                 self.contracts[contractName].approve(authority.address, 2**254, sender=testerKey)
 
     def uploadShareToken(self, controllerAddress = None):
-        controllerAddress = controllerAddress if controllerAddress else self.controller.address
+        controllerAddress = controllerAddress if controllerAddress else self.contracts['Controller'].address
         self.ensureShareTokenDependencies()
         shareTokenFactory = self.contracts['ShareTokenFactory']
         shareToken = shareTokenFactory.createShareToken(controllerAddress)
         return self.applySignature('shareToken', shareToken)
 
     def createUniverse(self, parentUniverse, payoutDistributionHash):
-        universeAddress = self.contracts['UniverseFactory'].createUniverse(self.controller.address, parentUniverse, payoutDistributionHash)
+        universeAddress = self.contracts['UniverseFactory'].createUniverse(self.contracts['Controller'].address, parentUniverse, payoutDistributionHash)
         universe = self.applySignature('Universe', universeAddress)
+        assert universe.getTypeName() == stringToBytes('Universe')
         return universe
 
     def getReportingToken(self, market, payoutDistribution, invalid=False):
@@ -401,11 +386,94 @@ class ContractsFixture:
             numTicks = 40 * 10 ** 18,
             designatedReporterAddress = tester.a0)
 
-@fixture(scope="session")
-def sessionFixture():
+@pytest.fixture(scope="session")
+def fixture():
     return ContractsFixture()
 
-@fixture
-def contractsFixture(sessionFixture):
-    sessionFixture.resetSnapshot()
-    return sessionFixture
+@pytest.fixture(scope="session")
+def baseSnapshot(fixture):
+    return fixture.createSnapshot()
+
+@pytest.fixture(scope="session")
+def controllerSnapshot(fixture, baseSnapshot):
+    fixture.resetToSnapshot(baseSnapshot)
+    controller = fixture.upload('../source/contracts/Controller.sol')
+    assert fixture.contracts['Controller'].owner() == bytesToHexString(tester.a0)
+    return fixture.createSnapshot()
+
+@pytest.fixture(scope="session")
+def augurInitializedSnapshot(fixture, controllerSnapshot):
+    fixture.resetToSnapshot(controllerSnapshot)
+    fixture.uploadAllContracts()
+    fixture.whitelistTradingContracts()
+    fixture.initializeAllContracts()
+    fixture.approveCentralAuthority()
+    return fixture.createSnapshot()
+
+@pytest.fixture(scope="session")
+def kitchenSinkSnapshot(fixture, augurInitializedSnapshot):
+    fixture.resetToSnapshot(augurInitializedSnapshot)
+    # TODO: remove assignments to the fixture as they don't get rolled back, so can bleed across tests.  We should be accessing things via `fixture.contracts[...]`
+    universe = fixture.createUniverse(0, "")
+    cash = fixture.getSeededCash()
+    augur = fixture.contracts['Augur']
+    fixture.upload("solidity_test_helpers/Utils.sol")
+    fixture.distributeRep(universe)
+    binaryMarket = fixture.createReasonableBinaryMarket(universe, cash)
+    startingGas = fixture.chain.head_state.gas_used
+    categoricalMarket = fixture.createReasonableCategoricalMarket(universe, 3, cash)
+    print 'Gas Used: %s' % (fixture.chain.head_state.gas_used - startingGas)
+    scalarMarket = fixture.createReasonableScalarMarket(universe, 40, cash)
+    fixture.uploadAndAddToController("solidity_test_helpers/Constants.sol")
+    snapshot = fixture.createSnapshot()
+    snapshot['universe'] = universe
+    snapshot['cash'] = cash
+    snapshot['augur'] = augur
+    snapshot['binaryMarket'] = binaryMarket
+    snapshot['categoricalMarket'] = categoricalMarket
+    snapshot['scalarMarket'] = scalarMarket
+    return snapshot
+
+@pytest.fixture
+def kitchenSinkFixture(fixture, kitchenSinkSnapshot):
+    fixture.resetToSnapshot(kitchenSinkSnapshot)
+    return fixture
+
+@pytest.fixture
+def universe(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['universe'].translator, kitchenSinkSnapshot['universe'].address)
+
+@pytest.fixture
+def cash(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['cash'].translator, kitchenSinkSnapshot['cash'].address)
+
+@pytest.fixture
+def augur(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['augur'].translator, kitchenSinkSnapshot['augur'].address)
+
+@pytest.fixture
+def market(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['binaryMarket'].translator, kitchenSinkSnapshot['binaryMarket'].address)
+
+@pytest.fixture
+def binaryMarket(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['binaryMarket'].translator, kitchenSinkSnapshot['binaryMarket'].address)
+
+@pytest.fixture
+def categoricalMarket(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['categoricalMarket'].translator, kitchenSinkSnapshot['categoricalMarket'].address)
+
+@pytest.fixture
+def scalarMarket(kitchenSinkFixture, kitchenSinkSnapshot):
+    return ABIContract(kitchenSinkFixture.chain, kitchenSinkSnapshot['scalarMarket'].translator, kitchenSinkSnapshot['scalarMarket'].address)
+
+# TODO: globally replace this with `fixture` and `kitchenSinkSnapshot` as appropriate then delete this
+@pytest.fixture(scope="session")
+def sessionFixture(fixture, kitchenSinkSnapshot):
+    fixture.resetToSnapshot(kitchenSinkSnapshot)
+    return fixture
+
+@pytest.fixture
+def contractsFixture(fixture, kitchenSinkSnapshot):
+    fixture.resetToSnapshot(kitchenSinkSnapshot)
+    return fixture

--- a/tests/libraries/test_arrays.py
+++ b/tests/libraries/test_arrays.py
@@ -5,20 +5,18 @@ from ethereum.tools.tester import TransactionFailed
 from pytest import fixture
 from ethereum.config import config_metropolis
 
-#config_metropolis['BLOCK_GAS_LIMIT'] = 2**128
-
 @fixture(scope="session")
-def arraySnapshot(sessionFixture):
-    arrayHelper = sessionFixture.upload('solidity_test_helpers/ArrayHelper.sol')
-    return sessionFixture.createSnapshot()
+def localSnapshot(fixture, baseSnapshot):
+    fixture.resetToSnapshot(baseSnapshot)
+    fixture.upload('solidity_test_helpers/ArrayHelper.sol')
+    return fixture.createSnapshot()
 
 @fixture
-def arrayContractsFixture(sessionFixture, arraySnapshot):
-    sessionFixture.resetToSnapshot(arraySnapshot)
-    return sessionFixture
+def arrayContractsFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
 
 def test_arraySlicingOnEmpty(arrayContractsFixture):
-
     arrayHelper = arrayContractsFixture.contracts['ArrayHelper']
 
     assert arrayHelper.getSlice(0, 1) == []
@@ -27,7 +25,6 @@ def test_arraySlicingOnEmpty(arrayContractsFixture):
     assert arrayHelper.getSlice(1, 0) == []
 
 def test_arraySlicing(arrayContractsFixture):
-
     arrayHelper = arrayContractsFixture.contracts['ArrayHelper']
 
     # Set some initial data

--- a/tests/libraries/test_cash_auto_wrapper.py
+++ b/tests/libraries/test_cash_auto_wrapper.py
@@ -2,38 +2,60 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture as pytest_fixture, raises
 
-def test_convertToAndFromCash(testerContractsFixture):
-    cash = testerContractsFixture.cash
-    cashWrapperHelper = testerContractsFixture.contracts['CashWrapperHelper']
-
-    originalETHBalance = testerContractsFixture.utils.getETHBalance(tester.a1)
+def test_convertToAndFromCash(cash, cashWrapperHelper, controller, augur, chain):
+    originalETHBalance = chain.head_state.get_balance(tester.a1)
 
     # We'll manually provide the tester with Cash since no normal code path will allow them to keep a non-zero balance
     assert cash.depositEther(sender=tester.k1, value=40)
     assert cash.balanceOf(tester.a1) == 40
+    assert cash.approve(augur.address, 2**256-1, sender=tester.k1)
 
     # Initially we can't call the function since this helper contract isn't whitelisted
     with raises(TransactionFailed):
-        cashWrapperHelper.toETHFunction(sender=tester.k1)
+        cashWrapperHelper.toEthFunction(sender=tester.k1)
 
     # Whitelist the contract
-    testerContractsFixture.controller.addToWhitelist(cashWrapperHelper.address)
+    controller.addToWhitelist(cashWrapperHelper.address)
 
     # Now call the function which converts existing Cash balance to ETH and withdraws it at the end of the call
-    cashWrapperHelper.toETHFunction(sender=tester.k1)
+    cashWrapperHelper.toEthFunction(sender=tester.k1)
     assert cash.balanceOf(tester.a1) == 0
-    assert testerContractsFixture.utils.getETHBalance(tester.a1) == originalETHBalance
+    assert chain.head_state.get_balance(tester.a1) == originalETHBalance
 
-@fixture(scope='session')
-def testerSnapshot(sessionFixture):
-    sessionFixture.uploadAndAddToController('solidity_test_helpers/CashWrapperHelper.sol')
-    cashWrapperHelper = sessionFixture.contracts['CashWrapperHelper']
-    cashWrapperHelper.setController(sessionFixture.controller.address)
-    return sessionFixture.createSnapshot()
+@pytest_fixture(scope='session')
+def localSnapshot(fixture, controllerSnapshot):
+    fixture.resetToSnapshot(controllerSnapshot)
+    fixture.uploadAndAddToController('../source/contracts/Augur.sol')
+    fixture.contracts['Augur'].setController(fixture.contracts['Controller'].address)
+    fixture.uploadAndAddToController('../source/contracts/trading/Cash.sol')
+    fixture.contracts['Cash'].setController(fixture.contracts['Controller'].address)
+    fixture.uploadAndAddToController('solidity_test_helpers/CashWrapperHelper.sol')
+    fixture.contracts['CashWrapperHelper'].setController(fixture.contracts['Controller'].address)
+    return fixture.createSnapshot()
 
-@fixture
-def testerContractsFixture(sessionFixture, testerSnapshot):
-    sessionFixture.resetToSnapshot(testerSnapshot)
-    return sessionFixture
+@pytest_fixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@pytest_fixture
+def cash(localFixture):
+    return localFixture.contracts['Cash']
+
+@pytest_fixture
+def cashWrapperHelper(localFixture):
+    return localFixture.contracts['CashWrapperHelper']
+
+@pytest_fixture
+def controller(localFixture):
+    return localFixture.contracts['Controller']
+
+@pytest_fixture
+def augur(localFixture):
+    return localFixture.contracts['Augur']
+
+@pytest_fixture
+def chain(localFixture):
+    return localFixture.chain

--- a/tests/libraries/test_reentrancy_guard.py
+++ b/tests/libraries/test_reentrancy_guard.py
@@ -2,7 +2,7 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture, mark, raises
 
 @fixture(scope='session')
 def testerSnapshot(sessionFixture):
@@ -15,7 +15,7 @@ def testerContractsFixture(sessionFixture, testerSnapshot):
     sessionFixture.resetToSnapshot(testerSnapshot)
     return sessionFixture
 
-def test_nonReentrant(testerContractsFixture): 
+def test_nonReentrant(testerContractsFixture):
     ReentrancyGuardHelper = testerContractsFixture.contracts['ReentrancyGuardHelper']
     assert ReentrancyGuardHelper.testerCanReentrant()
 

--- a/tests/libraries/token/test_standard_token.py
+++ b/tests/libraries/token/test_standard_token.py
@@ -2,7 +2,7 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture, mark, raises
 
 @fixture(scope='session')
 def testerSnapshot(sessionFixture):
@@ -46,7 +46,7 @@ def test_eternal_approval_magic(testStandardTokenFixture):
     assert standardToken.allowance(tester.a0, tester.a1) == 2 ** 256 - 1
     assert standardToken.balanceOf(tester.a0) == 4
     assert standardToken.balanceOf(tester.a1) == 96
-    
+
 def test_create_negative_balance(testStandardTokenFixture):
     standardToken = testStandardTokenFixture.contracts['StandardTokenHelper']
     assert standardToken.totalSupply() == 0
@@ -68,7 +68,7 @@ def test_transfer_then_create_negative_balance(testStandardTokenFixture):
     assert standardToken.balanceOf(tester.a1) == 10
     # approve and allow transfer of more tokens than tester has
     assert standardToken.approve(tester.a1, 11)
-    # try to transfer more than tester has  
+    # try to transfer more than tester has
     with raises(TransactionFailed):
         standardToken.transfer(tester.a1, 11, sender=tester.k1)
 
@@ -133,4 +133,4 @@ def test_transfrom_more_than_total_supply(testStandardTokenFixture):
     assert standardToken.totalSupply() == 20
     with raises(TransactionFailed):
         standardToken.transfer(tester.a1, 21)
-    
+

--- a/tests/reporting/test_dispute_bond_token.py
+++ b/tests/reporting/test_dispute_bond_token.py
@@ -113,18 +113,17 @@ SCALAR_OUTCOME_C = [20*10**18, 20*10**18]
     (MARKET_TYPE_SCALAR, 0, SCALAR_OUTCOME_A, 1, [[2, SCALAR_OUTCOME_B, 105 * REP_DIVISOR]], 0, SCALAR_OUTCOME_A, [[3, SCALAR_OUTCOME_B, 11050 * REP_DIVISOR]], 4, [[0, SCALAR_OUTCOME_A], [1, SCALAR_OUTCOME_B], [2, SCALAR_OUTCOME_B], [3, SCALAR_OUTCOME_B], [4, SCALAR_OUTCOME_A], [5, SCALAR_OUTCOME_B], [6, SCALAR_OUTCOME_B]], [[0, None, 0], [1, None, 0], [2, None, 0], [3, None, 0], [4, None, 0], [5, None, 0], [6, None, 0], [0, SCALAR_OUTCOME_A, 998901999999999999999999], [1, SCALAR_OUTCOME_A, 0], [2, SCALAR_OUTCOME_A, 0], [3, SCALAR_OUTCOME_A, 0], [4, SCALAR_OUTCOME_A, 1000000000000000000000000], [5, SCALAR_OUTCOME_A, 0], [6, SCALAR_OUTCOME_A, 0], [0, SCALAR_OUTCOME_B, 0], [1, SCALAR_OUTCOME_B, 999999999999999999999999], [2, SCALAR_OUTCOME_B, 1000000000000000000000000], [3, SCALAR_OUTCOME_B, 1000000000000000000000000], [4, SCALAR_OUTCOME_B, 0], [5, SCALAR_OUTCOME_B, 1000000000000000000000000], [6, SCALAR_OUTCOME_B, 1000000000000000000000000], [0, SCALAR_OUTCOME_C, 0], [1, SCALAR_OUTCOME_C, 0], [2, SCALAR_OUTCOME_C, 0], [3, SCALAR_OUTCOME_C, 0], [4, SCALAR_OUTCOME_C, 0], [5, SCALAR_OUTCOME_C, 0], [6, SCALAR_OUTCOME_C, 0]]),
     # ----- End scalar market test cases -----
 ])
-def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designatedReporterOutcome, designatedReporterDisputerAccountNum, designatedReporterDisputeStakes, round1ReportersDisputerAccountNum, round1ReporterDisputeOutcome, round1ReportersDisputeStakes, round2ReportersDisputerAccountNum, round2ReportersDisputeStakes, expectedAccountBalances, contractsFixture):
-    universe = contractsFixture.universe
+def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designatedReporterOutcome, designatedReporterDisputerAccountNum, designatedReporterDisputeStakes, round1ReportersDisputerAccountNum, round1ReporterDisputeOutcome, round1ReportersDisputeStakes, round2ReportersDisputerAccountNum, round2ReportersDisputeStakes, expectedAccountBalances, contractsFixture, universe, binaryMarket, categoricalMarket, scalarMarket):
     if (marketType == MARKET_TYPE_CATEGORICAL):
-        market = contractsFixture.categoricalMarket
-        otherMarket = contractsFixture.scalarMarket
+        market = categoricalMarket
+        otherMarket = scalarMarket
         otherOutcome = SCALAR_OUTCOME_A
         OUTCOME_A = CATEGORICAL_OUTCOME_A
         OUTCOME_B = CATEGORICAL_OUTCOME_B
         OUTCOME_C = CATEGORICAL_OUTCOME_C
     elif (marketType == MARKET_TYPE_SCALAR):
-        market = contractsFixture.scalarMarket
-        otherMarket = contractsFixture.categoricalMarket
+        market = scalarMarket
+        otherMarket = categoricalMarket
         otherOutcome = CATEGORICAL_OUTCOME_A
         OUTCOME_A = SCALAR_OUTCOME_A
         OUTCOME_B = SCALAR_OUTCOME_B
@@ -163,7 +162,7 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
 
     # Perform designated reports on the other markets so they can finalize and we can redeemWinningTokens later
     assert contractsFixture.designatedReport(otherMarket, otherOutcome, tester.k0)
-    assert contractsFixture.designatedReport(contractsFixture.binaryMarket, [10**18,0], tester.k0)
+    assert contractsFixture.designatedReport(binaryMarket, [10**18,0], tester.k0)
 
     # Perform designated report (if there is one)
     if (len(designatedReporterOutcome) > 0):
@@ -307,11 +306,11 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
     assert market.tryFinalize()
     if (round2ReportersDisputerAccountNum == None):
         assert otherMarket.tryFinalize()
-        assert contractsFixture.binaryMarket.tryFinalize()
-        assert otherMarket.getReportingState() == contractsFixture.constants.FINALIZED()
-        assert contractsFixture.binaryMarket.getReportingState() == contractsFixture.constants.FINALIZED()
+        assert binaryMarket.tryFinalize()
+        assert otherMarket.getReportingState() == contractsFixture.contracts['Constants'].FINALIZED()
+        assert binaryMarket.getReportingState() == contractsFixture.contracts['Constants'].FINALIZED()
 
-    assert market.getReportingState() == contractsFixture.constants.FINALIZED()
+    assert market.getReportingState() == contractsFixture.contracts['Constants'].FINALIZED()
     if (round2ReportersDisputerAccountNum):
         print "Original universe test accounts"
         printTestAccountBalances(reputationToken, False)

--- a/tests/reporting/test_market.py
+++ b/tests/reporting/test_market.py
@@ -6,24 +6,21 @@ from utils import stringToBytes
 
 tester.STARTGAS = long(6.7 * 10**6)
 
-def test_market_creation(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_market_creation(contractsFixture, universe, cash, market):
     reportingWindow = contractsFixture.applySignature('ReportingWindow', market.getReportingWindow())
     shadyReportingToken = contractsFixture.upload('../source/contracts/reporting/ReportingToken.sol', 'shadyReportingToken')
     shadyReportingToken.initialize(market.address, [0,10**18])
 
     # TODO: When require is re-enabled uncomment this test
-    #shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(0))
-    #with raises(TransactionFailed, message="Markets can only use Cash as their denomination token"):
-    #    contractsFixture.createReasonableBinaryMarket(universe, shareToken)
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(0))
+    with raises(TransactionFailed, message="Markets can only use Cash as their denomination token"):
+       contractsFixture.createReasonableBinaryMarket(universe, shareToken)
 
     assert market.getUniverse() == universe.address
     assert market.getNumberOfOutcomes() == 2
     assert market.getNumTicks() == 10**18
     assert reportingWindow.getReputationToken() == universe.getReputationToken()
     assert market.getFinalPayoutDistributionHash() == stringToBytes("")
-    assert market.getReportingState() == contractsFixture.constants.PRE_REPORTING()
+    assert market.getReportingState() == contractsFixture.contracts['Constants'].PRE_REPORTING()
     assert market.isContainerForReportingToken(shadyReportingToken.address) == 0
     assert market.getDesignatedReportDueTimestamp() == market.getEndTime() + timedelta(days=3).total_seconds()

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -1,36 +1,33 @@
 from ethereum.tools import tester
-from ethereum.tools.tester import TransactionFailed
+from ethereum.tools.tester import ABIContract, TransactionFailed
 from pytest import fixture, mark, raises
 from utils import longTo32Bytes, captureFilteredLogs
 from reporting_utils import proceedToDesignatedReporting, proceedToRound1Reporting, proceedToRound2Reporting, proceedToForking, finalizeForkingMarket, initializeReportingFixture
 
 tester.STARTGAS = long(6.7 * 10**6)
 
-def test_reportingFullHappyPath(reportingFixture):
-    cash = reportingFixture.cash
-    market = reportingFixture.binaryMarket
-    universe = reportingFixture.universe
-    reputationToken = reportingFixture.applySignature('ReputationToken', universe.getReputationToken())
-    reportingTokenNo = reportingFixture.getReportingToken(market, [10**18,0])
-    reportingTokenYes = reportingFixture.getReportingToken(market, [0,10**18])
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', universe.getNextReportingWindow())
+def test_reportingFullHappyPath(localFixture, universe, cash, market):
+    reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
+    reportingTokenNo = localFixture.getReportingToken(market, [10**18,0])
+    reportingTokenYes = localFixture.getReportingToken(market, [0,10**18])
+    reportingWindow = localFixture.applySignature('ReportingWindow', universe.getNextReportingWindow())
     expectedMarketCreatorFeePayout = universe.getValidityBond()
     reporterGasCosts = universe.getTargetReporterGasCosts()
 
     # We can't yet report on the market as it's in the pre reporting phase
-    assert market.getReportingState() == reportingFixture.constants.PRE_REPORTING()
+    assert market.getReportingState() == localFixture.contracts['Constants'].PRE_REPORTING()
     with raises(TransactionFailed, message="Reporting cannot be done in the PRE REPORTING state"):
         reportingTokenNo.buy(100, sender=tester.k0)
 
     # Fast forward to one second after the next reporting window
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getStartTime() + 1
+    localFixture.chain.head_state.timestamp = reportingWindow.getStartTime() + 1
 
     # This will cause us to be in the first reporting phase
-    assert market.getReportingState() == reportingFixture.constants.ROUND1_REPORTING()
+    assert market.getReportingState() == localFixture.contracts['Constants'].ROUND1_REPORTING()
 
-    noShowBondCosts = 3 * reportingFixture.constants.DEFAULT_DESIGNATED_REPORT_NO_SHOW_BOND()
+    noShowBondCosts = 3 * localFixture.contracts['Constants'].DEFAULT_DESIGNATED_REPORT_NO_SHOW_BOND()
     # Both reporters report on the outcome. Tester 1 reports first, winning the no-show REP bond and and causing the YES outcome to be the tentative winner
-    initialRound1ReporterETH = reportingFixture.utils.getETHBalance(tester.a1)
+    initialRound1ReporterETH = localFixture.contracts['Utils'].getETHBalance(tester.a1)
     reportingTokenYes.buy(0, sender=tester.k1)
     assert reportingTokenYes.balanceOf(tester.a1) == 2 * 10 ** 18
     assert reputationToken.balanceOf(tester.a1) == 1 * 10**6 * 10 **18
@@ -41,27 +38,27 @@ def test_reportingFullHappyPath(reportingFixture):
     assert tentativeWinner == reportingTokenYes.getPayoutDistributionHash()
 
     # The first reporter also recieves reporter gas fees
-    assert reportingFixture.utils.getETHBalance(tester.a1) == initialRound1ReporterETH + reporterGasCosts
+    assert localFixture.contracts['Utils'].getETHBalance(tester.a1) == initialRound1ReporterETH + reporterGasCosts
 
     # Move time forward into the FIRST DISPUTE phase
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
-    assert market.getReportingState() == reportingFixture.constants.FIRST_DISPUTE()
+    localFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
+    assert market.getReportingState() == localFixture.contracts['Constants'].FIRST_DISPUTE()
 
     # Contest the results with Tester 0
     market.disputeRound1Reporters([], 0, False, sender=tester.k0)
     assert not reportingWindow.isContainerForMarket(market.address)
     assert universe.isContainerForMarket(market.address)
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
     assert reportingWindow.isContainerForMarket(market.address)
 
     # We're now in the ROUND2 REPORTING phase
-    assert market.getReportingState() == reportingFixture.constants.ROUND2_REPORTING()
+    assert market.getReportingState() == localFixture.contracts['Constants'].ROUND2_REPORTING()
 
     # Tester 0 has a REP balance less the first bond amount
     assert reputationToken.balanceOf(tester.a0) == 8 * 10**6 * 10 **18 - 100 - 11 * 10**21 - noShowBondCosts
 
     # Tester 2 reports for the NO outcome
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getStartTime() + 1
+    localFixture.chain.head_state.timestamp = reportingWindow.getStartTime() + 1
     reportingTokenNo.buy(2, sender=tester.k2)
     assert reportingTokenNo.balanceOf(tester.a2) == 2
     assert reputationToken.balanceOf(tester.a2) == 10**6 * 10 **18 - 2
@@ -69,24 +66,24 @@ def test_reportingFullHappyPath(reportingFixture):
     assert tentativeWinner == reportingTokenNo.getPayoutDistributionHash()
 
     # Move forward in time to put us in the LAST DISPUTE PHASE
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
-    assert market.getReportingState() == reportingFixture.constants.LAST_DISPUTE()
+    localFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
+    assert market.getReportingState() == localFixture.contracts['Constants'].LAST_DISPUTE()
 
     # Tester 1 contests the outcome of the ALL report which will cause a fork
     market.disputeRound2Reporters(sender=tester.k1)
     assert universe.getForkingMarket() == market.address
     assert not reportingWindow.isContainerForMarket(market.address)
     assert universe.isContainerForMarket(market.address)
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
     assert reportingWindow.isContainerForMarket(market.address)
-    assert market.getReportingState() == reportingFixture.constants.FORKING()
+    assert market.getReportingState() == localFixture.contracts['Constants'].FORKING()
 
     # The universe forks and there is now a universe where NO and YES are the respective outcomes of each
-    noUniverse = reportingFixture.getOrCreateChildUniverse(universe, market, [10**18,0])
-    noUniverseReputationToken = reportingFixture.applySignature('ReputationToken', noUniverse.getReputationToken())
+    noUniverse = localFixture.getOrCreateChildUniverse(universe, market, [10**18,0])
+    noUniverseReputationToken = localFixture.applySignature('ReputationToken', noUniverse.getReputationToken())
     assert noUniverse.address != universe.address
-    yesUniverse = reportingFixture.getOrCreateChildUniverse(universe, market, [0,10**18])
-    yesUniverseReputationToken = reportingFixture.applySignature('ReputationToken', yesUniverse.getReputationToken())
+    yesUniverse = localFixture.getOrCreateChildUniverse(universe, market, [0,10**18])
+    yesUniverseReputationToken = localFixture.applySignature('ReputationToken', yesUniverse.getReputationToken())
     assert yesUniverse.address != universe.address
     assert yesUniverse.address != noUniverse.address
 
@@ -109,59 +106,55 @@ def test_reportingFullHappyPath(reportingFixture):
     assert not reputationToken.balanceOf(tester.a2)
     assert noUniverseReputationToken.balanceOf(tester.a2) == 1 * 10 ** 6 * 10 ** 18  - 2
 
-    # We can finalize the market now since a mjaority of REP has moved. Alternatively we could "reportingFixture.chain.head_state.timestamp = universe.getForkEndTime() + 1" to move
-    initialMarketCreatorETHBalance = reportingFixture.utils.getETHBalance(market.getOwner())
+    # We can finalize the market now since a mjaority of REP has moved. Alternatively we could "localFixture.chain.head_state.timestamp = universe.getForkEndTime() + 1" to move
+    initialMarketCreatorETHBalance = localFixture.contracts['Utils'].getETHBalance(market.getOwner())
     assert market.tryFinalize()
 
     # The market is now finalized and the NO outcome is the winner
-    assert market.getReportingState() == reportingFixture.constants.FINALIZED()
+    assert market.getReportingState() == localFixture.contracts['Constants'].FINALIZED()
     assert market.getFinalWinningReportingToken() == reportingTokenNo.address
 
     # Since the designated report was not invalid the market creator gets back the validity bond
-    increaseInMarketCreatorBalance = reportingFixture.utils.getETHBalance(market.getOwner()) - initialMarketCreatorETHBalance
+    increaseInMarketCreatorBalance = localFixture.contracts['Utils'].getETHBalance(market.getOwner()) - initialMarketCreatorETHBalance
     assert increaseInMarketCreatorBalance == expectedMarketCreatorFeePayout
 
     # We can redeem forked REP on any universe we didn't dispute
     assert reportingTokenNo.redeemForkedTokens(sender = tester.k0)
     assert noUniverseReputationToken.balanceOf(tester.a0) == 8 * 10 ** 6 * 10 ** 18 - 11000 * 10 ** 18 - noShowBondCosts
 
-def test_designatedReportingHappyPath(reportingFixture):
-    market = reportingFixture.binaryMarket
-
+def test_designatedReportingHappyPath(localFixture, universe, market):
     # Proceed to the DESIGNATED REPORTING phase
-    proceedToDesignatedReporting(reportingFixture, market, [0,10**18])
+    proceedToDesignatedReporting(localFixture, universe, market, [0,10**18])
 
     # To progress into the DESIGNATED DISPUTE phase we do a designated report
-    assert reportingFixture.designatedReport(market, [0,10**18], tester.k0)
+    assert localFixture.designatedReport(market, [0,10**18], tester.k0)
 
     # We're now in the DESIGNATED DISPUTE PHASE
-    assert market.getReportingState() == reportingFixture.constants.DESIGNATED_DISPUTE()
+    assert market.getReportingState() == localFixture.contracts['Constants'].DESIGNATED_DISPUTE()
 
     # If time passes and no dispute bond is placed the market can be finalized
-    reportingFixture.chain.head_state.timestamp = market.getEndTime() + reportingFixture.constants.DESIGNATED_REPORTING_DURATION_SECONDS() + reportingFixture.constants.DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS() + 1
+    localFixture.chain.head_state.timestamp = market.getEndTime() + localFixture.contracts['Constants'].DESIGNATED_REPORTING_DURATION_SECONDS() + localFixture.contracts['Constants'].DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS() + 1
 
     # The market is awaiting finalization now
-    assert market.getReportingState() == reportingFixture.constants.AWAITING_FINALIZATION()
+    assert market.getReportingState() == localFixture.contracts['Constants'].AWAITING_FINALIZATION()
 
     # We can finalize it
     assert market.tryFinalize()
-    assert market.getReportingState() == reportingFixture.constants.FINALIZED()
+    assert market.getReportingState() == localFixture.contracts['Constants'].FINALIZED()
 
 @mark.parametrize('makeReport', [
     True,
     False
 ])
-def test_round1ReportingHappyPath(makeReport, reportingFixture):
-    market = reportingFixture.binaryMarket
-    universe = reportingFixture.universe
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
-    reputationToken = reportingFixture.applySignature('ReputationToken', universe.getReputationToken())
+def test_round1ReportingHappyPath(makeReport, localFixture, universe, market):
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
 
     # Proceed to the ROUND1 REPORTING phase
-    proceedToRound1Reporting(reportingFixture, market, makeReport, tester.k1, [0,10**18], [10**18,0])
+    proceedToRound1Reporting(localFixture, universe, market, makeReport, tester.k1, [0,10**18], [10**18,0])
 
     # We make one report by Tester 2
-    reportingTokenYes = reportingFixture.getReportingToken(market, [0,10**18])
+    reportingTokenYes = localFixture.getReportingToken(market, [0,10**18])
     reportingTokenYes.buy(1, sender=tester.k2)
     # If there ws no designated report he first reporter gets the no-show REP bond auto-staked on the outcome they're purchasing
     expectedReportingTokenBalance = 1
@@ -174,52 +167,49 @@ def test_round1ReportingHappyPath(makeReport, reportingFixture):
     tentativeWinner = market.getTentativeWinningPayoutDistributionHash()
     if (makeReport):
         # The tentative winner will be the No outcome at first since we disputed Yes and have to stake on an outcome in that case
-        reportingTokenNo = reportingFixture.getReportingToken(market, [10**18,0])
+        reportingTokenNo = localFixture.getReportingToken(market, [10**18,0])
         assert tentativeWinner == reportingTokenNo.getPayoutDistributionHash()
         # If we buy the full designated bond amount we will be back to the YES outcome winning
-        reportingTokenYes.buy(reportingFixture.constants.DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT(), sender=tester.k2)
+        reportingTokenYes.buy(localFixture.contracts['Constants'].DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT(), sender=tester.k2)
         tentativeWinner = market.getTentativeWinningPayoutDistributionHash()
 
     assert tentativeWinner == reportingTokenYes.getPayoutDistributionHash()
 
     # To progress into the FIRST DISPUTE phase we move time forward
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
-    assert market.getReportingState() == reportingFixture.constants.FIRST_DISPUTE()
+    localFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
+    assert market.getReportingState() == localFixture.contracts['Constants'].FIRST_DISPUTE()
 
     # If time passes and no dispute bond is placed the market can be finalized
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeEndTime() + 1
+    localFixture.chain.head_state.timestamp = reportingWindow.getDisputeEndTime() + 1
 
     # The market is awaiting finalization now
-    assert market.getReportingState() == reportingFixture.constants.AWAITING_FINALIZATION()
+    assert market.getReportingState() == localFixture.contracts['Constants'].AWAITING_FINALIZATION()
 
     # We can finalize it
     assert market.tryFinalize()
-    assert market.getReportingState() == reportingFixture.constants.FINALIZED()
-
+    assert market.getReportingState() == localFixture.contracts['Constants'].FINALIZED()
 
 @mark.parametrize('makeReport', [
     True,
     False
 ])
-def test_round2ReportingHappyPath(reportingFixture, makeReport):
-    market = reportingFixture.binaryMarket
-    universe = reportingFixture.universe
-    reputationToken = reportingFixture.applySignature('ReputationToken', universe.getReputationToken())
+def test_round2ReportingHappyPath(localFixture, makeReport, universe, market):
+    reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
 
     # Proceed to the ROUND2 REPORTING phase
-    proceedToRound2Reporting(reportingFixture, market, makeReport, tester.k1, tester.k3, [0,10**18], [10**18,0], tester.k2, [10**18,0], [0,10**18])
+    proceedToRound2Reporting(localFixture, universe, market, makeReport, tester.k1, tester.k3, [0,10**18], [10**18,0], tester.k2, [10**18,0], [0,10**18])
 
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
 
-    reportingTokenNo = reportingFixture.getReportingToken(market, [10**18,0])
-    reportingTokenYes = reportingFixture.getReportingToken(market, [0,10**18])
+    reportingTokenNo = localFixture.getReportingToken(market, [10**18,0])
+    reportingTokenYes = localFixture.getReportingToken(market, [0,10**18])
 
     # When disputing the ROUND1 REPORT outcome enough was staked on the other outcome that it is now the winner
     tentativeWinner = market.getTentativeWinningPayoutDistributionHash()
     assert tentativeWinner == reportingTokenYes.getPayoutDistributionHash()
 
     # If we buy the delta between outcome stakes that will be sufficient to make the outcome win
-    marketExtensions = reportingFixture.contracts["MarketExtensions"]
+    marketExtensions = localFixture.contracts["MarketExtensions"]
     noStake = marketExtensions.getPayoutDistributionHashStake(market.address, reportingTokenNo.getPayoutDistributionHash())
     yesStake = marketExtensions.getPayoutDistributionHashStake(market.address, reportingTokenYes.getPayoutDistributionHash())
     stakeDelta = yesStake - noStake
@@ -229,19 +219,18 @@ def test_round2ReportingHappyPath(reportingFixture, makeReport):
     assert tentativeWinner == reportingTokenNo.getPayoutDistributionHash()
 
     # To progress into the LAST DISPUTE phase we move time forward
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
-    assert market.getReportingState() == reportingFixture.constants.LAST_DISPUTE()
+    localFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
+    assert market.getReportingState() == localFixture.contracts['Constants'].LAST_DISPUTE()
 
     # If time passes and no dispute bond is placed the market can be finalized
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeEndTime() + 1
+    localFixture.chain.head_state.timestamp = reportingWindow.getDisputeEndTime() + 1
 
     # The market is awaiting finalization now
-    assert market.getReportingState() == reportingFixture.constants.AWAITING_FINALIZATION()
+    assert market.getReportingState() == localFixture.contracts['Constants'].AWAITING_FINALIZATION()
 
     # We can finalize it
     assert market.tryFinalize()
-    assert market.getReportingState() == reportingFixture.constants.FINALIZED()
-
+    assert market.getReportingState() == localFixture.contracts['Constants'].FINALIZED()
 
 @mark.parametrize('makeReport, finalizeByMigration', [
     (True, True),
@@ -249,14 +238,12 @@ def test_round2ReportingHappyPath(reportingFixture, makeReport):
     (True, False),
     (False, False),
 ])
-def test_forking(reportingFixture, makeReport, finalizeByMigration):
-    market = reportingFixture.binaryMarket
+def test_forking(localFixture, makeReport, finalizeByMigration, universe, market):
     # Proceed to the FORKING phase
-    proceedToForking(reportingFixture, market, makeReport, tester.k1, tester.k3, tester.k3, [0,10**18], [10**18,0], tester.k2, [10**18,0], [0,10**18], [10**18,0])
+    proceedToForking(localFixture, universe, market, makeReport, tester.k1, tester.k3, tester.k3, [0,10**18], [10**18,0], tester.k2, [10**18,0], [0,10**18], [10**18,0])
 
     # Finalize the market
-    finalizeForkingMarket(reportingFixture, market, finalizeByMigration, tester.a1, tester.k1, tester.a0, tester.k0, tester.a2, tester.k2, [0,10**18], [10**18,0])
-
+    finalizeForkingMarket(localFixture, universe, market, finalizeByMigration, tester.a1, tester.k1, tester.a0, tester.k0, tester.a2, tester.k2, [0,10**18], [10**18,0])
 
 @mark.parametrize('makeReport, finalizeByMigration', [
     (True, True),
@@ -264,11 +251,9 @@ def test_forking(reportingFixture, makeReport, finalizeByMigration):
     (True, False),
     (False, False),
 ])
-def test_forkMigration(reportingFixture, makeReport, finalizeByMigration):
-    market = reportingFixture.binaryMarket
-    cash = reportingFixture.cash
-    newMarket = reportingFixture.createReasonableBinaryMarket(reportingFixture.universe, cash)
-    completeSets = reportingFixture.contracts['CompleteSets']
+def test_forkMigration(localFixture, makeReport, finalizeByMigration, universe, cash, market):
+    newMarket = localFixture.createReasonableBinaryMarket(universe, cash)
+    completeSets = localFixture.contracts['CompleteSets']
 
     # We'll do some transactions that cause fee collection here so we can test that fees are properly migrated automatically when a market migrates from a fork
     cost = 10 * newMarket.getNumTicks()
@@ -280,17 +265,17 @@ def test_forkMigration(reportingFixture, makeReport, finalizeByMigration):
     assert cash.balanceOf(oldReportingWindowAddress) == fees
 
     # We proceed the standard market to the FORKING state
-    proceedToForking(reportingFixture,  market, makeReport, tester.k1, tester.k2, tester.k3, [0,10**18], [10**18,0], tester.k2, [10**18,0], [0,10**18], [10**18,0])
+    proceedToForking(localFixture, universe, market, makeReport, tester.k1, tester.k2, tester.k3, [0,10**18], [10**18,0], tester.k2, [10**18,0], [0,10**18], [10**18,0])
 
     # The market we created is now awaiting migration
-    assert newMarket.getReportingState() == reportingFixture.constants.AWAITING_FORK_MIGRATION()
+    assert newMarket.getReportingState() == localFixture.contracts['Constants'].AWAITING_FORK_MIGRATION()
 
     # If we attempt to migrate now it will not work since the forking market is not finalized
     with raises(TransactionFailed, message="Migration cannot occur until the forking market is finalized"):
         newMarket.migrateThroughOneFork()
 
     # We'll finalize the forking market
-    finalizeForkingMarket(reportingFixture, market, finalizeByMigration, tester.a1, tester.k1, tester.a0, tester.k0, tester.a2, tester.k2, [0,10**18], [10**18,0])
+    finalizeForkingMarket(localFixture, universe, market, finalizeByMigration, tester.a1, tester.k1, tester.a0, tester.k0, tester.a2, tester.k2, [0,10**18], [10**18,0])
 
     # Now we can migrate the market to the winning universe
     assert newMarket.migrateThroughOneFork()
@@ -299,7 +284,7 @@ def test_forkMigration(reportingFixture, makeReport, finalizeByMigration):
     assert cash.balanceOf(oldReportingWindowAddress) == 0
 
     # Now that we're on the correct universe we are send back to the DESIGNATED REPORTING phase
-    assert newMarket.getReportingState() == reportingFixture.constants.DESIGNATED_REPORTING()
+    assert newMarket.getReportingState() == localFixture.contracts['Constants'].DESIGNATED_REPORTING()
 
     # We can confirm that migrating the market also triggered a migration of its reporting window's ETH fees to the new reporting window
     assert cash.balanceOf(newMarket.getReportingWindow()) == fees
@@ -308,42 +293,37 @@ def test_forkMigration(reportingFixture, makeReport, finalizeByMigration):
     True,
     False
 ])
-def test_noReports(reportingFixture, pastDisputePhase):
-    market = reportingFixture.binaryMarket
-
+def test_noReports(localFixture, pastDisputePhase, universe, market):
     # Proceed to the ROUND1 REPORTING phase
-    proceedToRound1Reporting(reportingFixture, market, False, tester.k1, [0,10**18], [10**18,0])
+    proceedToRound1Reporting(localFixture, universe, market, False, tester.k1, [0,10**18], [10**18,0])
 
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
 
     if (pastDisputePhase):
-        reportingFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
+        localFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
     else:
-        reportingFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
-    
+        localFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
+
     # If we receive no reports by the time Limited Reporting is finished we will be in the AWAITING NO REPORT MIGRATION phase
-    assert market.getReportingState() == reportingFixture.constants.AWAITING_NO_REPORT_MIGRATION()
+    assert market.getReportingState() == localFixture.contracts['Constants'].AWAITING_NO_REPORT_MIGRATION()
 
     # We can try to report on the market, which will move it to the next reporting window where it will be back in ROUND1 REPORTING
-    reportingToken = reportingFixture.getReportingToken(market, [0,10**18])
+    reportingToken = localFixture.getReportingToken(market, [0,10**18])
     assert reportingToken.buy(1, sender=tester.k2)
 
-    assert market.getReportingState() == reportingFixture.constants.ROUND1_REPORTING()
+    assert market.getReportingState() == localFixture.contracts['Constants'].ROUND1_REPORTING()
     assert market.getReportingWindow() != reportingWindow.address
 
-def test_invalid_round1_report(reportingFixture):
-    market = reportingFixture.binaryMarket
-    universe = reportingFixture.universe
-    cash = reportingFixture.cash
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
-    reputationToken = reportingFixture.applySignature('ReputationToken', universe.getReputationToken())
+def test_invalid_round1_report(localFixture, universe, cash, market):
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
     expectedReportingWindowFeePayout = universe.getValidityBond()
 
     # Proceed to the ROUND1 REPORTING phase
-    proceedToRound1Reporting(reportingFixture, market, False, tester.k1, [0,10**18], [10**18,0])
+    proceedToRound1Reporting(localFixture, universe, market, False, tester.k1, [0,10**18], [10**18,0])
 
     # We make an invalid report
-    reportingTokenInvalid = reportingFixture.getReportingToken(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], True)
+    reportingTokenInvalid = localFixture.getReportingToken(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], True)
     reportingTokenInvalid.buy(1, sender=tester.k2)
     assert reportingTokenInvalid.balanceOf(tester.a2) == 1 + universe.getDesignatedReportNoShowBond()
     tentativeWinner = market.getTentativeWinningPayoutDistributionHash()
@@ -352,7 +332,7 @@ def test_invalid_round1_report(reportingFixture):
 
     # If we finalize the market it will be recorded as an invalid result
     initialReportingWindowCashBalance = cash.balanceOf(reportingWindow.address)
-    reportingFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
+    localFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
     assert market.tryFinalize()
     assert not market.isValid()
     assert reportingWindow.getNumInvalidMarkets() == 1
@@ -361,28 +341,26 @@ def test_invalid_round1_report(reportingFixture):
     increaseInReportingWindowBalance = cash.balanceOf(reportingWindow.address) - initialReportingWindowCashBalance
     assert increaseInReportingWindowBalance == expectedReportingWindowFeePayout
 
-def test_invalid_designated_report(reportingFixture):
-    market = reportingFixture.binaryMarket
-    cash = reportingFixture.cash
-    reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
-    expectedReportingWindowFeePayout = reportingFixture.universe.getValidityBond()
-    expectedMarketCreatorFeePayout = reportingFixture.universe.getTargetReporterGasCosts()
+def test_invalid_designated_report(localFixture, universe, cash, market):
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    expectedReportingWindowFeePayout = universe.getValidityBond()
+    expectedMarketCreatorFeePayout = universe.getTargetReporterGasCosts()
 
     # Proceed to the DESIGNATED REPORTING phase
-    proceedToDesignatedReporting(reportingFixture, market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)])
+    proceedToDesignatedReporting(localFixture, universe, market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)])
 
     # To progress into the DESIGNATED DISPUTE phase we do a designated report of invalid
-    initialMarketCreatorETHBalance = reportingFixture.utils.getETHBalance(market.getOwner())
-    assert reportingFixture.designatedReport(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], tester.k0, True)
+    initialMarketCreatorETHBalance = localFixture.contracts['Utils'].getETHBalance(market.getOwner())
+    assert localFixture.designatedReport(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], tester.k0, True)
 
     # We're now in the DESIGNATED DISPUTE PHASE
-    assert market.getReportingState() == reportingFixture.constants.DESIGNATED_DISPUTE()
+    assert market.getReportingState() == localFixture.contracts['Constants'].DESIGNATED_DISPUTE()
 
     # If time passes and no dispute bond is placed the market can be finalized
-    reportingFixture.chain.head_state.timestamp = market.getEndTime() + reportingFixture.constants.DESIGNATED_REPORTING_DURATION_SECONDS() + reportingFixture.constants.DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS() + 1
+    localFixture.chain.head_state.timestamp = market.getEndTime() + localFixture.contracts['Constants'].DESIGNATED_REPORTING_DURATION_SECONDS() + localFixture.contracts['Constants'].DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS() + 1
 
     # The market is awaiting finalization now
-    assert market.getReportingState() == reportingFixture.constants.AWAITING_FINALIZATION()
+    assert market.getReportingState() == localFixture.contracts['Constants'].AWAITING_FINALIZATION()
 
     # If we finalize the market it will be recorded as an invalid result
     initialReportingWindowCashBalance = cash.balanceOf(reportingWindow.address)
@@ -395,15 +373,29 @@ def test_invalid_designated_report(reportingFixture):
     assert increaseInReportingWindowBalance == expectedReportingWindowFeePayout
 
     # Since the designated reporter showed up the market creator still gets back the reporter gas cost fee
-    increaseInMarketCreatorBalance = reportingFixture.utils.getETHBalance(market.getOwner()) - initialMarketCreatorETHBalance
+    increaseInMarketCreatorBalance = localFixture.contracts['Utils'].getETHBalance(market.getOwner()) - initialMarketCreatorETHBalance
     assert increaseInMarketCreatorBalance == expectedMarketCreatorFeePayout
 
 @fixture(scope="session")
-def reportingSnapshot(sessionFixture):
-    sessionFixture.resetSnapshot()
-    return initializeReportingFixture(sessionFixture, sessionFixture.binaryMarket)
+def localSnapshot(fixture, kitchenSinkSnapshot):
+    fixture.resetToSnapshot(kitchenSinkSnapshot)
+    universe = ABIContract(fixture.chain, kitchenSinkSnapshot['universe'].translator, kitchenSinkSnapshot['universe'].address)
+    market = ABIContract(fixture.chain, kitchenSinkSnapshot['binaryMarket'].translator, kitchenSinkSnapshot['binaryMarket'].address)
+    return initializeReportingFixture(fixture, universe, market)
 
 @fixture
-def reportingFixture(sessionFixture, reportingSnapshot):
-    sessionFixture.resetToSnapshot(reportingSnapshot)
-    return sessionFixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@fixture
+def universe(localFixture, kitchenSinkSnapshot):
+    return ABIContract(localFixture.chain, kitchenSinkSnapshot['universe'].translator, kitchenSinkSnapshot['universe'].address)
+
+@fixture
+def market(localFixture, kitchenSinkSnapshot):
+    return ABIContract(localFixture.chain, kitchenSinkSnapshot['binaryMarket'].translator, kitchenSinkSnapshot['binaryMarket'].address)
+
+@fixture
+def cash(localFixture, kitchenSinkSnapshot):
+    return ABIContract(localFixture.chain, kitchenSinkSnapshot['cash'].translator, kitchenSinkSnapshot['cash'].address)

--- a/tests/reporting/test_reporting_token_redemption.py
+++ b/tests/reporting/test_reporting_token_redemption.py
@@ -1,35 +1,34 @@
 from ethereum.tools import tester
-from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, raises
+from ethereum.tools.tester import ABIContract, TransactionFailed
+from pytest import fixture as pytest_fixture, mark, raises
 from reporting_utils import proceedToDesignatedReporting, proceedToRound1Reporting, initializeReportingFixture
 
-def test_one_market_one_correct_report(reportingTokenPayoutFixture):
-    market = reportingTokenPayoutFixture.market1
-    universe = reportingTokenPayoutFixture.applySignature('Universe', market.getUniverse())
-    reportingWindow = reportingTokenPayoutFixture.applySignature('ReportingWindow', market.getReportingWindow())
-    reputationToken = reportingTokenPayoutFixture.applySignature('ReputationToken', reportingWindow.getReputationToken())
+def test_one_market_one_correct_report(localFixture, universe, market):
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reputationToken = localFixture.applySignature('ReputationToken', reportingWindow.getReputationToken())
+    marketFeeCalculator = localFixture.contracts["MarketFeeCalculator"]
 
     # Proceed to the DESIGNATED REPORTING phase
-    proceedToDesignatedReporting(reportingTokenPayoutFixture, market, [0,10**18])
+    proceedToDesignatedReporting(localFixture, universe, market, [0,10**18])
 
     # To progress into the DESIGNATED DISPUTE phase we do a designated report
     initialRepBalance = reputationToken.balanceOf(tester.a0)
-    assert reportingTokenPayoutFixture.designatedReport(market, [0,10**18], tester.k0)
+    assert localFixture.designatedReport(market, [0,10**18], tester.k0)
     # The market owner gets back the no-show REP bond, which cancels out the amount used to pay for the required dispute tokens
     assert reputationToken.balanceOf(tester.a0) == initialRepBalance + universe.getDesignatedReportNoShowBond() - universe.getDesignatedReportStake()
     initialREPBalance = reputationToken.balanceOf(tester.a0)
 
     # We're now in the DESIGNATED DISPUTE PHASE
-    assert market.getReportingState() == reportingTokenPayoutFixture.constants.DESIGNATED_DISPUTE()
+    assert market.getReportingState() == localFixture.contracts['Constants'].DESIGNATED_DISPUTE()
 
     # Time passes until the end of the reporting window
-    reportingTokenPayoutFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
+    localFixture.chain.head_state.timestamp = reportingWindow.getEndTime() + 1
 
     # Finalize the market
     market.tryFinalize()
 
     # The designated reporter may redeem their reporting tokens which were purchased to make the designated report
-    reportingToken = reportingTokenPayoutFixture.getReportingToken(market, [0, 10**18])
+    reportingToken = localFixture.getReportingToken(market, [0, 10**18])
     assert reportingToken.balanceOf(tester.a0) == universe.getDesignatedReportStake()
 
     expectedREPBalance = initialREPBalance
@@ -45,17 +44,16 @@ def test_one_market_one_correct_report(reportingTokenPayoutFixture):
     (3, 2),
     (3, 1),
 ])
-def test_reporting_token_redemption(numReports, numCorrect, reportingTokenPayoutFixture):
-    market = reportingTokenPayoutFixture.market1
-    reportingWindow = reportingTokenPayoutFixture.applySignature('ReportingWindow', market.getReportingWindow())
-    reputationToken = reportingTokenPayoutFixture.applySignature('ReputationToken', reportingWindow.getReputationToken())
+def test_reporting_token_redemption(localFixture, universe, market, numReports, numCorrect):
+    reportingWindow = localFixture.applySignature('ReportingWindow', market.getReportingWindow())
+    reputationToken = localFixture.applySignature('ReputationToken', reportingWindow.getReputationToken())
 
     # Proceed to ROUND1 REPORTING
-    proceedToRound1Reporting(reportingTokenPayoutFixture, market, False, tester.k1, [0,10**18], [10**18,0])
+    proceedToRound1Reporting(localFixture, universe, market, False, tester.k1, [0,10**18], [10**18,0])
 
-    doReports(reportingTokenPayoutFixture, market, numReports, numCorrect)
+    doReports(localFixture, market, numReports, numCorrect)
 
-    confirmPayouts(reportingTokenPayoutFixture, market, numCorrect)
+    confirmPayouts(localFixture, market, numCorrect)
 
 def doReports(fixture, market, numReporters, numCorrect):
     reportingWindow = fixture.applySignature('ReportingWindow', market.getReportingWindow())
@@ -88,16 +86,28 @@ def confirmPayouts(fixture, market, numCorrectReporters):
             expectedRep += universe.getDesignatedReportNoShowBond()
         assert reputationToken.balanceOf(testerAddress) == expectedRep
 
-@fixture(scope="session")
-def reportingFeePayoutSnapshot(sessionFixture):
-    sessionFixture.resetSnapshot()
-    # Move to the next reporting window for these tests as we want to control market creation and reporting in isolation
-    originalReportingWindow = sessionFixture.applySignature('ReportingWindow', sessionFixture.binaryMarket.getReportingWindow())
-    sessionFixture.chain.head_state.timestamp = originalReportingWindow.getEndTime() + 1
-    market = sessionFixture.market1 = sessionFixture.createReasonableBinaryMarket(sessionFixture.universe, sessionFixture.cash)
-    return initializeReportingFixture(sessionFixture, market)
+@pytest_fixture(scope="session")
+def localSnapshot(fixture, augurInitializedSnapshot):
+    fixture.resetToSnapshot(augurInitializedSnapshot)
+    fixture.upload("solidity_test_helpers/Constants.sol")
+    fixture.upload("solidity_test_helpers/Utils.sol")
+    universe = fixture.createUniverse(0, "")
+    fixture.distributeRep(universe)
+    market = fixture.createReasonableBinaryMarket(universe, fixture.contracts['Cash'])
+    snapshot = initializeReportingFixture(fixture, universe, market)
+    snapshot['universe'] = universe
+    snapshot['market'] = market
+    return snapshot
 
-@fixture
-def reportingTokenPayoutFixture(sessionFixture, reportingFeePayoutSnapshot):
-    sessionFixture.resetToSnapshot(reportingFeePayoutSnapshot)
-    return sessionFixture
+@pytest_fixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@pytest_fixture
+def universe(localFixture, localSnapshot):
+    return ABIContract(localFixture.chain, localSnapshot['universe'].translator, localSnapshot['universe'].address)
+
+@pytest_fixture
+def market(localFixture, localSnapshot):
+    return ABIContract(localFixture.chain, localSnapshot['market'].translator, localSnapshot['market'].address)

--- a/tests/reporting/test_reputation.py
+++ b/tests/reporting/test_reputation.py
@@ -1,16 +1,15 @@
 from ethereum.tools import tester
 
-def test_decimals(contractsFixture):
+def test_decimals(contractsFixture, universe):
     reputationTokenFactory = contractsFixture.contracts['ReputationTokenFactory']
     assert reputationTokenFactory
-    reputationTokenAddress = reputationTokenFactory.createReputationToken(contractsFixture.controller.address, contractsFixture.universe.address)
+    reputationTokenAddress = reputationTokenFactory.createReputationToken(contractsFixture.contracts['Controller'].address, universe.address)
     reputationToken = contractsFixture.applySignature('ReputationToken', reputationTokenAddress)
 
     assert reputationToken.decimals() == 18
 
 ''' TODO: When we get finer grained test fixture/setup in place make this use a more base fixture without the rep distributed, as without that there is nothing here to test
-def test_redeem_legacy_rep(contractsFixture):
-    universe = contractsFixture.universe
+def test_redeem_legacy_rep(contractsFixture, universe):
     reputationToken = contractsFixture.applySignature('ReputationToken', universe.getReputationToken())
     legacyRepContract = contractsFixture.contracts['LegacyRepContract']
     legacyRepContract.faucet(long(11 * 10**6 * 10**18))

--- a/tests/reporting/test_universe.py
+++ b/tests/reporting/test_universe.py
@@ -153,4 +153,9 @@ def test_open_interest(universe):
 def localFixture(fixture, augurInitializedSnapshot):
     fixture.resetToSnapshot(augurInitializedSnapshot)
     fixture.uploadAndAddToController("solidity_test_helpers/Constants.sol")
+    universe = fixture.createUniverse(0, "")
+    cash = fixture.getSeededCash()
+    augur = fixture.contracts['Augur']
+    fixture.distributeRep(universe)
+    binaryMarket = fixture.createReasonableBinaryMarket(universe, cash)
     return fixture

--- a/tests/reporting/test_universe.py
+++ b/tests/reporting/test_universe.py
@@ -2,9 +2,9 @@ from ethereum.tools import tester
 from utils import longToHexString, stringToBytes
 from pytest import fixture
 
-def test_universe_creation(universeFixture):
-    universe = universeFixture.createUniverse(3, "5")
-    reputationToken = universeFixture.applySignature('ReputationToken', universe.getReputationToken())
+def test_universe_creation(localFixture):
+    universe = localFixture.createUniverse(3, "5")
+    reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
     assert universe.getParentUniverse() == longToHexString(3)
     assert universe.getParentPayoutDistributionHash() == stringToBytes("5")
     assert universe.getForkingMarket() == longToHexString(0)
@@ -15,11 +15,11 @@ def test_universe_creation(universeFixture):
     assert universe.getForkEndTime() == 0
     assert universe.getChildUniverse("5") == longToHexString(0)
 
-def test_get_reporting_window(universeFixture):
-    universe = universeFixture.createUniverse(1, "10")
-    timestamp = universeFixture.chain.head_state.timestamp
-    duration =  universeFixture.constants.REPORTING_DURATION_SECONDS()
-    dispute_duration = universeFixture.constants.REPORTING_DISPUTE_DURATION_SECONDS()
+def test_get_reporting_window(localFixture):
+    universe = localFixture.createUniverse(1, "10")
+    timestamp = localFixture.chain.head_state.timestamp
+    duration =  localFixture.contracts['Constants'].REPORTING_DURATION_SECONDS()
+    dispute_duration = localFixture.contracts['Constants'].REPORTING_DISPUTE_DURATION_SECONDS()
     total_dispute_duration = duration + dispute_duration
     reportingPeriodDurationForTimestamp = timestamp / total_dispute_duration
 
@@ -34,34 +34,32 @@ def test_get_reporting_window(universeFixture):
     assert universe.getReportingWindow(reportingPeriodDurationForTimestamp) == report_window
 
     # Make up end timestamp for testing internal calculations
-    end_timestamp = universeFixture.chain.head_state.timestamp + 1
+    end_timestamp = localFixture.chain.head_state.timestamp + 1
     end_report_window_des = universe.getReportingWindowByMarketEndTime(end_timestamp)
 
-    # Test getting same calculated end reporting window 
-    end_timestamp_des_test = end_timestamp + universeFixture.constants.DESIGNATED_REPORTING_DURATION_SECONDS() + universeFixture.constants.DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS() + 1 + total_dispute_duration
+    # Test getting same calculated end reporting window
+    end_timestamp_des_test = end_timestamp + localFixture.contracts['Constants'].DESIGNATED_REPORTING_DURATION_SECONDS() + localFixture.contracts['Constants'].DESIGNATED_REPORTING_DISPUTE_DURATION_SECONDS() + 1 + total_dispute_duration
     assert universe.getReportingWindowByTimestamp(end_timestamp_des_test) == end_report_window_des
 
-    assert universe.getPreviousReportingWindow() == universe.getReportingWindowByTimestamp(universeFixture.chain.head_state.timestamp - total_dispute_duration)
-    assert universe.getCurrentReportingWindow() == universe.getReportingWindowByTimestamp(universeFixture.chain.head_state.timestamp)
-    assert universe.getNextReportingWindow() == universe.getReportingWindowByTimestamp(universeFixture.chain.head_state.timestamp + total_dispute_duration)
-    
-def test_create_child_universe(universeFixture):
-    universe = universeFixture.universe
+    assert universe.getPreviousReportingWindow() == universe.getReportingWindowByTimestamp(localFixture.chain.head_state.timestamp - total_dispute_duration)
+    assert universe.getCurrentReportingWindow() == universe.getReportingWindowByTimestamp(localFixture.chain.head_state.timestamp)
+    assert universe.getNextReportingWindow() == universe.getReportingWindowByTimestamp(localFixture.chain.head_state.timestamp + total_dispute_duration)
+
+def test_create_child_universe(localFixture, universe):
     assert universe.getChildUniverse("20") == longToHexString(0)
     assert universe.getOrCreateChildUniverse("20") == universe.getChildUniverse("20")
     assert universe.getChildUniverse("20") != longToHexString(0)
     child = universe.getChildUniverse("20")
     assert universe.isParentOf(child)
 
-    other_universe = universeFixture.createUniverse(3, "1")
+    other_universe = localFixture.createUniverse(3, "1")
     other_child = other_universe.getOrCreateChildUniverse("21")
     assert universe.isParentOf(other_child) == False
 
-def test_universe_contains_reporting_win(universeFixture):
-    universe = universeFixture.universe
-    other_universe = universeFixture.createUniverse(1, "15")
+def test_universe_contains_reporting_win(localFixture, universe):
+    other_universe = localFixture.createUniverse(1, "15")
     other_curr_reporting_win = other_universe.getCurrentReportingWindow()
-    reportingWindow = universeFixture.applySignature('ReportingWindow', universe.getCurrentReportingWindow())
+    reportingWindow = localFixture.applySignature('ReportingWindow', universe.getCurrentReportingWindow())
 
     curr_reporting_window = universe.getCurrentReportingWindow()
     assert universe.isContainerForReportingWindow(curr_reporting_window)
@@ -69,30 +67,28 @@ def test_universe_contains_reporting_win(universeFixture):
     assert universe.isContainerForReportingWindow(other_curr_reporting_win) == False
 
     # Pass in non ReportingWindow object address
-    nonReportingWindow = universeFixture.upload('../source/contracts/reporting/ReportingToken.sol', 'nonReportingWindow')
+    nonReportingWindow = localFixture.upload('../source/contracts/reporting/ReportingToken.sol', 'nonReportingWindow')
     assert universe.isContainerForReportingWindow(nonReportingWindow.address) == False
 
     # create reporting windo with startTime of 0
-    reporting_window_factory = universeFixture.upload('../source/contracts/factories/ReportingWindowFactory.sol', 'reporting_window_factory')
-    zero_window = reporting_window_factory.createReportingWindow(universeFixture.controller.address, universe.address, 0)
+    reporting_window_factory = localFixture.upload('../source/contracts/factories/ReportingWindowFactory.sol', 'reporting_window_factory')
+    zero_window = reporting_window_factory.createReportingWindow(localFixture.contracts['Controller'].address, universe.address, 0)
     assert universe.isContainerForReportingWindow(zero_window) == False
-    
-def test_universe_contains_dispute_bond_token(universeFixture):
-    universe = universeFixture.universe
+
+def test_universe_contains_dispute_bond_token(localFixture, universe, market):
     # Pass in non Dispute Bond Token object address
-    nonDisputeBondToken = universeFixture.upload('../source/contracts/reporting/ReportingToken.sol', 'nonReportingWindow')
+    nonDisputeBondToken = localFixture.upload('../source/contracts/reporting/ReportingToken.sol', 'nonReportingWindow')
     assert universe.isContainerForDisputeBondToken(nonDisputeBondToken.address) == False
-    
+
     # Create bond for market not in this universe
-    market = universeFixture.binaryMarket
-    dispute_bond_token_factory = universeFixture.upload('../source/contracts/factories/DisputeBondTokenFactory.sol', 'dispute_bond_token_factory')
-    bond = dispute_bond_token_factory.createDisputeBondToken(universeFixture.controller.address, market.address, tester.a0, 10, "15")
+    dispute_bond_token_factory = localFixture.upload('../source/contracts/factories/DisputeBondTokenFactory.sol', 'dispute_bond_token_factory')
+    bond = dispute_bond_token_factory.createDisputeBondToken(localFixture.contracts['Controller'].address, market.address, tester.a0, 10, "15")
     assert universe.isContainerForDisputeBondToken(bond) == False
 
     # Pass in bond with market address of 0
-    zero_market_bond = dispute_bond_token_factory.createDisputeBondToken(universeFixture.controller.address, 0, tester.a0, 10, "15")
+    zero_market_bond = dispute_bond_token_factory.createDisputeBondToken(localFixture.contracts['Controller'].address, 0, tester.a0, 10, "15")
     assert universe.isContainerForDisputeBondToken(zero_market_bond) == False
- 
+
     # TODO Get correct dispute bond token from active market in correct state
 
     # Since we have non Market/ReportingToken/ShareToken lets test the getTypeName() tests
@@ -100,57 +96,53 @@ def test_universe_contains_dispute_bond_token(universeFixture):
     assert universe.isContainerForReportingToken(nonDisputeBondToken.address) == False
     assert universe.isContainerForShareToken(nonDisputeBondToken.address) == False
 
-def test_universe_contains_market(universeFixture):
-    universe = universeFixture.createUniverse(1, "25")
+def test_universe_contains_market(localFixture, cash, market):
+    universe = localFixture.createUniverse(1, "25")
     # market in different universe
-    market = universeFixture.binaryMarket
     assert universe.isContainerForMarket(market.address) == False
-    
+
     # Give some REP in this universe to tester0 to pay market creation fee
-    legacyRepContract = universeFixture.contracts['LegacyRepContract']
+    legacyRepContract = localFixture.contracts['LegacyRepContract']
     legacyRepContract.faucet(11 * 10**6 * 10**18)
 
     # Get the reputation token for this universe and migrate legacy REP to it
-    reputationToken = universeFixture.applySignature('ReputationToken', universe.getReputationToken())
+    reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
     legacyRepContract.approve(reputationToken.address, 11 * 10**6 * 10**18)
     reputationToken.migrateFromLegacyRepContract()
 
-    uni_market = universeFixture.createReasonableBinaryMarket(universe, universeFixture.cash)
+    uni_market = localFixture.createReasonableBinaryMarket(universe, cash)
     assert universe.isContainerForMarket(uni_market.address)
 
-def test_universe_reporting_token(universeFixture):
-    universe = universeFixture.universe
-    reporting_token_factory = universeFixture.upload('../source/contracts/factories/ReportingTokenFactory.sol', 'reporting_token_factory')
+def test_universe_reporting_token(localFixture, universe, cash, market):
+    reporting_token_factory = localFixture.upload('../source/contracts/factories/ReportingTokenFactory.sol', 'reporting_token_factory')
 
     # Reporting token not associated with this universe market
-    different_reporting_token = reporting_token_factory.createReportingToken(universeFixture.controller.address, universeFixture.binaryMarket.address, [0, 10**18])
+    different_reporting_token = reporting_token_factory.createReportingToken(localFixture.contracts['Controller'].address, market.address, [0, 10**18])
     assert universe.isContainerForReportingToken(different_reporting_token) == False
 
     # TODO add test for Reporting token associated market address of 0
 
     # Create market and test it's reporting token
-    uni_market = universeFixture.createReasonableBinaryMarket(universe, universeFixture.cash)
-    good_reporting_token = universeFixture.getReportingToken(uni_market, [0,10**18])
+    uni_market = localFixture.createReasonableBinaryMarket(universe, cash)
+    good_reporting_token = localFixture.getReportingToken(uni_market, [0,10**18])
     assert universe.isContainerForMarket(uni_market.address)
     assert universe.isContainerForReportingToken(good_reporting_token.address)
 
-def test_universe_contains_share_token(universeFixture):
-    universe = universeFixture.universe
-    share_token_factory = universeFixture.upload('../source/contracts/factories/ShareTokenFactory.sol', 'share_token_factory')
+def test_universe_contains_share_token(localFixture, universe, cash, market):
+    share_token_factory = localFixture.upload('../source/contracts/factories/ShareTokenFactory.sol', 'share_token_factory')
 
     # Share token not associated with this universe market
-    different_share_token = share_token_factory.createShareToken(universeFixture.controller.address, universeFixture.binaryMarket.address, 1)
+    different_share_token = share_token_factory.createShareToken(localFixture.contracts['Controller'].address, market.address, 1)
     assert universe.isContainerForShareToken(different_share_token) == False
 
     # TODO add test for Share token associated market address of 0
 
     # Create market and test it's reporting token
-    uni_market = universeFixture.createReasonableBinaryMarket(universe, universeFixture.cash)
-    good_share_token = universeFixture.getShareToken(uni_market, 1)
+    uni_market = localFixture.createReasonableBinaryMarket(universe, cash)
+    good_share_token = localFixture.getShareToken(uni_market, 1)
     assert universe.isContainerForShareToken(good_share_token.address)
-    
-def test_open_interest(universeFixture):
-    universe = universeFixture.universe
+
+def test_open_interest(universe):
     assert universe.getOpenInterestInAttoEth() == 0
     universe.incrementOpenInterest(10)
     assert universe.getOpenInterestInAttoEth() == 10
@@ -158,11 +150,7 @@ def test_open_interest(universeFixture):
     assert universe.getOpenInterestInAttoEth() == 5
 
 @fixture
-def sessionSnapshot(contractsFixture):
-    contractsFixture.resetSnapshot()
-    return contractsFixture.createSnapshot()
-
-@fixture
-def universeFixture(contractsFixture, sessionSnapshot):
-    contractsFixture.resetToSnapshot(sessionSnapshot)
-    return contractsFixture
+def localFixture(fixture, augurInitializedSnapshot):
+    fixture.resetToSnapshot(augurInitializedSnapshot)
+    fixture.uploadAndAddToController("solidity_test_helpers/Constants.sol")
+    return fixture

--- a/tests/reporting_utils.py
+++ b/tests/reporting_utils.py
@@ -2,25 +2,24 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import fixture, mark, lazy_fixture, raises
+from pytest import fixture, mark, raises
 from datetime import timedelta
 
-def initializeReportingFixture(sessionFixture, market):
+def initializeReportingFixture(sessionFixture, universe, market):
     # Give some REP to testers to make things interesting
-    reputationToken = sessionFixture.applySignature('ReputationToken', sessionFixture.universe.getReputationToken())
+    reputationToken = sessionFixture.applySignature('ReputationToken', universe.getReputationToken())
     for testAccount in [tester.a1, tester.a2, tester.a3]:
         reputationToken.transfer(testAccount, 1 * 10**6 * 10**18)
 
     return sessionFixture.createSnapshot()
 
-def proceedToDesignatedReporting(testFixture, market, reportOutcomes):
-    cash = testFixture.cash
-    universe = testFixture.universe
+def proceedToDesignatedReporting(testFixture, universe, market, reportOutcomes):
+    cash = testFixture.contracts['Cash']
     reputationToken = testFixture.applySignature('ReputationToken', universe.getReputationToken())
     reportingWindow = testFixture.applySignature('ReportingWindow', market.getReportingWindow())
 
     # We can't yet do a designated report on the market as it's in the pre reporting phase
-    if (market.getReportingState() == testFixture.constants.PRE_REPORTING()):
+    if (market.getReportingState() == testFixture.contracts['Constants'].PRE_REPORTING()):
         with raises(TransactionFailed, message="Reporting cannot be done in the PRE REPORTING state"):
             testFixture.designatedReport(market, reportOutcomes, tester.k0)
 
@@ -29,31 +28,30 @@ def proceedToDesignatedReporting(testFixture, market, reportOutcomes):
     testFixture.chain.head_state.timestamp = market.getEndTime() + 1
 
     # This will cause us to be in the DESIGNATED REPORTING phase
-    assert market.getReportingState() == testFixture.constants.DESIGNATED_REPORTING()
+    assert market.getReportingState() == testFixture.contracts['Constants'].DESIGNATED_REPORTING()
 
-def proceedToRound1Reporting(testFixture, market, makeReport, disputer, reportOutcomes, designatedDisputeOutcomes):
-    if (market.getReportingState() != testFixture.constants.DESIGNATED_REPORTING()):
-        proceedToDesignatedReporting(testFixture, market, reportOutcomes)
+def proceedToRound1Reporting(testFixture, universe, market, makeReport, disputer, reportOutcomes, designatedDisputeOutcomes):
+    if (market.getReportingState() != testFixture.contracts['Constants'].DESIGNATED_REPORTING()):
+        proceedToDesignatedReporting(testFixture, universe, market, reportOutcomes)
 
     # To proceed to first reporting we will either dispute a designated report or not make a designated report within the alotted time window for doing so
     if (makeReport):
         assert testFixture.designatedReport(market, reportOutcomes, tester.k0)
-        assert market.getReportingState() == testFixture.constants.DESIGNATED_DISPUTE()
+        assert market.getReportingState() == testFixture.contracts['Constants'].DESIGNATED_DISPUTE()
         assert market.disputeDesignatedReport(designatedDisputeOutcomes, 1, False, sender=disputer)
     else:
-        testFixture.chain.head_state.timestamp = market.getEndTime() + testFixture.constants.DESIGNATED_REPORTING_DURATION_SECONDS() + 1
+        testFixture.chain.head_state.timestamp = market.getEndTime() + testFixture.contracts['Constants'].DESIGNATED_REPORTING_DURATION_SECONDS() + 1
 
     # We're in the ROUND1 REPORTING phase now
-    assert market.getReportingState() == testFixture.constants.ROUND1_REPORTING()
+    assert market.getReportingState() == testFixture.contracts['Constants'].ROUND1_REPORTING()
 
-def proceedToRound2Reporting(testFixture, market, makeReport, designatedDisputer, round1Disputer, reportOutcomes, designatedDisputeOutcomes, round1Reporter, round1ReportOutcomes, round1ReportDisputeOutcomes):
-    cash = testFixture.cash
-    universe = testFixture.universe
+def proceedToRound2Reporting(testFixture, universe, market, makeReport, designatedDisputer, round1Disputer, reportOutcomes, designatedDisputeOutcomes, round1Reporter, round1ReportOutcomes, round1ReportDisputeOutcomes):
+    cash = testFixture.contracts['Cash']
     reputationToken = testFixture.applySignature('ReputationToken', universe.getReputationToken())
     reportingWindow = testFixture.applySignature('ReportingWindow', market.getReportingWindow())
 
-    if (market.getReportingState() != testFixture.constants.ROUND1_REPORTING()):
-        proceedToRound1Reporting(testFixture, market, makeReport, designatedDisputer, reportOutcomes, designatedDisputeOutcomes)
+    if (market.getReportingState() != testFixture.contracts['Constants'].ROUND1_REPORTING()):
+        proceedToRound1Reporting(testFixture, universe, market, makeReport, designatedDisputer, reportOutcomes, designatedDisputeOutcomes)
 
     reportingToken = testFixture.getReportingToken(market, round1ReportOutcomes)
 
@@ -64,22 +62,20 @@ def proceedToRound2Reporting(testFixture, market, makeReport, designatedDisputer
 
     testFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
 
-    assert market.getReportingState() == testFixture.constants.FIRST_DISPUTE()
+    assert market.getReportingState() == testFixture.contracts['Constants'].FIRST_DISPUTE()
 
-    disputeRound1ReportOutcomeStake = testFixture.constants.DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT()
+    disputeRound1ReportOutcomeStake = testFixture.contracts['Constants'].DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT()
     assert market.disputeRound1Reporters(round1ReportDisputeOutcomes, disputeRound1ReportOutcomeStake, False, sender=round1Disputer)
 
     # We're in the ROUND2 REPORTING phase now
-    assert market.getReportingState() == testFixture.constants.ROUND2_REPORTING()
+    assert market.getReportingState() == testFixture.contracts['Constants'].ROUND2_REPORTING()
 
-def proceedToForking(testFixture, market, makeReport, designatedDisputer, round1Disputer, reporter, reportOutcomes, designatedDisputeOutcomes, round1Reporter, round1ReportOutcomes, round1ReportDisputeOutcomes, round2ReportOutcomes):
-    market = testFixture.binaryMarket
-    universe = testFixture.universe
+def proceedToForking(testFixture, universe, market, makeReport, designatedDisputer, round1Disputer, reporter, reportOutcomes, designatedDisputeOutcomes, round1Reporter, round1ReportOutcomes, round1ReportDisputeOutcomes, round2ReportOutcomes):
     reputationToken = testFixture.applySignature('ReputationToken', universe.getReputationToken())
 
     # Proceed to the ROUND2 REPORTING phase
-    if (market.getReportingState() != testFixture.constants.ROUND2_REPORTING()):
-        proceedToRound2Reporting(testFixture, market, makeReport, designatedDisputer, round1Disputer, reportOutcomes, designatedDisputeOutcomes, round1Reporter, round1ReportOutcomes, round1ReportDisputeOutcomes)
+    if (market.getReportingState() != testFixture.contracts['Constants'].ROUND2_REPORTING()):
+        proceedToRound2Reporting(testFixture, universe, market, makeReport, designatedDisputer, round1Disputer, reportOutcomes, designatedDisputeOutcomes, round1Reporter, round1ReportOutcomes, round1ReportDisputeOutcomes)
 
     reportingWindow = testFixture.applySignature('ReportingWindow', market.getReportingWindow())
 
@@ -97,14 +93,13 @@ def proceedToForking(testFixture, market, makeReport, designatedDisputer, round1
 
     # To progress into the LAST DISPUTE phase we move time forward
     testFixture.chain.head_state.timestamp = reportingWindow.getDisputeStartTime() + 1
-    assert market.getReportingState() == testFixture.constants.LAST_DISPUTE()
+    assert market.getReportingState() == testFixture.contracts['Constants'].LAST_DISPUTE()
 
     # Making a dispute at this phase will progress the market into FORKING
     assert market.disputeRound2Reporters(sender=tester.k0)
-    assert market.getReportingState() == testFixture.constants.FORKING()
+    assert market.getReportingState() == testFixture.contracts['Constants'].FORKING()
 
-def finalizeForkingMarket(reportingFixture, market, finalizeByMigration, yesMigratorAddress, yesMigratorKey, noMigratorAddress1, noMigratorKey1, noMigratorAddress2, noMigratorKey2, round1ReportOutcomes, secondReportOutcomes):
-    universe = reportingFixture.universe
+def finalizeForkingMarket(reportingFixture, universe, market, finalizeByMigration, yesMigratorAddress, yesMigratorKey, noMigratorAddress1, noMigratorKey1, noMigratorAddress2, noMigratorKey2, round1ReportOutcomes, secondReportOutcomes):
     reputationToken = reportingFixture.applySignature('ReputationToken', universe.getReputationToken())
 
     # The universe forks and there is now a universe where NO and YES are the respective outcomes of each
@@ -152,5 +147,5 @@ def finalizeForkingMarket(reportingFixture, market, finalizeByMigration, yesMigr
     assert market.tryFinalize()
 
     # The market is now finalized
-    assert market.getReportingState() == reportingFixture.constants.FINALIZED()
+    assert market.getReportingState() == reportingFixture.contracts['Constants'].FINALIZED()
     assert market.getFinalWinningReportingToken() == winningTokenAddress

--- a/tests/solidity_test_helpers/CashWrapperHelper.sol
+++ b/tests/solidity_test_helpers/CashWrapperHelper.sol
@@ -5,13 +5,7 @@ import 'trading/ICash.sol';
 
 
 contract CashWrapperHelper is CashAutoConverter {
-    function toCashFunction(uint256 _balance) public convertToAndFromCash payable returns (bool) {
-        ICash _cash = ICash(controller.lookup("Cash"));
-        require(_cash.balanceOf(msg.sender) == _balance);
-        return true;
-    }
-
-    function toETHFunction() public convertToAndFromCash returns (bool) {
+    function toEthFunction() public convertToAndFromCash returns (bool) {
         return true;
     }
 }

--- a/tests/solidity_test_helpers/ControllerUser.sol
+++ b/tests/solidity_test_helpers/ControllerUser.sol
@@ -1,19 +1,29 @@
 pragma solidity ^0.4.17;
 
-import 'Controlled.sol';
+import 'IControlled.sol';
+import 'IController.sol';
 import 'libraries/token/ERC20Basic.sol';
 
 
-contract ControllerUser is Controlled {
+contract ControllerUser is IControlled {
     address public updatedController;
+    address public suicideFundsDestination;
+    ERC20Basic[] public suicideFundsTokens;
+
+    function getController() public constant returns (IController) {
+        return IController(0);
+    }
 
     function setController(IController _controller) public returns(bool) {
-        super.setController(_controller);
         updatedController = _controller;
         return true;
     }
 
     function suicideFunds(address _destination, ERC20Basic[] _tokens) public returns (bool) {
-        return super.suicideFunds(_destination, _tokens);
+        suicideFundsDestination = _destination;
+        for (uint256 i; i < _tokens.length; ++i) {
+            suicideFundsTokens.push(_tokens[i]);
+        }
+        return true;
     }
 }

--- a/tests/solidity_test_helpers/TestControlled.sol
+++ b/tests/solidity_test_helpers/TestControlled.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.17;
+
+import 'Controlled.sol';
+
+
+contract TestControlled is Controlled {
+    function deposit() public payable { }
+}

--- a/tests/test_augur.py
+++ b/tests/test_augur.py
@@ -2,18 +2,43 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import raises
+from pytest import raises, fixture as pytest_fixture
 
 
-def test_augur_central_authority_for_cash(contractsFixture):
+def test_augur_central_authority_for_cash(augur, cash):
     # In testing we automatically provide the augur central authority contract with approval to transfer on behalf of the tester accounts
-    cash = contractsFixture.cash
     testers = [(getattr(tester, 'k%i' % x), getattr(tester, 'a%i' % x)) for x in range(0,10)]
     # We will prove this by having testers dust some of their Cash through a trusted request to the Augur contract
     for (testerKey, testerAddress) in testers:
         assert cash.depositEther(sender=testerKey, value=100)
         originalTesterBalance = cash.balanceOf(testerAddress)
         originalVoidBalance = cash.balanceOf(0)
-        assert contractsFixture.augur.trustedTransfer(cash.address, testerAddress, 0, 40)
+        assert augur.trustedTransfer(cash.address, testerAddress, 0, 40)
         assert cash.balanceOf(testerAddress) == originalTesterBalance - 40
         assert cash.balanceOf(0) == originalVoidBalance + 40
+
+@pytest_fixture(scope="session")
+def localSnapshot(fixture, controllerSnapshot):
+    fixture.resetToSnapshot(controllerSnapshot)
+    augur = fixture.uploadAndAddToController("../source/contracts/Augur.sol")
+    cash = fixture.uploadAndAddToController("../source/contracts/trading/Cash.sol")
+    augur.setController(fixture.contracts['Controller'].address)
+    cash.setController(fixture.contracts['Controller'].address)
+    fixture.approveCentralAuthority()
+    snapshot = fixture.createSnapshot()
+    snapshot["augur"] = augur
+    snapshot["cash"] = cash
+    return snapshot
+
+@pytest_fixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@pytest_fixture
+def augur(localFixture, localSnapshot):
+    return localSnapshot["augur"]
+
+@pytest_fixture
+def cash(localFixture, localSnapshot):
+    return localSnapshot["cash"]

--- a/tests/test_controlled.py
+++ b/tests/test_controlled.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+from ethereum.tools import tester
+from ethereum.tools.tester import TransactionFailed
+from pytest import raises, fixture as pytest_fixture
+from utils import bytesToHexString
+
+def test_getController(controlled):
+    assert controlled.getController() == bytesToHexString(tester.a0)
+
+def test_setController(controlled):
+    with raises(TransactionFailed):
+        controlled.setController(tester.a1, sender=tester.k1)
+    assert controlled.setController(tester.a1, sender=tester.k0)
+    assert controlled.getController() == bytesToHexString(tester.a1)
+    with raises(TransactionFailed):
+        controlled.setController(tester.a2, sender=tester.k0)
+
+def test_suicide(controlled, token, chain):
+    token.faucet(7, sender=tester.k0)
+    token.transfer(controlled.address, 7, sender=tester.k0)
+    assert token.balanceOf(tester.a0) == 0
+    assert token.balanceOf(controlled.address) == 7
+    controlled.deposit(value=11, sender=tester.k0)
+    assert chain.head_state.get_balance(controlled.address) == 11
+    startBalance = chain.head_state.get_balance(tester.a0)
+
+    with raises(TransactionFailed):
+        controlled.suicideFunds(tester.a1, [], sender=tester.k1)
+    with raises(TransactionFailed):
+        controlled.suicideFunds(tester.a1, [tester.a1], sender=tester.k0)
+    # self destructs so no return value
+    controlled.suicideFunds(tester.a0, [token.address], sender=tester.k0)
+
+    assert chain.head_state.get_balance(controlled.address) == 0
+    assert chain.head_state.get_balance(tester.a0) == startBalance + 11
+    assert token.balanceOf(controlled.address) == 0
+    assert token.balanceOf(tester.a0) == 7
+
+@pytest_fixture(scope="session")
+def localSnapshot(fixture, baseSnapshot):
+    fixture.resetToSnapshot(baseSnapshot)
+    fixture.upload('solidity_test_helpers/TestControlled.sol')
+    fixture.upload('solidity_test_helpers/StandardTokenHelper.sol')
+    return fixture.createSnapshot()
+
+@pytest_fixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@pytest_fixture
+def controlled(localFixture):
+    return localFixture.contracts['TestControlled']
+
+@pytest_fixture
+def token(localFixture):
+    return localFixture.contracts['StandardTokenHelper']
+
+@pytest_fixture
+def chain(localFixture):
+    return localFixture.chain

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2,7 +2,7 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import raises, fixture, mark
+from pytest import raises, fixture
 from utils import longToHexString, bytesToHexString
 
 def test_whitelists(controller):
@@ -32,16 +32,13 @@ def test_registry(controller, decentralizedController):
     with raises(TransactionFailed): decentralizedController.assertOnlySpecifiedCaller(tester.a2, key2, sender = tester.k0)
     with raises(TransactionFailed): controller.assertOnlySpecifiedCaller(tester.a2, key2, sender = tester.k2)
 
-def test_suicideTokens(contractsFixture, controller, decentralizedController, controllerUser):
-    legacyRepContract = contractsFixture.contracts['LegacyRepContract']
-    legacyRepContract.faucet(0)
-    legacyRepContract.transfer(controllerUser.address, 40 * 10**18)
-    with raises(TransactionFailed): controller.suicideFunds(controllerUser.address, tester.a0, [legacyRepContract.address], sender = tester.k2)
+def test_suicide(contractsFixture, controller, decentralizedController, controllerUser):
+    with raises(TransactionFailed): controller.suicideFunds(controllerUser.address, tester.a0, [tester.a2], sender = tester.k2)
     assert decentralizedController.owner() == bytesToHexString(tester.a0)
-    with raises(TransactionFailed): decentralizedController.suicideFunds(controllerUser.address, tester.a0, [legacyRepContract.address], sender = tester.k0)
-    assert controllerUser.setController(controller.address)
-    assert controller.suicideFunds(controllerUser.address, tester.a1, [legacyRepContract.address], sender = tester.k0)
-    assert legacyRepContract.balanceOf(tester.a1) == 40 * 10**18
+    with raises(TransactionFailed): decentralizedController.suicideFunds(controllerUser.address, tester.a0, [tester.a2], sender = tester.k0)
+    assert controller.suicideFunds(controllerUser.address, tester.a1, [tester.a2], sender = tester.k0)
+    assert controllerUser.suicideFundsDestination() == bytesToHexString(tester.a1)
+    assert controllerUser.suicideFundsTokens(0) == bytesToHexString(tester.a2)
 
 def test_updateController(controller, decentralizedController, controllerUser):
     with raises(TransactionFailed): controller.updateController(controllerUser.address, tester.a0, sender = tester.k2)
@@ -79,7 +76,7 @@ def test_switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed_failures(contro
 
 @fixture
 def controller(contractsFixture):
-    return contractsFixture.controller
+    return contractsFixture.contracts['Controller']
 
 @fixture
 def controllerUser(contractsFixture):

--- a/tests/trading/test_cancelOrder.py
+++ b/tests/trading/test_cancelOrder.py
@@ -8,9 +8,7 @@ from constants import BID, ASK, YES, NO
 
 tester.STARTGAS = long(6.7 * 10**6)
 
-def test_cancelBid(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_cancelBid(contractsFixture, cash, market):
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
     cancelOrder = contractsFixture.contracts['CancelOrder']
@@ -22,32 +20,29 @@ def test_cancelBid(contractsFixture):
     tradeGroupID = 42
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
-    creatorInitialETH = contractsFixture.utils.getETHBalance(tester.a1)
+    creatorInitialETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
     creatorInitialShares = yesShareToken.balanceOf(tester.a1)
     marketInitialCash = cash.balanceOf(market.address)
     marketInitialYesShares = yesShareToken.totalSupply()
     marketInitialNoShares = noShareToken.totalSupply()
     orderID = createOrder.publicCreateOrder(orderType, fxpAmount, fxpPrice, market.address, outcomeID, longTo32Bytes(0), longTo32Bytes(0), tradeGroupID, sender=tester.k1, value = fix('10000'))
-    
+
     assert orderID, "Order ID should be non-zero"
     _,_,owner,_,_,_,_,_ = ordersFetcher.getOrder(orderID)
     assert owner, "Order should have an owner"
 
-    assert contractsFixture.utils.getETHBalance(tester.a1) == creatorInitialETH - fix('0.6'), "ETH should be deducted from the creator balance"
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == creatorInitialETH - fix('0.6'), "ETH should be deducted from the creator balance"
 
     assert(cancelOrder.cancelOrder(orderID, orderType, market.address, outcomeID, sender=tester.k1) == 1), "cancelOrder should succeed"
 
     assert(ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]), "Canceled order elements should all be zero"
-    assert(creatorInitialETH == contractsFixture.utils.getETHBalance(tester.a1)), "Maker's ETH should be the same as before the order was placed"
+    assert(creatorInitialETH == contractsFixture.contracts['Utils'].getETHBalance(tester.a1)), "Maker's ETH should be the same as before the order was placed"
     assert(marketInitialCash == cash.balanceOf(market.address)), "Market's cash balance should be the same as before the order was placed"
     assert(creatorInitialShares == yesShareToken.balanceOf(tester.a1)), "Maker's shares should be unchanged"
     assert(marketInitialYesShares == yesShareToken.totalSupply()), "Market's yes shares should be unchanged"
     assert marketInitialNoShares == noShareToken.totalSupply(), "Market's no shares should be unchanged"
 
-def test_cancelAsk(contractsFixture):
-    contractsFixture.resetSnapshot()
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_cancelAsk(contractsFixture, cash, market):
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
     cancelOrder = contractsFixture.contracts['CancelOrder']
@@ -59,7 +54,7 @@ def test_cancelAsk(contractsFixture):
     tradeGroupID = 42
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
-    creatorInitialETH = contractsFixture.utils.getETHBalance(tester.a1)
+    creatorInitialETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
     creatorInitialShares = yesShareToken.balanceOf(tester.a1)
     marketInitialCash = cash.balanceOf(market.address)
     marketInitialYesShares = yesShareToken.totalSupply()
@@ -69,20 +64,18 @@ def test_cancelAsk(contractsFixture):
     _,_,owner,_,_,_,_,_ = ordersFetcher.getOrder(orderID)
     assert owner, "Order should have an owner"
 
-    assert contractsFixture.utils.getETHBalance(tester.a1) == creatorInitialETH - fix('0.4'), "ETH should be deducted from the creator balance"
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == creatorInitialETH - fix('0.4'), "ETH should be deducted from the creator balance"
 
     assert(cancelOrder.cancelOrder(orderID, orderType, market.address, outcomeID, sender=tester.k1) == 1), "cancelOrder should succeed"
 
     assert(ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]), "Canceled order elements should all be zero"
-    assert(creatorInitialETH == contractsFixture.utils.getETHBalance(tester.a1)), "Maker's ETH should be the same as before the order was placed"
+    assert(creatorInitialETH == contractsFixture.contracts['Utils'].getETHBalance(tester.a1)), "Maker's ETH should be the same as before the order was placed"
     assert(marketInitialCash == cash.balanceOf(market.address)), "Market's cash balance should be the same as before the order was placed"
     assert(creatorInitialShares == yesShareToken.balanceOf(tester.a1)), "Maker's shares should be unchanged"
     assert(marketInitialYesShares == yesShareToken.totalSupply()), "Market's yes shares should be unchanged"
     assert marketInitialNoShares == noShareToken.totalSupply(), "Market's no shares should be unchanged"
 
-def test_exceptions(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_exceptions(contractsFixture, cash, market):
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
     cancelOrder = contractsFixture.contracts['CancelOrder']

--- a/tests/trading/test_cash.py
+++ b/tests/trading/test_cash.py
@@ -7,15 +7,12 @@ from pytest import raises
 
 tester.GASPRICE = 0
 
-def test_init(contractsFixture):
-    cash = contractsFixture.cash
-
+def test_init(cash):
     assert cash.name() == 'Cash'
     assert cash.decimals() == 18
     assert cash.symbol() == 'CASH'
 
-def test_depositEther(contractsFixture):
-    cash = contractsFixture.cash
+def test_depositEther(contractsFixture, cash):
     startingUserEthBalance = contractsFixture.chain.head_state.get_balance(tester.a0)
     startingUserCashBalance = cash.balanceOf(tester.a0)
     startingCashEthBalance = contractsFixture.chain.head_state.get_balance(cash.address)
@@ -28,8 +25,7 @@ def test_depositEther(contractsFixture):
     assert startingCashEthBalance + 7 == contractsFixture.chain.head_state.get_balance(cash.address)
     assert startingCashSupply + 7 == cash.totalSupply()
 
-def test_withdrawEther(contractsFixture):
-    cash = contractsFixture.cash
+def test_withdrawEther(contractsFixture, cash):
     cash.depositEther(value = 7)
     startingUserEthBalance = contractsFixture.chain.head_state.get_balance(tester.a0)
     startingUserCashBalance = cash.balanceOf(tester.a0)
@@ -43,8 +39,7 @@ def test_withdrawEther(contractsFixture):
     assert startingCashEthBalance - 5 == contractsFixture.chain.head_state.get_balance(cash.address)
     assert startingCashSupply - 5 == cash.totalSupply()
 
-def test_withdrawEther_failures(contractsFixture):
-    cash = contractsFixture.cash
+def test_withdrawEther_failures(contractsFixture, cash):
     cash.depositEther(value = 7)
 
     with raises(TransactionFailed):
@@ -58,8 +53,7 @@ def test_withdrawEther_failures(contractsFixture):
     with raises(TransactionFailed):
         cash.withdrawEther(5)
 
-def test_transfer(contractsFixture):
-    cash = contractsFixture.cash
+def test_transfer(contractsFixture, cash):
     cash.depositEther(value = 7, sender = tester.k0)
     startingBalance0 = cash.balanceOf(tester.a0)
     startingBalance1 = cash.balanceOf(tester.a1)
@@ -82,8 +76,7 @@ def test_transfer(contractsFixture):
         { "_event_type": "Transfer", "from": '0x'+tester.a0.encode("hex"), "to": '0x'+tester.a1.encode("hex"), "value": 0L },
     ]
 
-def test_transfer_failures(contractsFixture):
-    cash = contractsFixture.cash
+def test_transfer_failures(contractsFixture, cash):
     cash.depositEther(value = 7, sender = tester.k0)
 
     with raises(TransactionFailed):
@@ -91,8 +84,7 @@ def test_transfer_failures(contractsFixture):
     with raises(TransactionFailed):
         cash.transfer(tester.a1, 5, sender = tester.k2)
 
-def test_approve(contractsFixture):
-    cash = contractsFixture.cash
+def test_approve(contractsFixture, cash):
     cash.depositEther(value = 7, sender = tester.k0)
     logs = []
     contractsFixture.chain.head_state.log_listeners.append(lambda x: logs.append(cash.translator.listen(x)))
@@ -107,8 +99,7 @@ def test_approve(contractsFixture):
         { "_event_type": "Approval", "owner": '0x'+tester.a0.encode("hex"), "spender": '0x'+tester.a1.encode("hex"), "value": 2**256L-1L }
     ]
 
-def test_transferFrom(contractsFixture):
-    cash = contractsFixture.cash
+def test_transferFrom(contractsFixture, cash):
     cash.depositEther(value = 7, sender = tester.k0)
     cash.approve(tester.a1, 10, sender = tester.k0)
     startingBalance0 = cash.balanceOf(tester.a0)
@@ -124,8 +115,7 @@ def test_transferFrom(contractsFixture):
     assert startingSupply == cash.totalSupply()
     assert logs == [ { "_event_type": "Transfer", "from": '0x'+tester.a0.encode("hex"), "to": '0x'+tester.a2.encode("hex"), "value": 5 } ]
 
-def test_transferFrom_failures(contractsFixture):
-    cash = contractsFixture.cash
+def test_transferFrom_failures(contractsFixture, cash):
     cash.depositEther(value = 7, sender = tester.k0)
     cash.approve(tester.a1, 10, sender = tester.k0)
 
@@ -134,14 +124,10 @@ def test_transferFrom_failures(contractsFixture):
     with raises(TransactionFailed):
         cash.transferFrom(tester.a0, tester.a1, 5, sender = tester.k2)
 
-def test_setController_failure(contractsFixture):
-    cash = contractsFixture.cash
-
+def test_setController_failure(contractsFixture, cash):
     with raises(TransactionFailed):
         cash.setController(tester.a1, sender = tester.k1)
 
-def test_suicideFunds_failure(contractsFixture):
-    cash = contractsFixture.cash
-
+def test_suicideFunds_failure(contractsFixture, cash):
     with raises(TransactionFailed):
         cash.suicideFunds(tester.a1, [], sender = tester.k1)

--- a/tests/trading/test_claimProceeds.py
+++ b/tests/trading/test_claimProceeds.py
@@ -13,38 +13,36 @@ def captureLog(contract, logs, message):
     if not translated: return
     logs.append(translated)
 
-def acquireLongShares(contractsFixture, market, outcome, amount, approvalAddress, sender):
+def acquireLongShares(kitchenSinkFixture, cash, market, outcome, amount, approvalAddress, sender):
     if amount == 0: return
 
-    cash = contractsFixture.cash
-    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(outcome))
-    completeSets = contractsFixture.contracts['CompleteSets']
-    createOrder = contractsFixture.contracts['CreateOrder']
-    fillOrder = contractsFixture.contracts['FillOrder']
+    shareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(outcome))
+    completeSets = kitchenSinkFixture.contracts['CompleteSets']
+    createOrder = kitchenSinkFixture.contracts['CreateOrder']
+    fillOrder = kitchenSinkFixture.contracts['FillOrder']
     cost = amount * market.getNumTicks()
 
     assert completeSets.publicBuyCompleteSets(market.address, amount, sender = sender, value = cost)
     assert shareToken.approve(approvalAddress, amount, sender = sender)
     for otherOutcome in range(0, market.getNumberOfOutcomes()):
         if otherOutcome == outcome: continue
-        otherShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(otherOutcome))
+        otherShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(otherOutcome))
         assert otherShareToken.transfer(0, amount, sender = sender)
 
-def acquireShortShareSet(contractsFixture, market, outcome, amount, approvalAddress, sender):
+def acquireShortShareSet(kitchenSinkFixture, cash, market, outcome, amount, approvalAddress, sender):
     if amount == 0: return
     cost = amount * market.getNumTicks()
 
-    cash = contractsFixture.cash
-    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(outcome))
-    completeSets = contractsFixture.contracts['CompleteSets']
-    createOrder = contractsFixture.contracts['CreateOrder']
-    fillOrder = contractsFixture.contracts['FillOrder']
+    shareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(outcome))
+    completeSets = kitchenSinkFixture.contracts['CompleteSets']
+    createOrder = kitchenSinkFixture.contracts['CreateOrder']
+    fillOrder = kitchenSinkFixture.contracts['FillOrder']
 
     assert completeSets.publicBuyCompleteSets(market.address, amount, sender = sender, value = cost)
     assert shareToken.transfer(0, amount, sender = sender)
     for otherOutcome in range(0, market.getNumberOfOutcomes()):
         if otherOutcome == outcome: continue
-        otherShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(otherOutcome))
+        otherShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(otherOutcome))
         assert otherShareToken.approve(approvalAddress, amount, sender = sender)
 
 def finalizeMarket(fixture, market, payoutNumerators):
@@ -59,10 +57,9 @@ def finalizeMarket(fixture, market, payoutNumerators):
     # set timestamp to 3 days later (waiting period)
     fixture.chain.head_state.timestamp += long(timedelta(days = 3, seconds = 1).total_seconds())
 
-def test_helpers(contractsFixture):
-    market = contractsFixture.scalarMarket
-    claimProceeds = contractsFixture.contracts['ClaimProceeds']
-    finalizeMarket(contractsFixture, market, [0,40*10**18])
+def test_helpers(kitchenSinkFixture, market):
+    claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
+    finalizeMarket(kitchenSinkFixture, market, [0,40*10**18])
 
     assert claimProceeds.calculateCreatorFee(market.address, fix('3')) == fix('0.03')
     assert claimProceeds.calculateReportingFee(market.address, fix('5')) == fix('0.0005')
@@ -74,13 +71,10 @@ def test_helpers(contractsFixture):
     assert creatorShare == 13.0 * market.getNumTicks() * .01
     assert shareholderShare == 13.0 * market.getNumTicks() * 0.9899
 
-def test_redeem_shares_in_binary_market(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
-    universe = contractsFixture.universe
-    claimProceeds = contractsFixture.contracts['ClaimProceeds']
-    yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
-    noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
+def test_redeem_shares_in_binary_market(kitchenSinkFixture, universe, cash, market):
+    claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
+    yesShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(YES))
+    noShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(NO))
     expectedValue = 1 * market.getNumTicks()
     expectedSettlementFees = expectedValue * 0.0101
     expectedPayout = long(expectedValue - expectedSettlementFees)
@@ -88,37 +82,34 @@ def test_redeem_shares_in_binary_market(contractsFixture):
     assert universe.getOpenInterestInAttoEth() == 0
 
     # get YES shares with a1
-    acquireLongShares(contractsFixture, market, YES, 1, claimProceeds.address, sender = tester.k1)
+    acquireLongShares(kitchenSinkFixture, cash, market, YES, 1, claimProceeds.address, sender = tester.k1)
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
     # get NO shares with a2
-    acquireShortShareSet(contractsFixture, market, YES, 1, claimProceeds.address, sender = tester.k2)
+    acquireShortShareSet(kitchenSinkFixture, cash, market, YES, 1, claimProceeds.address, sender = tester.k2)
     assert universe.getOpenInterestInAttoEth() == 2 * market.getNumTicks()
-    finalizeMarket(contractsFixture, market, [0,10**18])
+    finalizeMarket(kitchenSinkFixture, market, [0,10**18])
 
     # redeem shares with a1
-    initialLongHolderETH = contractsFixture.utils.getETHBalance(tester.a1)
+    initialLongHolderETH = kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a1)
     claimProceeds.claimProceeds(market.address, sender = tester.k1)
     # redeem shares with a2
-    initialShortHolderETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialShortHolderETH = kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a2)
     claimProceeds.claimProceeds(market.address, sender = tester.k2)
 
     # assert a1 ends up with cash (minus fees) and a2 does not
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialLongHolderETH + expectedPayout
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialShortHolderETH
+    assert kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a1) == initialLongHolderETH + expectedPayout
+    assert kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a2) == initialShortHolderETH
     assert yesShareToken.balanceOf(tester.a1) == 0
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 0
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks() # The corresponding share for tester2's complete set has not been redeemed
 
-def test_redeem_shares_in_categorical_market(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.categoricalMarket
-    universe = contractsFixture.universe
-    claimProceeds = contractsFixture.contracts['ClaimProceeds']
-    shareToken2 = contractsFixture.applySignature('ShareToken', market.getShareToken(2))
-    shareToken1 = contractsFixture.applySignature('ShareToken', market.getShareToken(1))
-    shareToken0 = contractsFixture.applySignature('ShareToken', market.getShareToken(0))
+def test_redeem_shares_in_categorical_market(kitchenSinkFixture, universe, cash, market):
+    claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
+    shareToken2 = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(2))
+    shareToken1 = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(1))
+    shareToken0 = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(0))
     expectedValue = 1 * market.getNumTicks()
     expectedSettlementFees = expectedValue * 0.0101
     expectedPayout = long(expectedValue - expectedSettlementFees)
@@ -126,23 +117,23 @@ def test_redeem_shares_in_categorical_market(contractsFixture):
     assert universe.getOpenInterestInAttoEth() == 0
 
     # get long shares with a1
-    acquireLongShares(contractsFixture, market, 2, 1, claimProceeds.address, sender = tester.k1)
+    acquireLongShares(kitchenSinkFixture, cash, market, 2, 1, claimProceeds.address, sender = tester.k1)
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
     # get short shares with a2
-    acquireShortShareSet(contractsFixture, market, 2, 1, claimProceeds.address, sender = tester.k2)
+    acquireShortShareSet(kitchenSinkFixture, cash, market, 2, 1, claimProceeds.address, sender = tester.k2)
     assert universe.getOpenInterestInAttoEth() == 2 * market.getNumTicks()
-    finalizeMarket(contractsFixture, market, [0, 0, 3 * 10 ** 17])
+    finalizeMarket(kitchenSinkFixture, market, [0, 0, 3 * 10 ** 17])
 
     # redeem shares with a1
-    initialLongHolderETH = contractsFixture.utils.getETHBalance(tester.a1)
+    initialLongHolderETH = kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a1)
     claimProceeds.claimProceeds(market.address, sender = tester.k1)
     # redeem shares with a2
-    initialShortHolderETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialShortHolderETH = kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a2)
     claimProceeds.claimProceeds(market.address, sender = tester.k2)
 
     # assert a1 ends up with cash (minus fees) and a2 does not
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialLongHolderETH + expectedPayout
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialShortHolderETH
+    assert kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a1) == initialLongHolderETH + expectedPayout
+    assert kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a2) == initialShortHolderETH
     assert shareToken2.balanceOf(tester.a1) == 0
     assert shareToken2.balanceOf(tester.a2) == 0
     assert shareToken1.balanceOf(tester.a1) == 0
@@ -151,13 +142,10 @@ def test_redeem_shares_in_categorical_market(contractsFixture):
     assert shareToken0.balanceOf(tester.a2) == 0
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
-def test_redeem_shares_in_scalar_market(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.scalarMarket
-    universe = contractsFixture.universe
-    claimProceeds = contractsFixture.contracts['ClaimProceeds']
-    yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
-    noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
+def test_redeem_shares_in_scalar_market(kitchenSinkFixture, universe, cash, market):
+    claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
+    yesShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(YES))
+    noShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(NO))
     expectedValue = 1 * market.getNumTicks()
     expectedSettlementFees = expectedValue * 0.0101
     expectedPayout = long(expectedValue - expectedSettlementFees)
@@ -165,44 +153,42 @@ def test_redeem_shares_in_scalar_market(contractsFixture):
     assert universe.getOpenInterestInAttoEth() == 0
 
     # get YES shares with a1
-    acquireLongShares(contractsFixture, market, YES, 1, claimProceeds.address, sender = tester.k1)
+    acquireLongShares(kitchenSinkFixture, cash, market, YES, 1, claimProceeds.address, sender = tester.k1)
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
     # get NO shares with a2
-    acquireShortShareSet(contractsFixture, market, YES, 1, claimProceeds.address, sender = tester.k2)
+    acquireShortShareSet(kitchenSinkFixture, cash, market, YES, 1, claimProceeds.address, sender = tester.k2)
     assert universe.getOpenInterestInAttoEth() == 2 * market.getNumTicks()
-    finalizeMarket(contractsFixture, market, [10**19, 3*10**19])
+    finalizeMarket(kitchenSinkFixture, market, [10**19, 3*10**19])
 
     # redeem shares with a1
-    initialLongHolderETH = contractsFixture.utils.getETHBalance(tester.a1)
+    initialLongHolderETH = kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a1)
     claimProceeds.claimProceeds(market.address, sender = tester.k1)
     # redeem shares with a2
-    initialShortHolderETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialShortHolderETH = kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a2)
     claimProceeds.claimProceeds(market.address, sender = tester.k2)
 
     # assert a1 ends up with cash (minus fees) and a2 does not
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialLongHolderETH + expectedPayout * 3 / 4
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialShortHolderETH + expectedPayout * 1 / 4
+    assert kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a1) == initialLongHolderETH + expectedPayout * 3 / 4
+    assert kitchenSinkFixture.contracts['Utils'].getETHBalance(tester.a2) == initialShortHolderETH + expectedPayout * 1 / 4
     assert yesShareToken.balanceOf(tester.a1) == 0
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 0
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
-def test_reedem_failure(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
-    claimProceeds = contractsFixture.contracts['ClaimProceeds']
+def test_reedem_failure(kitchenSinkFixture, cash, market):
+    claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
 
     # get YES shares with a1
-    acquireLongShares(contractsFixture, market, YES, 1, claimProceeds.address, sender = tester.k1)
+    acquireLongShares(kitchenSinkFixture, cash, market, YES, 1, claimProceeds.address, sender = tester.k1)
     # get NO shares with a2
-    acquireShortShareSet(contractsFixture, market, YES, 1, claimProceeds.address, sender = tester.k2)
+    acquireShortShareSet(kitchenSinkFixture, cash, market, YES, 1, claimProceeds.address, sender = tester.k2)
     # set timestamp to after market end
-    contractsFixture.chain.head_state.timestamp = market.getEndTime() + 1
+    kitchenSinkFixture.chain.head_state.timestamp = market.getEndTime() + 1
     # have tester.a0 subimt designated report (75% high, 25% low, range -10*10^18 to 30*10^18)
-    contractsFixture.designatedReport(market, [0, 10**18], tester.k0)
+    kitchenSinkFixture.designatedReport(market, [0, 10**18], tester.k0)
     # set timestamp to after designated dispute end
-    contractsFixture.chain.head_state.timestamp = market.getDesignatedReportDisputeDueTimestamp() + 1
+    kitchenSinkFixture.chain.head_state.timestamp = market.getDesignatedReportDisputeDueTimestamp() + 1
 
     # market not finalized
     with raises(TransactionFailed):
@@ -214,6 +200,6 @@ def test_reedem_failure(contractsFixture):
         claimProceeds.claimProceeds(market.address, sender = tester.k1)
 
     # set timestamp to 3 days later (waiting period)
-    contractsFixture.chain.head_state.timestamp += long(timedelta(days = 3, seconds = 1).total_seconds())
+    kitchenSinkFixture.chain.head_state.timestamp += long(timedelta(days = 3, seconds = 1).total_seconds())
     # validate that everything else is OK
     assert claimProceeds.claimProceeds(market.address, sender = tester.k1)

--- a/tests/trading/test_claimProceeds.py
+++ b/tests/trading/test_claimProceeds.py
@@ -57,7 +57,8 @@ def finalizeMarket(fixture, market, payoutNumerators):
     # set timestamp to 3 days later (waiting period)
     fixture.chain.head_state.timestamp += long(timedelta(days = 3, seconds = 1).total_seconds())
 
-def test_helpers(kitchenSinkFixture, market):
+def test_helpers(kitchenSinkFixture, scalarMarket):
+    market = scalarMarket
     claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
     finalizeMarket(kitchenSinkFixture, market, [0,40*10**18])
 
@@ -105,7 +106,8 @@ def test_redeem_shares_in_binary_market(kitchenSinkFixture, universe, cash, mark
     assert noShareToken.balanceOf(tester.a2) == 0
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks() # The corresponding share for tester2's complete set has not been redeemed
 
-def test_redeem_shares_in_categorical_market(kitchenSinkFixture, universe, cash, market):
+def test_redeem_shares_in_categorical_market(kitchenSinkFixture, universe, cash, categoricalMarket):
+    market = categoricalMarket
     claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
     shareToken2 = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(2))
     shareToken1 = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(1))
@@ -142,7 +144,8 @@ def test_redeem_shares_in_categorical_market(kitchenSinkFixture, universe, cash,
     assert shareToken0.balanceOf(tester.a2) == 0
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
-def test_redeem_shares_in_scalar_market(kitchenSinkFixture, universe, cash, market):
+def test_redeem_shares_in_scalar_market(kitchenSinkFixture, universe, cash, scalarMarket):
+    market = scalarMarket
     claimProceeds = kitchenSinkFixture.contracts['ClaimProceeds']
     yesShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = kitchenSinkFixture.applySignature('ShareToken', market.getShareToken(NO))

--- a/tests/trading/test_completeSets.py
+++ b/tests/trading/test_completeSets.py
@@ -6,10 +6,7 @@ from pytest import raises
 from utils import bytesToHexString, fix, captureFilteredLogs
 from constants import YES, NO
 
-def test_publicBuyCompleteSets(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_publicBuyCompleteSets(contractsFixture, universe, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     orders = contractsFixture.contracts['Orders']
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
@@ -43,10 +40,7 @@ def test_publicBuyCompleteSets(contractsFixture):
     assert noShareToken.totalSupply() == 10, "Increase in yes shares purchased for this market should be 10"
     assert universe.getOpenInterestInAttoEth() == cost, "Open interest in the universe increases by the cost in ETH of the sets purchased"
 
-def test_publicBuyCompleteSets_failure(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_publicBuyCompleteSets_failure(contractsFixture, universe, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     orders = contractsFixture.contracts['Orders']
 
@@ -61,10 +55,7 @@ def test_publicBuyCompleteSets_failure(contractsFixture):
     with raises(TransactionFailed):
         completeSets.publicBuyCompleteSets(tester.a1, amount, sender=tester.k1, value=cost)
 
-def test_publicSellCompleteSets(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_publicSellCompleteSets(contractsFixture, universe, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     orders = contractsFixture.contracts['Orders']
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
@@ -83,8 +74,8 @@ def test_publicSellCompleteSets(contractsFixture):
     completeSets.publicBuyCompleteSets(market.address, 10, sender = tester.k1, value = cost)
     assert universe.getOpenInterestInAttoEth() == 10 * market.getNumTicks()
     captureFilteredLogs(contractsFixture.chain.head_state, orders, logs)
-    initialTester1ETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialTester0ETH = contractsFixture.utils.getETHBalance(tester.a0)
+    initialTester1ETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialTester0ETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a0)
     result = completeSets.publicSellCompleteSets(market.address, 9, sender=tester.k1)
     assert universe.getOpenInterestInAttoEth() == 1 * market.getNumTicks()
 
@@ -103,15 +94,12 @@ def test_publicSellCompleteSets(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 1, "Should have 1 share of outcome no"
     assert yesShareToken.totalSupply() == 1
     assert noShareToken.totalSupply() == 1
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialTester1ETH + fix('8.9091')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialTester1ETH + fix('8.9091')
     assert cash.balanceOf(market.address) == fix('1')
-    assert contractsFixture.utils.getETHBalance(tester.a0) == initialTester0ETH + fix('0.09')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a0) == initialTester0ETH + fix('0.09')
     assert cash.balanceOf(market.getReportingWindow()) == fix('0.0009')
 
-def test_publicSellCompleteSets_failure(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_publicSellCompleteSets_failure(contractsFixture, universe, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     orders = contractsFixture.contracts['Orders']
 

--- a/tests/trading/test_createOrder.py
+++ b/tests/trading/test_createOrder.py
@@ -18,10 +18,8 @@ BETTER_ORDER_ID = 5
 WORSE_ORDER_ID = 6
 GAS_PRICE = 7
 
-def test_publicCreateOrder_bid(contractsFixture):
+def test_publicCreateOrder_bid(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
 
@@ -37,9 +35,7 @@ def test_publicCreateOrder_bid(contractsFixture):
     assert betterOrderId == bytearray(32)
     assert worseOrderId == bytearray(32)
 
-def test_publicCreateOrder_ask(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_publicCreateOrder_ask(contractsFixture, cash, market):
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
 
@@ -55,9 +51,7 @@ def test_publicCreateOrder_ask(contractsFixture):
     assert worseOrderId == bytearray(32)
     assert cash.balanceOf(market.address) == 10**18 - 10**17
 
-def test_publicCreateOrder_bid2(contractsFixture):
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_publicCreateOrder_bid2(contractsFixture, cash, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
@@ -71,7 +65,7 @@ def test_publicCreateOrder_bid2(contractsFixture):
 
     marketInitialCash = cash.balanceOf(market.address)
     captureFilteredLogs(contractsFixture.chain.head_state, orders, logs)
-    creatorInitialETH = contractsFixture.utils.getETHBalance(tester.a1)
+    creatorInitialETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
     orderID = createOrder.publicCreateOrder(orderType, amount, fxpPrice, market.address, outcome, longTo32Bytes(0), longTo32Bytes(0), tradeGroupID, sender=tester.k1, value = fix('10'))
     assert orderID != bytearray(32), "Order ID should be non-zero"
 
@@ -82,7 +76,7 @@ def test_publicCreateOrder_bid2(contractsFixture):
     assert tokensEscrowed == 0.6 * 10**18
     assert sharesEscrowed == 0
     assert cash.balanceOf(tester.a1) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == creatorInitialETH - long(0.6 * 10**18)
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == creatorInitialETH - long(0.6 * 10**18)
     assert cash.balanceOf(market.address) - marketInitialCash == 0.6 * 10**18
     assert logs == [
         {
@@ -100,10 +94,7 @@ def test_publicCreateOrder_bid2(contractsFixture):
         }
     ]
 
-def test_createOrder_failure(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_createOrder_failure(contractsFixture, universe, cash, market):
     orders = contractsFixture.contracts['Orders']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
@@ -147,10 +138,7 @@ def test_createOrder_failure(contractsFixture):
     with raises(TransactionFailed):
         createOrder.publicCreateOrder(ASK, 1, fix('0.6'), market.address, YES, longTo32Bytes(0), longTo32Bytes(0), 42, sender=tester.k1)
 
-def test_ask_withPartialShares(contractsFixture):
-    universe = contractsFixture.universe
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_ask_withPartialShares(contractsFixture, universe, cash, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']

--- a/tests/trading/test_decreaseTradingFee.py
+++ b/tests/trading/test_decreaseTradingFee.py
@@ -5,8 +5,7 @@ from ethereum.tools.tester import TransactionFailed
 from pytest import raises
 from utils import fix, bytesToHexString
 
-def test_decrease_trading_fee_success(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_decrease_trading_fee_success(market):
     originalFee = market.getMarketCreatorSettlementFeeInAttoethPerEth()
     assert market.getOwner() == bytesToHexString(tester.a0)
     newFee = originalFee -1
@@ -16,8 +15,7 @@ def test_decrease_trading_fee_success(contractsFixture):
 
     assert newFee == newFee
 
-def test_decrease_trading_fee_failure(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_decrease_trading_fee_failure(market):
     originalFee = market.getMarketCreatorSettlementFeeInAttoethPerEth()
 
     with raises(TransactionFailed):

--- a/tests/trading/test_fillOrder.py
+++ b/tests/trading/test_fillOrder.py
@@ -5,18 +5,16 @@ from utils import fix, bytesToHexString, captureFilteredLogs, longTo32Bytes, lon
 from constants import BID, ASK, YES, NO
 
 
-def test_publicFillOrder_bid(contractsFixture):
-    cash = contractsFixture.cash
+def test_publicFillOrder_bid(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     tradeGroupID = 42
     logs = []
 
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     creatorCost = fix('2', '0.6')
     fillerCost = fix('2', '0.4')
 
@@ -53,23 +51,21 @@ def test_publicFillOrder_bid(contractsFixture):
         },
     ]
 
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH - creatorCost
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH - fillerCost
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH - creatorCost
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH - fillerCost
     assert ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == 0
 
-def test_publicFillOrder_ask(contractsFixture):
-    cash = contractsFixture.cash
+def test_publicFillOrder_ask(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     tradeGroupID = 42
     logs = []
 
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     creatorCost = fix('2', '0.4')
     fillerCost = fix('2', '0.6')
 
@@ -106,24 +102,23 @@ def test_publicFillOrder_ask(contractsFixture):
         },
     ]
 
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH - creatorCost
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH - fillerCost
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH - creatorCost
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH - fillerCost
     assert ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == 0
 
-def test_publicFillOrder_bid_scalar(contractsFixture):
-    cash = contractsFixture.cash
+def test_publicFillOrder_bid_scalar(contractsFixture, cash, scalarMarket):
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     # We're testing the scalar market because it has a different numTicks than 10**18 as the other do. In particular it's numTicks is 40*18**18
-    market = contractsFixture.scalarMarket
+    market = scalarMarket
     tradeGroupID = 42
     logs = []
 
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     creatorCost = fix('2', '0.6')
     fillerCost = fix('2', '39.4')
 
@@ -160,7 +155,7 @@ def test_publicFillOrder_bid_scalar(contractsFixture):
         },
     ]
 
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH - creatorCost
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH - fillerCost
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH - creatorCost
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH - fillerCost
     assert ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == 0

--- a/tests/trading/test_orders.py
+++ b/tests/trading/test_orders.py
@@ -2,7 +2,7 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import mark, lazy_fixture, raises
+from pytest import mark, raises
 from utils import fix, bytesToHexString, longTo32Bytes, longToHexString
 from constants import BID, ASK, YES, NO
 
@@ -17,8 +17,7 @@ BETTER_ORDER_ID = 5
 WORSE_ORDER_ID = 6
 GAS_PRICE = 7
 
-def test_walkOrderList_bids(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_walkOrderList_bids(contractsFixture, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     outcomeID = 1
@@ -117,8 +116,7 @@ def test_walkOrderList_bids(contractsFixture):
     assert(orders.removeOrder(orderId6) == 1), "Remove order 6"
     assert(orders.removeOrder(orderId7) == 1), "Remove order 7"
 
-def test_walkOrderList_asks(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_walkOrderList_asks(contractsFixture, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     outcomeID = 1
@@ -215,25 +213,23 @@ def test_walkOrderList_asks(contractsFixture):
     assert(orders.removeOrder(orderId9) == 1), "Remove order 9"
     assert(orders.removeOrder(orderId10) == 1), "Remove order 10"
 
-@mark.parametrize('where, orderType, hints, fixture', [
-    ('best', BID, True, lazy_fixture('contractsFixture')),
-    ('middle', BID, True, lazy_fixture('contractsFixture')),
-    ('worst', BID, True, lazy_fixture('contractsFixture')),
-    ('best', BID, False, lazy_fixture('contractsFixture')),
-    ('middle', BID, False, lazy_fixture('contractsFixture')),
-    ('worst', BID, False, lazy_fixture('contractsFixture')),
-    ('best', ASK, True, lazy_fixture('contractsFixture')),
-    ('middle', ASK, True, lazy_fixture('contractsFixture')),
-    ('worst', ASK, True, lazy_fixture('contractsFixture')),
-    ('best', ASK, False, lazy_fixture('contractsFixture')),
-    ('middle', ASK, False, lazy_fixture('contractsFixture')),
-    ('worst', ASK, False, lazy_fixture('contractsFixture')),
+@mark.parametrize('where, orderType, hints', [
+    ('best', BID, True),
+    ('middle', BID, True),
+    ('worst', BID, True),
+    ('best', BID, False),
+    ('middle', BID, False),
+    ('worst', BID, False),
+    ('best', ASK, True),
+    ('middle', ASK, True),
+    ('worst', ASK, True),
+    ('best', ASK, False),
+    ('middle', ASK, False),
+    ('worst', ASK, False),
 ])
-def test_orderBidSorting(where, orderType, hints, fixture):
-    print dir(fixture)
-    market = fixture.binaryMarket
-    orders = fixture.contracts['Orders']
-    ordersFetcher = fixture.contracts['OrdersFetcher']
+def test_orderBidSorting(where, orderType, hints, contractsFixture, market):
+    orders = contractsFixture.contracts['Orders']
+    ordersFetcher = contractsFixture.contracts['OrdersFetcher']
 
     # setup pre-existing orders
     worstPrice = fix('0.60') if orderType == BID else fix('0.66')
@@ -270,8 +266,7 @@ def test_orderBidSorting(where, orderType, hints, fixture):
     assert orders.getBestOrderId(orderType, market.address, YES) == insertedOrder if where == 'best' else bestOrderId
     assert orders.getWorstOrderId(orderType, market.address, YES) == insertedOrder if where == 'worst' else worstOrderId
 
-def test_saveOrder(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_saveOrder(contractsFixture, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
 
@@ -295,8 +290,7 @@ def test_saveOrder(contractsFixture):
     assert(orders.removeOrder(orderId1) == 1), "Remove order 1"
     assert(orders.removeOrder(orderId2) == 1), "Remove order 2"
 
-def test_fillOrder(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_fillOrder(contractsFixture, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
 
@@ -324,8 +318,7 @@ def test_fillOrder(contractsFixture):
     assert(orders.fillOrder(orderId2, 0, fix('2')) == 1), "fillOrder wasn't executed successfully"
     assert(ordersFetcher.getOrder(orderId2) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]), "getOrder for order2 didn't return the expected data array"
 
-def test_removeOrder(contractsFixture):
-    market = contractsFixture.binaryMarket
+def test_removeOrder(contractsFixture, market):
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
 

--- a/tests/trading/test_orders_fuzzy.py
+++ b/tests/trading/test_orders_fuzzy.py
@@ -1,7 +1,7 @@
 from ethereum.tools import tester
 import numpy as np
 from os import getenv
-from pytest import fixture, mark, lazy_fixture
+from pytest import fixture, mark
 from utils import fix
 from constants import BID, ASK
 
@@ -59,10 +59,8 @@ GAS_PRICE = 7
     (BID, 100, True,   1.0),
     (ASK, 100, True,   1.0),
 ])
-def test_randomSorting(orderType, numOrders, withBoundingOrders, deadOrderProbability, contractsFixture):
+def test_randomSorting(market, orderType, numOrders, withBoundingOrders, deadOrderProbability, contractsFixture):
     print("Order sorting tests (orderType=" + str(orderType) + ", numOrders=" + str(numOrders) + ", withBoundingOrders=" + str(withBoundingOrders) + ", deadOrderProbability=" + str(deadOrderProbability) + ")")
-    contractsFixture.resetSnapshot()
-    market = contractsFixture.binaryMarket
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     outcomeID = 1

--- a/tests/trading/test_shareToken.py
+++ b/tests/trading/test_shareToken.py
@@ -5,16 +5,16 @@ from ethereum.tools.tester import TransactionFailed
 from pytest import raises
 from utils import captureFilteredLogs, bytesToHexString
 
-def test_init(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_init(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
 
     # FIXME: enable after we fix Delegated contract string handling
     # assert shareToken.name() == "Shares", "currency name"
     assert shareToken.decimals() == 0, "number of decimals"
     # assert shareToken.symbol() == "SHARE", "currency symbol"
 
-def test_createShares(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_createShares(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
     initialTotalSupply = shareToken.totalSupply()
     initialBalance = shareToken.balanceOf(tester.a1)
 
@@ -26,8 +26,8 @@ def test_createShares(contractsFixture):
     assert shareToken.totalSupply() - initialTotalSupply == 7, "Total supply increase should equal the number of tokens created"
     assert shareToken.balanceOf(tester.a1) - initialBalance == 7, "Address 1 token balance increase should equal the number of tokens created"
 
-def test_destroyShares(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_destroyShares(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
     shareToken.createShares(tester.a1, 7, sender=tester.k0)
     initialTotalSupply = shareToken.totalSupply()
     initialBalance = shareToken.balanceOf(tester.a1)
@@ -40,8 +40,8 @@ def test_destroyShares(contractsFixture):
     assert initialTotalSupply - shareToken.totalSupply() == 7, "Total supply decrease should equal the number of tokens destroyed"
     assert initialBalance - shareToken.balanceOf(tester.a1) == 7, "Address 1 token balance decrease should equal the number of tokens destroyed"
 
-def test_transfer(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_transfer(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
     shareToken.createShares(tester.a0, 7, sender=tester.k0)
     initialTotalSupply = shareToken.totalSupply()
     initialBalance0 = shareToken.balanceOf(tester.a0)
@@ -72,8 +72,8 @@ def test_transfer(contractsFixture):
     assert(shareToken.totalSupply() == initialTotalSupply), "Total supply should be unchanged"
     assert(retval == 1), "transfer with 0 value should succeed"
 
-def test_approve(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_approve(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
     shareToken.createShares(tester.a0, 7, sender=tester.k0)
     logs = []
 
@@ -99,24 +99,24 @@ def test_approve(contractsFixture):
         },
     ]
 
-def test_transferFrom(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_transferFrom(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
     shareToken.createShares(tester.a1, 7, sender=tester.k0)
 
     with raises(TransactionFailed):
         shareToken.transferFrom(tester.a0, tester.a1, 7, sender=tester.k1)
 
-def test_setController(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_setController(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
     newController = contractsFixture.upload('../source/contracts/Controller.sol', 'newController')
     newController.setValue('shareToken'.ljust(32, '\x00'), shareToken.address)
 
-    contractsFixture.controller.updateController(shareToken.address, newController.address, sender=tester.k0)
+    contractsFixture.contracts['Controller'].updateController(shareToken.address, newController.address, sender=tester.k0)
     with raises(TransactionFailed):
         shareToken.setController(tester.a0, sender=tester.k0)
 
-def test_suicideFunds(contractsFixture):
-    shareToken = contractsFixture.applySignature('ShareToken', contractsFixture.binaryMarket.getShareToken())
+def test_suicideFunds(contractsFixture, market):
+    shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken())
 
     with raises(TransactionFailed):
         shareToken.suicideFunds(tester.a0, [], sender=tester.k0)

--- a/tests/trading/test_trade.py
+++ b/tests/trading/test_trade.py
@@ -5,14 +5,12 @@ from utils import longTo32Bytes, longToHexString, bytesToHexString, fix, capture
 from constants import BID, ASK, YES, NO
 
 
-def test_one_bid_on_books_buy_full_order(contractsFixture):
-    cash = contractsFixture.cash
+def test_one_bid_on_books_buy_full_order(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     tradeGroupID = 42L
     logs = []
 
@@ -53,14 +51,12 @@ def test_one_bid_on_books_buy_full_order(contractsFixture):
     assert fillOrderID == longTo32Bytes(1)
 
 
-def test_one_bid_on_books_buy_partial_order(contractsFixture):
-    cash = contractsFixture.cash
+def test_one_bid_on_books_buy_partial_order(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     tradeGroupID = 42L
     logs = []
 
@@ -100,14 +96,12 @@ def test_one_bid_on_books_buy_partial_order(contractsFixture):
     assert fillOrderID == longTo32Bytes(1)
 
 
-def test_one_bid_on_books_buy_excess_order(contractsFixture):
-    cash = contractsFixture.cash
+def test_one_bid_on_books_buy_excess_order(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     tradeGroupID = 42L
     logs = []
 
@@ -159,15 +153,13 @@ def test_one_bid_on_books_buy_excess_order(contractsFixture):
     assert ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert ordersFetcher.getOrder(fillOrderID) == [1, fix('0.6'), bytesToHexString(tester.a2), fix('1', '0.4'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
 
-def test_two_bids_on_books_buy_both(contractsFixture):
-    cash = contractsFixture.cash
+def test_two_bids_on_books_buy_both(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order 1
@@ -230,15 +222,13 @@ def test_two_bids_on_books_buy_both(contractsFixture):
     assert ordersFetcher.getOrder(orderID2) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == longTo32Bytes(1)
 
-def test_two_bids_on_books_buy_full_and_partial(contractsFixture):
-    cash = contractsFixture.cash
+def test_two_bids_on_books_buy_full_and_partial(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order 1
@@ -302,15 +292,13 @@ def test_two_bids_on_books_buy_full_and_partial(contractsFixture):
     assert ordersFetcher.getOrder(orderID2) == [4, fix('0.6'), bytesToHexString(tester.a3), fix('4', '0.6'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == longTo32Bytes(1)
 
-def test_two_bids_on_books_buy_one_full_then_create(contractsFixture):
-    cash = contractsFixture.cash
+def test_two_bids_on_books_buy_one_full_then_create(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order 1
@@ -364,8 +352,7 @@ def test_two_bids_on_books_buy_one_full_then_create(contractsFixture):
     assert ordersFetcher.getOrder(orderID2) == [7, fix('0.5'), bytesToHexString(tester.a3), fix('7', '0.5'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert ordersFetcher.getOrder(fillOrderID) == [3, fix('0.6'), bytesToHexString(tester.a2), fix('3', '0.4'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
 
-def test_one_ask_on_books_buy_full_order(contractsFixture):
-    cash = contractsFixture.cash
+def test_one_ask_on_books_buy_full_order(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
@@ -373,7 +360,6 @@ def test_one_ask_on_books_buy_full_order(contractsFixture):
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order
@@ -412,15 +398,13 @@ def test_one_ask_on_books_buy_full_order(contractsFixture):
     assert ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == longTo32Bytes(1)
 
-def test_one_ask_on_books_buy_partial_order(contractsFixture):
-    cash = contractsFixture.cash
+def test_one_ask_on_books_buy_partial_order(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order
@@ -460,15 +444,13 @@ def test_one_ask_on_books_buy_partial_order(contractsFixture):
     assert ordersFetcher.getOrder(orderID) == [5, fix('0.6'), bytesToHexString(tester.a1), fix('5', '0.4'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == longTo32Bytes(1)
 
-def test_one_ask_on_books_buy_excess_order(contractsFixture):
-    cash = contractsFixture.cash
+def test_one_ask_on_books_buy_excess_order(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order
@@ -519,15 +501,13 @@ def test_one_ask_on_books_buy_excess_order(contractsFixture):
     assert ordersFetcher.getOrder(orderID) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert ordersFetcher.getOrder(fillOrderID) == [3, fix('0.6'), bytesToHexString(tester.a2), fix('3', '0.6'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
 
-def test_two_asks_on_books_buy_both(contractsFixture):
-    cash = contractsFixture.cash
+def test_two_asks_on_books_buy_both(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order 1
@@ -591,15 +571,13 @@ def test_two_asks_on_books_buy_both(contractsFixture):
     assert ordersFetcher.getOrder(orderID2) == [0, 0, longToHexString(0), 0, 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == longTo32Bytes(1)
 
-def test_two_asks_on_books_buy_full_and_partial(contractsFixture):
-    cash = contractsFixture.cash
+def test_two_asks_on_books_buy_full_and_partial(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order 1
@@ -663,15 +641,13 @@ def test_two_asks_on_books_buy_full_and_partial(contractsFixture):
     assert ordersFetcher.getOrder(orderID2) == [4, fix('0.6'), bytesToHexString(tester.a3), fix('4', '0.4'), 0, longTo32Bytes(0), longTo32Bytes(0), 0]
     assert fillOrderID == longTo32Bytes(1)
 
-def test_two_asks_on_books_buy_one_full_then_create(contractsFixture):
-    cash = contractsFixture.cash
+def test_two_asks_on_books_buy_one_full_then_create(contractsFixture, cash, market):
     createOrder = contractsFixture.contracts['CreateOrder']
     trade = contractsFixture.contracts['Trade']
     fillOrder = contractsFixture.contracts['FillOrder']
     orders = contractsFixture.contracts['Orders']
     tradeGroupID = 42L
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
-    market = contractsFixture.binaryMarket
     logs = []
 
     # create order 1

--- a/tests/trading/test_tradingEscapeHatch.py
+++ b/tests/trading/test_tradingEscapeHatch.py
@@ -7,21 +7,19 @@ from utils import fix, longTo32Bytes
 from constants import LONG, YES, NO
 
 
-def test_escapeHatch(contractsFixture):
-    controller = contractsFixture.controller
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
+def test_escapeHatch(contractsFixture, cash, market):
+    controller = contractsFixture.contracts['Controller']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
     trade = contractsFixture.contracts['Trade']
     tradingEscapeHatch = contractsFixture.contracts['TradingEscapeHatch']
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
-    initialTester1ETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialTester2ETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialTester1ETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialTester2ETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
 
     # create order with cash
-    orderID = createOrder.publicCreateOrder(contractsFixture.constants.ASK(), 1, fix('0.6'), market.address, YES, longTo32Bytes(0), longTo32Bytes(0), 42, sender=tester.k1, value=fix('0.4'))
+    orderID = createOrder.publicCreateOrder(contractsFixture.contracts['Constants'].ASK(), 1, fix('0.6'), market.address, YES, longTo32Bytes(0), longTo32Bytes(0), 42, sender=tester.k1, value=fix('0.4'))
     assert orderID
 
     # fill order with cash using on-chain matcher
@@ -40,8 +38,8 @@ def test_escapeHatch(contractsFixture):
     assert tradingEscapeHatch.claimSharesInUpdate(market.address, sender = tester.k2)
 
     # assert final values (should be a zero sum game)
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialTester1ETH
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialTester2ETH
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialTester1ETH
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialTester2ETH
     assert cash.balanceOf(market.address) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert yesShareToken.balanceOf(tester.a2) == 0

--- a/tests/trading/test_wcl.py
+++ b/tests/trading/test_wcl.py
@@ -2,19 +2,17 @@
 
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
-from pytest import raises, mark, lazy_fixture
+from pytest import raises, mark
 from utils import longTo32Bytes, fix
 from constants import BID, ASK, YES, NO
 
 tester.STARTGAS = long(6.7 * 10**6)
 
 
-def test_create_ask_with_shares_fill_with_shares(contractsFixture):
+def test_create_ask_with_shares_fill_with_shares(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -37,8 +35,8 @@ def test_create_ask_with_shares_fill_with_shares(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 12
 
     # 3. fill ASK order for YES with NO shares
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     assert noShareToken.approve(fillOrder.address, 12, sender = tester.k2)
     fxpAmountRemaining = fillOrder.publicFillOrder(askOrderID, 12, sender = tester.k2)
     creatorFee = completeSetFees * 0.6
@@ -46,19 +44,17 @@ def test_create_ask_with_shares_fill_with_shares(contractsFixture):
     assert fxpAmountRemaining == 0
     assert cash.balanceOf(tester.a1) == 0
     assert cash.balanceOf(tester.a2) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH + fix('12', '0.6') - long(creatorFee)
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH + fix('12', '0.4') - long(fillerFee)
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH + fix('12', '0.6') - long(creatorFee)
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH + fix('12', '0.4') - long(fillerFee)
     assert yesShareToken.balanceOf(tester.a1) == 0
     assert yesShareToken.balanceOf(tester.a2) == 12
     assert noShareToken.balanceOf(tester.a1) == 12
     assert noShareToken.balanceOf(tester.a2) == 0
 
-def test_create_ask_with_shares_fill_with_cash(contractsFixture):
+def test_create_ask_with_shares_fill_with_cash(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -78,25 +74,23 @@ def test_create_ask_with_shares_fill_with_cash(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 12
 
     # 3. fill ASK order for YES with cash
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     fxpAmountRemaining = fillOrder.publicFillOrder(askOrderID, 12, sender = tester.k2, value=fix('12', '0.6'))
     assert fxpAmountRemaining == 0
     assert cash.balanceOf(tester.a1) == 0
     assert cash.balanceOf(tester.a2) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH + fix('12', '0.6')
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH - fix('12', '0.6')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH + fix('12', '0.6')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH - fix('12', '0.6')
     assert yesShareToken.balanceOf(tester.a1) == 0
     assert yesShareToken.balanceOf(tester.a2) == 12
     assert noShareToken.balanceOf(tester.a1) == 12
     assert noShareToken.balanceOf(tester.a2) == 0
 
-def test_create_ask_with_cash_fill_with_shares(contractsFixture):
+def test_create_ask_with_cash_fill_with_shares(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -115,26 +109,24 @@ def test_create_ask_with_cash_fill_with_shares(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 0
 
     # 3. fill ASK order for YES with shares of NO
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     assert noShareToken.approve(fillOrder.address, 12, sender = tester.k2)
     amountRemaining = fillOrder.publicFillOrder(askOrderID, 12, sender = tester.k2)
     assert amountRemaining == 0, "Amount remaining should be 0"
     assert cash.balanceOf(tester.a1) == 0
     assert cash.balanceOf(tester.a2) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH + fix('12', '0.4')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH + fix('12', '0.4')
     assert yesShareToken.balanceOf(tester.a1) == 0
     assert yesShareToken.balanceOf(tester.a2) == 12
     assert noShareToken.balanceOf(tester.a1) == 12
     assert noShareToken.balanceOf(tester.a2) == 0
 
-def test_create_ask_with_cash_fill_with_cash(contractsFixture):
+def test_create_ask_with_cash_fill_with_cash(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -156,12 +148,10 @@ def test_create_ask_with_cash_fill_with_cash(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 12
     assert noShareToken.balanceOf(tester.a2) == 0
 
-def test_create_bid_with_shares_fill_with_shares(contractsFixture):
+def test_create_bid_with_shares_fill_with_shares(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -186,8 +176,8 @@ def test_create_bid_with_shares_fill_with_shares(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 0
 
     # 3. fill BID order for YES with shares of YES
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     assert yesShareToken.approve(fillOrder.address, 12, sender = tester.k2)
     leftoverInOrder = fillOrder.publicFillOrder(orderID, 12, sender = tester.k2)
     creatorFee = completeSetFees * 0.4
@@ -197,19 +187,17 @@ def test_create_bid_with_shares_fill_with_shares(contractsFixture):
     fillerPayment = fix('12', '0.6') - fillerFee
     assert cash.balanceOf(tester.a1) == 0
     assert cash.balanceOf(tester.a2) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH + long(creatorPayment)
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH + long(fillerPayment)
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH + long(creatorPayment)
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH + long(fillerPayment)
     assert yesShareToken.balanceOf(tester.a1) == 12
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 12
 
-def test_create_bid_with_shares_fill_with_cash(contractsFixture):
+def test_create_bid_with_shares_fill_with_cash(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -229,25 +217,23 @@ def test_create_bid_with_shares_fill_with_cash(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 0
 
     # 3. fill BID order for YES with cash
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     leftoverInOrder = fillOrder.publicFillOrder(orderID, 12, sender = tester.k2, value=fix('12', '0.4'))
     assert leftoverInOrder == 0
     assert cash.balanceOf(tester.a1) == 0
     assert cash.balanceOf(tester.a2) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH + fix('12', '0.4')
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH - fix('12', '0.4')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH + fix('12', '0.4')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH - fix('12', '0.4')
     assert yesShareToken.balanceOf(tester.a1) == 12
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 12
 
-def test_create_bid_with_cash_fill_with_shares(contractsFixture):
+def test_create_bid_with_cash_fill_with_shares(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -266,26 +252,24 @@ def test_create_bid_with_cash_fill_with_shares(contractsFixture):
     assert noShareToken.balanceOf(tester.a1) == 0
 
     # 3. fill BID order for YES with shares of YES
-    initialMakerETH = contractsFixture.utils.getETHBalance(tester.a1)
-    initialFillerETH = contractsFixture.utils.getETHBalance(tester.a2)
+    initialMakerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a1)
+    initialFillerETH = contractsFixture.contracts['Utils'].getETHBalance(tester.a2)
     assert yesShareToken.approve(fillOrder.address, 12, sender = tester.k2)
     leftoverInOrder = fillOrder.publicFillOrder(orderID, 12, sender = tester.k2)
     assert leftoverInOrder == 0
     assert cash.balanceOf(tester.a1) == 0
     assert cash.balanceOf(tester.a2) == 0
-    assert contractsFixture.utils.getETHBalance(tester.a1) == initialMakerETH
-    assert contractsFixture.utils.getETHBalance(tester.a2) == initialFillerETH + fix('12', '0.6')
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a1) == initialMakerETH
+    assert contractsFixture.contracts['Utils'].getETHBalance(tester.a2) == initialFillerETH + fix('12', '0.6')
     assert yesShareToken.balanceOf(tester.a1) == 12
     assert yesShareToken.balanceOf(tester.a2) == 0
     assert noShareToken.balanceOf(tester.a1) == 0
     assert noShareToken.balanceOf(tester.a2) == 12
 
-def test_create_bid_with_cash_fill_with_cash(contractsFixture):
+def test_create_bid_with_cash_fill_with_cash(contractsFixture, cash, market):
     completeSets = contractsFixture.contracts['CompleteSets']
     createOrder = contractsFixture.contracts['CreateOrder']
     fillOrder = contractsFixture.contracts['FillOrder']
-    cash = contractsFixture.cash
-    market = contractsFixture.binaryMarket
 
     yesShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(YES))
     noShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(NO))
@@ -312,39 +296,40 @@ import contextlib
 def placeholder_context():
     yield None
 
-@mark.parametrize('type,outcome,displayPrice,orderSize,creatorYesShares,creatorNoShares,creatorCost,fillSize,fillerYesShares,fillerNoShares,fillerCost,expectMakeRaise,expectedMakerYesShares,expectedMakerNoShares,expectedMakerPayout,expectTakeRaise,expectedFillerYesShares,expectedFillerNoShares,expectedFillerPayout,fixture', [
+@mark.parametrize('type,outcome,displayPrice,orderSize,creatorYesShares,creatorNoShares,creatorCost,fillSize,fillerYesShares,fillerNoShares,fillerCost,expectMakeRaise,expectedMakerYesShares,expectedMakerNoShares,expectedMakerPayout,expectTakeRaise,expectedFillerYesShares,expectedFillerNoShares,expectedFillerPayout', [
     # | ------ ORDER ------ |   | ------ CREATOR START ------ |   | ------ FILLER START ------ |  | ------- CREATOR FINISH -------  |    | ------- FILLER FINISH -------  |
     #   type,outcome,  price,   size,    yes,     no,   cost,   size,    yes,     no,   cost,  raise,    yes,     no,      pay,    raise,    yes,     no,      pay,
-    (    BID,    YES,  '0.6',  '12',    '0',    '0', '7.2',  '12',  '12',    '0',    '0',  False,  '12',    '0',       '0',    False,    '0',    '0',    '7.2', lazy_fixture('contractsFixture')),
-    (    BID,    YES,  '0.6',  '12',    '0',  '12',    '0',  '12',  '12',    '0',    '0',  False,    '0',    '0','4.75152',    False,    '0',    '0','7.12728', lazy_fixture('contractsFixture')),
-    (    BID,    YES,  '0.6',  '12',    '0',    '0', '7.2',  '12',    '0',    '0', '4.8',  False,  '12',    '0',       '0',    False,    '0',  '12',       '0', lazy_fixture('contractsFixture')),
-    (    BID,    YES,  '0.6',  '12',    '0',  '12',    '0',  '12',    '0',    '0', '4.8',  False,    '0',    '0',    '4.8',    False,    '0',  '12',       '0', lazy_fixture('contractsFixture')),
+    (    BID,    YES,  '0.6',  '12',    '0',    '0', '7.2',  '12',  '12',    '0',    '0',  False,  '12',    '0',       '0',    False,    '0',    '0',    '7.2'),
+    (    BID,    YES,  '0.6',  '12',    '0',  '12',    '0',  '12',  '12',    '0',    '0',  False,    '0',    '0','4.75152',    False,    '0',    '0','7.12728'),
+    (    BID,    YES,  '0.6',  '12',    '0',    '0', '7.2',  '12',    '0',    '0', '4.8',  False,  '12',    '0',       '0',    False,    '0',  '12',       '0'),
+    (    BID,    YES,  '0.6',  '12',    '0',  '12',    '0',  '12',    '0',    '0', '4.8',  False,    '0',    '0',    '4.8',    False,    '0',  '12',       '0'),
 
-    (    BID,    YES,  '0.6',  '24',    '0',  '12', '7.2',  '24',  '24',    '0',    '0',  False,  '12',    '0','4.75152',    False,    '0',    '0','14.32728', lazy_fixture('contractsFixture')),
-    (    BID,    YES,  '0.6',  '24',    '0',  '12', '7.2',  '24',    '0',    '0', '9.6',  False,  '12',    '0',    '4.8',    False,    '0',  '24',       '0', lazy_fixture('contractsFixture')),
-    (    BID,    YES,  '0.6',  '24',    '0',    '0', '14.4',  '24',  '12',    '0', '4.8',  False,  '24',    '0',       '0',    False,    '0',  '12',    '7.2', lazy_fixture('contractsFixture')),
-    (    BID,    YES,  '0.6',  '24',    '0',  '24',    '0',  '24',  '12',    '0', '4.8',  False,    '0',    '0','9.55152',    False,    '0',  '12','7.12728', lazy_fixture('contractsFixture')),
+    (    BID,    YES,  '0.6',  '24',    '0',  '12', '7.2',  '24',  '24',    '0',    '0',  False,  '12',    '0','4.75152',    False,    '0',    '0','14.32728'),
+    (    BID,    YES,  '0.6',  '24',    '0',  '12', '7.2',  '24',    '0',    '0', '9.6',  False,  '12',    '0',    '4.8',    False,    '0',  '24',       '0'),
+    (    BID,    YES,  '0.6',  '24',    '0',    '0', '14.4',  '24',  '12',    '0', '4.8',  False,  '24',    '0',       '0',    False,    '0',  '12',    '7.2'),
+    (    BID,    YES,  '0.6',  '24',    '0',  '24',    '0',  '24',  '12',    '0', '4.8',  False,    '0',    '0','9.55152',    False,    '0',  '12','7.12728'),
 
-    (    BID,    YES,  '0.6',  '24',    '0',  '12', '7.2',  '24',  '12',    '0', '4.8',  False,  '12',    '0','4.75152',    False,    '0',  '12','7.12728', lazy_fixture('contractsFixture')),
+    (    BID,    YES,  '0.6',  '24',    '0',  '12', '7.2',  '24',  '12',    '0', '4.8',  False,  '12',    '0','4.75152',    False,    '0',  '12','7.12728'),
 
-    (    BID,     NO,  '0.6',  '12',    '0',    '0', '7.2',  '12',    '0',  '12',    '0',  False,    '0',  '12',       '0',    False,    '0',    '0',    '7.2', lazy_fixture('contractsFixture')),
-    (    BID,     NO,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',  '12',    '0',  False,    '0',    '0','4.75152',    False,    '0',    '0','7.12728', lazy_fixture('contractsFixture')),
-    (    BID,     NO,  '0.6',  '12',    '0',    '0', '7.2',  '12',    '0',    '0', '4.8',  False,    '0',  '12',       '0',    False,  '12',    '0',       '0', lazy_fixture('contractsFixture')),
-    (    BID,     NO,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',    '0', '4.8',  False,    '0',    '0',    '4.8',    False,  '12',    '0',       '0', lazy_fixture('contractsFixture')),
+    (    BID,     NO,  '0.6',  '12',    '0',    '0', '7.2',  '12',    '0',  '12',    '0',  False,    '0',  '12',       '0',    False,    '0',    '0',    '7.2'),
+    (    BID,     NO,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',  '12',    '0',  False,    '0',    '0','4.75152',    False,    '0',    '0','7.12728'),
+    (    BID,     NO,  '0.6',  '12',    '0',    '0', '7.2',  '12',    '0',    '0', '4.8',  False,    '0',  '12',       '0',    False,  '12',    '0',       '0'),
+    (    BID,     NO,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',    '0', '4.8',  False,    '0',    '0',    '4.8',    False,  '12',    '0',       '0'),
 
-    (    BID,     NO,  '0.6',  '24',  '12',    '0', '7.2',  '24',    '0',  '24',    '0',  False,    '0',  '12','4.75152',    False,    '0',    '0','14.32728', lazy_fixture('contractsFixture')),
-    (    BID,     NO,  '0.6',  '24',  '12',    '0', '7.2',  '24',    '0',    '0', '9.6',  False,    '0',  '12',    '4.8',    False,  '24',    '0',       '0', lazy_fixture('contractsFixture')),
-    (    BID,     NO,  '0.6',  '24',    '0',    '0', '14.4',  '24',    '0',  '12', '4.8',  False,    '0',  '24',       '0',    False,  '12',    '0',    '7.2', lazy_fixture('contractsFixture')),
-    (    BID,     NO,  '0.6',  '24',  '24',    '0',    '0',  '24',    '0',  '12', '4.8',  False,    '0',    '0','9.55152',    False,  '12',    '0','7.12728', lazy_fixture('contractsFixture')),
+    (    BID,     NO,  '0.6',  '24',  '12',    '0', '7.2',  '24',    '0',  '24',    '0',  False,    '0',  '12','4.75152',    False,    '0',    '0','14.32728'),
+    (    BID,     NO,  '0.6',  '24',  '12',    '0', '7.2',  '24',    '0',    '0', '9.6',  False,    '0',  '12',    '4.8',    False,  '24',    '0',       '0'),
+    (    BID,     NO,  '0.6',  '24',    '0',    '0', '14.4',  '24',    '0',  '12', '4.8',  False,    '0',  '24',       '0',    False,  '12',    '0',    '7.2'),
+    (    BID,     NO,  '0.6',  '24',  '24',    '0',    '0',  '24',    '0',  '12', '4.8',  False,    '0',    '0','9.55152',    False,  '12',    '0','7.12728'),
 
-    (    BID,     NO,  '0.6',  '24',  '12',    '0', '7.2',  '24',    '0',  '12', '4.8',  False,    '0',  '12','4.75152',    False,  '12',    '0','7.12728', lazy_fixture('contractsFixture')),
+    (    BID,     NO,  '0.6',  '24',  '12',    '0', '7.2',  '24',    '0',  '12', '4.8',  False,    '0',  '12','4.75152',    False,  '12',    '0','7.12728'),
 
-    (    ASK,    YES,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',    '0', '7.2',  False,    '0',    '0',    '7.2',    False,  '12',    '0',       '0', lazy_fixture('contractsFixture')),
-    (    ASK,    YES,  '0.6',  '12',    '0',    '0', '4.8',  '12',    '0',    '0', '7.2',  False,    '0',  '12',       '0',    False,  '12',    '0',       '0', lazy_fixture('contractsFixture')),
-    (    ASK,    YES,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',  '12',    '0',  False,    '0',    '0','7.12728',    False,    '0',    '0','4.75152', lazy_fixture('contractsFixture')),
-    (    ASK,    YES,  '0.6',  '12',    '0',    '0', '4.8',  '12',    '0',  '12',    '0',  False,    '0',  '12',       '0',    False,    '0',    '0',    '4.8', lazy_fixture('contractsFixture')),
+    (    ASK,    YES,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',    '0', '7.2',  False,    '0',    '0',    '7.2',    False,  '12',    '0',       '0'),
+    (    ASK,    YES,  '0.6',  '12',    '0',    '0', '4.8',  '12',    '0',    '0', '7.2',  False,    '0',  '12',       '0',    False,  '12',    '0',       '0'),
+    (    ASK,    YES,  '0.6',  '12',  '12',    '0',    '0',  '12',    '0',  '12',    '0',  False,    '0',    '0','7.12728',    False,    '0',    '0','4.75152'),
+    (    ASK,    YES,  '0.6',  '12',    '0',    '0', '4.8',  '12',    '0',  '12',    '0',  False,    '0',  '12',       '0',    False,    '0',    '0',    '4.8'),
 ])
-def test_parametrized(type, outcome, displayPrice, orderSize, creatorYesShares, creatorNoShares, creatorCost, fillSize, fillerYesShares, fillerNoShares, fillerCost, expectMakeRaise, expectedMakerYesShares, expectedMakerNoShares, expectedMakerPayout, expectTakeRaise, expectedFillerYesShares, expectedFillerNoShares, expectedFillerPayout, fixture):
+def test_parametrized(type, outcome, displayPrice, orderSize, creatorYesShares, creatorNoShares, creatorCost, fillSize, fillerYesShares, fillerNoShares, fillerCost, expectMakeRaise, expectedMakerYesShares, expectedMakerNoShares, expectedMakerPayout, expectTakeRaise, expectedFillerYesShares, expectedFillerNoShares, expectedFillerPayout, contractsFixture, cash, market):
+    fixture = contractsFixture
     # TODO: add support for wider range markets
     displayPrice = fix(displayPrice)
     assert displayPrice < 10**18
@@ -373,8 +358,6 @@ def test_parametrized(type, outcome, displayPrice, orderSize, creatorYesShares, 
     fillerAddress = tester.a2
     fillerKey = tester.k2
 
-    cash = fixture.cash
-    market = fixture.binaryMarket
     completeSets = fixture.contracts['CompleteSets']
     createOrder = fixture.contracts['CreateOrder']
     fillOrder = fixture.contracts['FillOrder']
@@ -400,16 +383,16 @@ def test_parametrized(type, outcome, displayPrice, orderSize, creatorYesShares, 
     # fill order
     acquireShares(YES, fillerYesShares, fillOrder.address, sender = fillerKey)
     acquireShares(NO, fillerNoShares, fillOrder.address, sender = fillerKey)
-    initialMakerETH = fixture.utils.getETHBalance(creatorAddress)
-    initialFillerETH = fixture.utils.getETHBalance(fillerAddress)
+    initialMakerETH = fixture.contracts['Utils'].getETHBalance(creatorAddress)
+    initialFillerETH = fixture.contracts['Utils'].getETHBalance(fillerAddress)
     with raises(TransactionFailed) if expectTakeRaise else placeholder_context():
         fillOrder.publicFillOrder(orderID, fillSize, sender = fillerKey, value = fillerCost)
 
     # assert final state
     assert cash.balanceOf(creatorAddress) == 0
     assert cash.balanceOf(fillerAddress) == 0
-    assert fixture.utils.getETHBalance(creatorAddress) == initialMakerETH + expectedMakerPayout
-    assert fixture.utils.getETHBalance(fillerAddress) == initialFillerETH + expectedFillerPayout - fillerCost
+    assert fixture.contracts['Utils'].getETHBalance(creatorAddress) == initialMakerETH + expectedMakerPayout
+    assert fixture.contracts['Utils'].getETHBalance(fillerAddress) == initialFillerETH + expectedFillerPayout - fillerCost
     assert yesShareToken.balanceOf(creatorAddress) == expectedMakerYesShares
     assert yesShareToken.balanceOf(fillerAddress) == expectedFillerYesShares
     assert noShareToken.balanceOf(creatorAddress) == expectedMakerNoShares

--- a/tests/trading/test_wcl_fuzzy.py
+++ b/tests/trading/test_wcl_fuzzy.py
@@ -22,13 +22,10 @@ GAS_PRICE = 7
 
 # TODO: turn these into 24 parameterized tests rather than 3 tests that each execute 8 sub-tests
 
-def execute(contractsFixture, market, orderType, orderSize, orderPrice, orderOutcome, creatorLongShares, creatorShortShares, creatorTokens, fillerLongShares, fillerShortShares, fillerTokens, expectedMakerLongShares, expectedMakerShortShares, expectedMakerTokens, expectedFillerLongShares, expectedFillerShortShares, expectedFillerTokens):
-    contractsFixture.resetSnapshot()
-
+def execute(contractsFixture, universe, cash, market, orderType, orderSize, orderPrice, orderOutcome, creatorLongShares, creatorShortShares, creatorTokens, fillerLongShares, fillerShortShares, fillerTokens, expectedMakerLongShares, expectedMakerShortShares, expectedMakerTokens, expectedFillerLongShares, expectedFillerShortShares, expectedFillerTokens):
     def acquireLongShares(outcome, amount, approvalAddress, sender):
         if amount == 0: return
 
-        cash = contractsFixture.cash
         shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(outcome))
         completeSets = contractsFixture.contracts['CompleteSets']
         createOrder = contractsFixture.contracts['CreateOrder']
@@ -45,7 +42,6 @@ def execute(contractsFixture, market, orderType, orderSize, orderPrice, orderOut
     def acquireShortShareSet(outcome, amount, approvalAddress, sender):
         if amount == 0: return
 
-        cash = contractsFixture.cash
         shareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(outcome))
         completeSets = contractsFixture.contracts['CompleteSets']
         createOrder = contractsFixture.contracts['CreateOrder']
@@ -62,14 +58,12 @@ def execute(contractsFixture, market, orderType, orderSize, orderPrice, orderOut
     legacyRepContract = contractsFixture.contracts['LegacyRepContract']
     legacyRepContract.faucet(long(11 * 10**6 * 10**18))
     contractsFixture.chain.head_state.timestamp += 15000
-    universe = contractsFixture.universe
 
     # Get the reputation token for this universe and migrate legacy REP to it
     reputationToken = contractsFixture.applySignature('ReputationToken', universe.getReputationToken())
     legacyRepContract.approve(reputationToken.address, 11 * 10**6 * 10**18)
     reputationToken.migrateFromLegacyRepContract()
 
-    cash = contractsFixture.cash
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']
     createOrder = contractsFixture.contracts['CreateOrder']
@@ -112,7 +106,7 @@ def execute(contractsFixture, market, orderType, orderSize, orderPrice, orderOut
             assert shareToken.balanceOf(creatorAddress) == expectedMakerShortShares
             assert shareToken.balanceOf(fillerAddress) == expectedFillerShortShares
 
-def execute_bidOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
+def execute_bidOrder_tests(contractsFixture, universe, market, fxpAmount, fxpPrice):
     longCost = long(fxpAmount * fxpPrice / 10**18)
     shortCost = long(fxpAmount * (market.getNumTicks() - fxpPrice) / 10**18)
     completeSetFees = long(fxpAmount * market.getNumTicks() * fix('0.0101') / 10**18 / 10**18)
@@ -122,6 +116,7 @@ def execute_bidOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows cash, filler pays with cash"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = BID,
         orderSize = fxpAmount,
@@ -143,6 +138,7 @@ def execute_bidOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows shares, filler pays with shares"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = BID,
         orderSize = fxpAmount,
@@ -164,6 +160,7 @@ def execute_bidOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows cash, filler pays with shares"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = BID,
         orderSize = fxpAmount,
@@ -185,6 +182,7 @@ def execute_bidOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows shares, filler pays with cash"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = BID,
         orderSize = fxpAmount,
@@ -203,7 +201,7 @@ def execute_bidOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
         expectedFillerShortShares = fxpAmount,
         expectedFillerTokens = 0)
 
-def execute_askOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
+def execute_askOrder_tests(contractsFixture, universe, market, fxpAmount, fxpPrice):
     longCost = long(fxpAmount * fxpPrice / 10**18)
     shortCost = long(fxpAmount * (market.getNumTicks() - fxpPrice) / 10**18)
     completeSetFees = long(fxpAmount * market.getNumTicks() * fix('0.0101') / 10**18 / 10**18)
@@ -213,6 +211,7 @@ def execute_askOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows cash, filler pays with cash"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = ASK,
         orderSize = fxpAmount,
@@ -234,6 +233,7 @@ def execute_askOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows shares, filler pays with shares"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = ASK,
         orderSize = fxpAmount,
@@ -255,6 +255,7 @@ def execute_askOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows cash, filler pays with shares"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = ASK,
         orderSize = fxpAmount,
@@ -276,6 +277,7 @@ def execute_askOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
     print "creator escrows shares, filler pays with cash"
     execute(
         contractsFixture = contractsFixture,
+        universe = universe,
         market = market,
         orderType = ASK,
         orderSize = fxpAmount,
@@ -294,8 +296,7 @@ def execute_askOrder_tests(contractsFixture, market, fxpAmount, fxpPrice):
         expectedFillerShortShares = 0,
         expectedFillerTokens = 0)
 
-def test_binary(contractsFixture, randomAmount, randomNormalizedPrice):
-    market = contractsFixture.binaryMarket
+def test_binary(contractsFixture, market, randomAmount, randomNormalizedPrice):
     print 'Random amount: ' + str(randomAmount)
     print 'Random price: ' + str(randomNormalizedPrice)
     fxpAmount = fix(randomAmount)


### PR DESCRIPTION
Fixtures are now built up in a hierarchy.  This way, tests that don't require a lot of setup can run quickly by using a simple base fixture, while tests that require the kitchen sink can start with that as their base.  When running individual tests, this can greatly improve test turn around time if the tests you are iterating on are based on the base (only need minimal setup).  See `test_controlled.py` for an example, the tests run in under a second (including test setup time).

Most existing tests just use the kitchen sink snapshot which contains everything that `contractsFixture` used to contain and an alias has been created for it as contractsFixture and sessionFixture, though over time we should preference better names and more targeted fixtures.

In the process, I fixed the Controller tests to no longer test the implementation details of Controlled (what actually started me down this path) and added tests for Controlled.

Removed lazy_fixture, since it turns out we don't actually need it.  When I added it I didn't know how to have fixtures as part of parameterized tests.  I now do (someone else figured it out and I copied).

In general, I recommend following the patterns found in `test_controlled.py` rather than the pre-existing patterns.