### PR TITLE
Explicit flag to indicate that a token represents the invalid case and support in function signatures for it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
         "**/*.pyc": true
     },
     "python.linting.pylintEnabled": false,
+    "solidity.lintOnChange": false,
     "solidity.solidityRoot": "source/contracts"
 }

--- a/source/contracts/factories/ReportingTokenFactory.sol
+++ b/source/contracts/factories/ReportingTokenFactory.sol
@@ -8,10 +8,10 @@ import 'IController.sol';
 
 
 contract ReportingTokenFactory {
-    function createReportingToken(IController _controller, IMarket _market, uint256[] _payoutNumerators) public returns (IReportingToken) {
+    function createReportingToken(IController _controller, IMarket _market, uint256[] _payoutNumerators, bool _invalid) public returns (IReportingToken) {
         Delegator _delegator = new Delegator(_controller, "ReportingToken");
         IReportingToken _reportingToken = IReportingToken(_delegator);
-        _reportingToken.initialize(_market, _payoutNumerators);
+        _reportingToken.initialize(_market, _payoutNumerators, _invalid);
         return _reportingToken;
     }
 }

--- a/source/contracts/reporting/IMarket.sol
+++ b/source/contracts/reporting/IMarket.sol
@@ -30,7 +30,7 @@ contract IMarket is Typed, IOwnable {
 
     function initialize(IReportingWindow _reportingWindow, uint256 _endTime, uint8 _numOutcomes, uint256 _numTicks, uint256 _feePerEthInAttoeth, ICash _cash, address _creator, address _designatedReporterAddress) public payable returns (bool _success);
     function updateTentativeWinningPayoutDistributionHash(bytes32 _payoutDistributionHash) public returns (bool);
-    function derivePayoutDistributionHash(uint256[] _payoutNumerators) public view returns (bytes32);
+    function derivePayoutDistributionHash(uint256[] _payoutNumerators, bool _invalid) public view returns (bytes32);
     function designatedReport() public returns (bool);
     function getUniverse() public view returns (IUniverse);
     function getReportingWindow() public view returns (IReportingWindow);

--- a/source/contracts/reporting/IReportingToken.sol
+++ b/source/contracts/reporting/IReportingToken.sol
@@ -7,7 +7,7 @@ import 'reporting/IMarket.sol';
 
 
 contract IReportingToken is Typed, ERC20 {
-    function initialize(IMarket _market, uint256[] _payoutNumerators) public returns (bool);
+    function initialize(IMarket _market, uint256[] _payoutNumerators, bool _invalid) public returns (bool);
     function getMarket() public view returns (IMarket);
     function getPayoutNumerator(uint8 index) public view returns (uint256);
     function getPayoutDistributionHash() public view returns (bytes32);

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -142,12 +142,12 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
         return true;
     }
 
-    function disputeDesignatedReport(uint256[] _payoutNumerators, uint256 _attotokens) public triggersMigration returns (bool) {
+    function disputeDesignatedReport(uint256[] _payoutNumerators, uint256 _attotokens, bool _invalid) public triggersMigration returns (bool) {
         require(getReportingState() == ReportingState.DESIGNATED_DISPUTE);
         designatedReporterDisputeBondToken = DisputeBondTokenFactory(controller.lookup("DisputeBondTokenFactory")).createDisputeBondToken(controller, this, msg.sender, Reporting.designatedReporterDisputeBondAmount(), tentativeWinningPayoutDistributionHash);
         reportingWindow.getReputationToken().trustedTransfer(msg.sender, designatedReporterDisputeBondToken, Reporting.designatedReporterDisputeBondAmount());
         if (_attotokens > 0) {
-            IReportingToken _reportingToken = getReportingToken(_payoutNumerators);
+            IReportingToken _reportingToken = getReportingToken(_payoutNumerators, _invalid);
             _reportingToken.trustedBuy(msg.sender, _attotokens);
         } else {
             updateTentativeWinningPayoutDistributionHash(tentativeWinningPayoutDistributionHash);
@@ -156,15 +156,15 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
         return true;
     }
 
-    function disputeRound1Reporters(uint256[] _payoutNumerators, uint256 _attotokens) public triggersMigration returns (bool) {
+    function disputeRound1Reporters(uint256[] _payoutNumerators, uint256 _attotokens, bool _invalid) public triggersMigration returns (bool) {
         require(getReportingState() == ReportingState.FIRST_DISPUTE);
         round1ReportersDisputeBondToken = DisputeBondTokenFactory(controller.lookup("DisputeBondTokenFactory")).createDisputeBondToken(controller, this, msg.sender, Reporting.round1ReportersDisputeBondAmount(), tentativeWinningPayoutDistributionHash);
         reportingWindow.getReputationToken().trustedTransfer(msg.sender, round1ReportersDisputeBondToken, Reporting.round1ReportersDisputeBondAmount());
         IReportingWindow _newReportingWindow = getUniverse().getNextReportingWindow();
         migrateReportingWindow(_newReportingWindow);
         if (_attotokens > 0) {
-            require(derivePayoutDistributionHash(_payoutNumerators) != tentativeWinningPayoutDistributionHash);
-            IReportingToken _reportingToken = getReportingToken(_payoutNumerators);
+            require(derivePayoutDistributionHash(_payoutNumerators, _invalid) != tentativeWinningPayoutDistributionHash);
+            IReportingToken _reportingToken = getReportingToken(_payoutNumerators, _invalid);
             _reportingToken.trustedBuy(msg.sender, _attotokens);
         } else {
             updateTentativeWinningPayoutDistributionHash(tentativeWinningPayoutDistributionHash);
@@ -265,11 +265,11 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
     // Helpers
     //
 
-    function getReportingToken(uint256[] _payoutNumerators) public returns (IReportingToken) {
-        bytes32 _payoutDistributionHash = derivePayoutDistributionHash(_payoutNumerators);
+    function getReportingToken(uint256[] _payoutNumerators, bool _invalid) public returns (IReportingToken) {
+        bytes32 _payoutDistributionHash = derivePayoutDistributionHash(_payoutNumerators, _invalid);
         IReportingToken _reportingToken = reportingTokens[_payoutDistributionHash];
         if (address(_reportingToken) == NULL_ADDRESS) {
-            _reportingToken = ReportingTokenFactory(controller.lookup("ReportingTokenFactory")).createReportingToken(controller, this, _payoutNumerators);
+            _reportingToken = ReportingTokenFactory(controller.lookup("ReportingTokenFactory")).createReportingToken(controller, this, _payoutNumerators, _invalid);
             reportingTokens[_payoutDistributionHash] = _reportingToken;
         }
         return _reportingToken;
@@ -317,13 +317,13 @@ contract Market is DelegationTarget, Typed, Initializable, Ownable, IMarket {
         }
     }
 
-    function derivePayoutDistributionHash(uint256[] _payoutNumerators) public view returns (bytes32) {
+    function derivePayoutDistributionHash(uint256[] _payoutNumerators, bool _invalid) public view returns (bytes32) {
         uint256 _sum = 0;
         for (uint8 i = 0; i < _payoutNumerators.length; i++) {
             _sum = _sum.add(_payoutNumerators[i]);
         }
         require(_sum == numTicks);
-        return keccak256(_payoutNumerators);
+        return keccak256(_payoutNumerators, _invalid);
     }
 
     function getReportingTokenOrZeroByPayoutDistributionHash(bytes32 _payoutDistributionHash) public view returns (IReportingToken) {

--- a/source/libraries/ContractDeployer.ts
+++ b/source/libraries/ContractDeployer.ts
@@ -202,8 +202,8 @@ export class ContractDeployer {
 
     // TODO: move these out of this class. this class is for deploying the contracts, not general purpose Augur interactions.
     // CONSIDER: create a class called Augur or something that deals with the various interactions one may want to participate in
-    public async getReportingToken(market, payoutDistribution): Promise<ContractBlockchainData> {
-        const reportingTokenAddress = market.getReportingToken(payoutDistribution);
+    public async getReportingToken(market, payoutDistribution, invalid): Promise<ContractBlockchainData> {
+        const reportingTokenAddress = market.getReportingToken(payoutDistribution, invalid);
         if (!reportingTokenAddress) {
             throw new Error();
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,8 +328,8 @@ class ContractsFixture:
         universe = self.applySignature('Universe', universeAddress)
         return universe
 
-    def getReportingToken(self, market, payoutDistribution):
-        reportingTokenAddress = market.getReportingToken(payoutDistribution)
+    def getReportingToken(self, market, payoutDistribution, invalid=False):
+        reportingTokenAddress = market.getReportingToken(payoutDistribution, invalid)
         assert reportingTokenAddress
         reportingToken = ABIContract(self.chain, ContractTranslator(ContractsFixture.signatures['ReportingToken']), reportingTokenAddress)
         return reportingToken
@@ -340,13 +340,13 @@ class ContractsFixture:
         shareToken = ABIContract(self.chain, ContractTranslator(ContractsFixture.signatures['ShareToken']), shareTokenAddress)
         return shareToken
 
-    def designatedReport(self, market, payoutDistribution, reporterKey):
-        reportingToken = self.getReportingToken(market, payoutDistribution)
+    def designatedReport(self, market, payoutDistribution, reporterKey, invalid=False):
+        reportingToken = self.getReportingToken(market, payoutDistribution, invalid)
         designatedReportStake = self.contracts['MarketFeeCalculator'].getDesignatedReportStake(market.getUniverse())
         return reportingToken.buy(designatedReportStake, sender=reporterKey)
 
     def getOrCreateChildUniverse(self, parentUniverse, market, payoutDistribution):
-        payoutDistributionHash = market.derivePayoutDistributionHash(payoutDistribution)
+        payoutDistributionHash = market.derivePayoutDistributionHash(payoutDistribution, False)
         assert payoutDistributionHash
         childUniverseAddress = parentUniverse.getOrCreateChildUniverse(payoutDistributionHash)
         assert childUniverseAddress

--- a/tests/reporting/test_dispute_bond_token.py
+++ b/tests/reporting/test_dispute_bond_token.py
@@ -129,9 +129,9 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
         OUTCOME_A = SCALAR_OUTCOME_A
         OUTCOME_B = SCALAR_OUTCOME_B
         OUTCOME_C = SCALAR_OUTCOME_C
-    reportingTokenA = contractsFixture.getReportingToken(market, OUTCOME_A)
-    reportingTokenB = contractsFixture.getReportingToken(market, OUTCOME_B)
-    reportingTokenC = contractsFixture.getReportingToken(market, OUTCOME_C)
+    reportingTokenA = contractsFixture.getReportingToken(market, OUTCOME_A, False)
+    reportingTokenB = contractsFixture.getReportingToken(market, OUTCOME_B, False)
+    reportingTokenC = contractsFixture.getReportingToken(market, OUTCOME_C, False)
     reportingWindow = contractsFixture.applySignature('ReportingWindow', market.getReportingWindow())
     aUniverseReputationToken = None
     bUniverseReputationToken = None
@@ -178,7 +178,7 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
 
             # Dispute the designated reporter outcome
             disputerAccountBalance = reputationToken.balanceOf(getattr(tester, 'a' + str(designatedReporterDisputerAccountNum)))
-            market.disputeDesignatedReport(OUTCOME_B, 1, sender=getattr(tester, 'k' + str(designatedReporterDisputerAccountNum)))
+            market.disputeDesignatedReport(OUTCOME_B, 1, False, sender=getattr(tester, 'k' + str(designatedReporterDisputerAccountNum)))
             designatedReporterDisputeBondToken = contractsFixture.applySignature('DisputeBondToken', market.getDesignatedReporterDisputeBondToken())
             assert designatedReporterDisputeBondToken.getMarket() == market.address
 
@@ -212,7 +212,7 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
         # Dispute the first reporters result
         disputerAccountBalance = reputationToken.balanceOf(getattr(tester, 'a' + str(round1ReportersDisputerAccountNum)))
         if (round1ReporterDisputeOutcome != None):
-            round1ReporterDisputeOutcomePayoutHash = market.derivePayoutDistributionHash(round1ReporterDisputeOutcome)
+            round1ReporterDisputeOutcomePayoutHash = market.derivePayoutDistributionHash(round1ReporterDisputeOutcome, False)
             stakeDelta = contractsFixture.contracts["MarketExtensions"].getPayoutDistributionHashStake(market.address, round1ReporterDisputeOutcomePayoutHash)
             stakeDelta = 1 - stakeDelta
             if stakeDelta < 0:
@@ -220,7 +220,7 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
         else:
             round1ReporterDisputeOutcome = []
             stakeDelta = 0
-        market.disputeRound1Reporters(round1ReporterDisputeOutcome, stakeDelta, sender=getattr(tester, 'k' + str(round1ReportersDisputerAccountNum)))
+        market.disputeRound1Reporters(round1ReporterDisputeOutcome, stakeDelta, False, sender=getattr(tester, 'k' + str(round1ReportersDisputerAccountNum)))
         round1ReportersDisputeBondToken = contractsFixture.applySignature('DisputeBondToken', market.getRound1ReportersDisputeBondToken())
         assert round1ReportersDisputeBondToken.getMarket() == market.address
 
@@ -545,14 +545,14 @@ def handleReportingTokens(market, designatedReporterAccountNum, designatedReport
                 winningOutcomeStakes[round1ReportersDisputerAccountNum] = 0
             winningOutcomeStakes[round1ReportersDisputerAccountNum] += stakeDelta
         for row in designatedReporterDisputeStakes:
-            if (market.derivePayoutDistributionHash(row[1]) == winningReportingToken.getPayoutDistributionHash()):
+            if (market.derivePayoutDistributionHash(row[1], False) == winningReportingToken.getPayoutDistributionHash()):
                 totalStakedOnWinningOutcome += row[2]
                 if (row[0] in winningOutcomeStakes):
                     winningOutcomeStakes[row[0]] += row[2]
                 else:
                     winningOutcomeStakes.update({row[0]: row[2]})
         for row in round1ReportersDisputeStakes:
-            if (market.derivePayoutDistributionHash(row[1]) == winningReportingToken.getPayoutDistributionHash()):
+            if (market.derivePayoutDistributionHash(row[1], False) == winningReportingToken.getPayoutDistributionHash()):
                 totalStakedOnWinningOutcome += row[2]
                 if (row[0] in winningOutcomeStakes):
                     winningOutcomeStakes[row[0]] += row[2]
@@ -604,8 +604,8 @@ def withdrawBondsFromDisputeTokens(market, round2ReportersDisputeStakes, designa
                 destinationUniverse = None
                 destinationUniverseReputationToken = None
                 #print "disputedPayoutDistributionHash:" + str(disputeBondToken.getDisputedPayoutDistributionHash())
-                #print "market.derivePayoutDistributionHash(row[1]): " + str(market.derivePayoutDistributionHash(row[1]))
-                if (disputeBondToken.getDisputedPayoutDistributionHash() != market.derivePayoutDistributionHash(row[1])):
+                #print "market.derivePayoutDistributionHash(row[1], False): " + str(market.derivePayoutDistributionHash(row[1], False))
+                if (disputeBondToken.getDisputedPayoutDistributionHash() != market.derivePayoutDistributionHash(row[1], False)):
                     if (row[1] == OUTCOME_A):
                         destinationUniverse = aUniverse
                         destinationUniverseReputationToken = aUniverseReputationToken
@@ -658,8 +658,8 @@ def withdrawBondsFromDisputeTokens(market, round2ReportersDisputeStakes, designa
                 destinationUniverse = None
                 destinationUniverseReputationToken = None
                 #print "disputedPayoutDistributionHash:" + str(disputeBondToken.getDisputedPayoutDistributionHash())
-                #print "market.derivePayoutDistributionHash(row[1]): " + str(market.derivePayoutDistributionHash(row[1]))
-                if (disputeBondToken.getDisputedPayoutDistributionHash() != market.derivePayoutDistributionHash(row[1])):
+                #print "market.derivePayoutDistributionHash(row[1], False): " + str(market.derivePayoutDistributionHash(row[1], False))
+                if (disputeBondToken.getDisputedPayoutDistributionHash() != market.derivePayoutDistributionHash(row[1], False)):
                     if (row[1] == OUTCOME_A):
                         destinationUniverse = aUniverse
                         destinationUniverseReputationToken = aUniverseReputationToken

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -48,7 +48,7 @@ def test_reportingFullHappyPath(reportingFixture):
     assert market.getReportingState() == reportingFixture.constants.FIRST_DISPUTE()
 
     # Contest the results with Tester 0
-    market.disputeRound1Reporters([], 0, sender=tester.k0)
+    market.disputeRound1Reporters([], 0, False, sender=tester.k0)
     assert not reportingWindow.isContainerForMarket(market.address)
     assert universe.isContainerForMarket(market.address)
     reportingWindow = reportingFixture.applySignature('ReportingWindow', market.getReportingWindow())
@@ -343,7 +343,7 @@ def test_invalid_round1_report(reportingFixture):
     proceedToRound1Reporting(reportingFixture, market, False, tester.k1, [0,10**18], [10**18,0])
 
     # We make an invalid report
-    reportingTokenInvalid = reportingFixture.getReportingToken(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)])
+    reportingTokenInvalid = reportingFixture.getReportingToken(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], True)
     reportingTokenInvalid.buy(1, sender=tester.k2)
     assert reportingTokenInvalid.balanceOf(tester.a2) == 1 + reportingFixture.contracts["MarketFeeCalculator"].getDesignatedReportNoShowBond(universe.address)
     tentativeWinner = market.getTentativeWinningPayoutDistributionHash()
@@ -373,7 +373,7 @@ def test_invalid_designated_report(reportingFixture):
 
     # To progress into the DESIGNATED DISPUTE phase we do a designated report of invalid
     initialMarketCreatorETHBalance = reportingFixture.utils.getETHBalance(market.getOwner())
-    assert reportingFixture.designatedReport(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], tester.k0)
+    assert reportingFixture.designatedReport(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], tester.k0, True)
 
     # We're now in the DESIGNATED DISPUTE PHASE
     assert market.getReportingState() == reportingFixture.constants.DESIGNATED_DISPUTE()

--- a/tests/reporting_utils.py
+++ b/tests/reporting_utils.py
@@ -39,7 +39,7 @@ def proceedToRound1Reporting(testFixture, market, makeReport, disputer, reportOu
     if (makeReport):
         assert testFixture.designatedReport(market, reportOutcomes, tester.k0)
         assert market.getReportingState() == testFixture.constants.DESIGNATED_DISPUTE()
-        assert market.disputeDesignatedReport(designatedDisputeOutcomes, 1, sender=disputer)
+        assert market.disputeDesignatedReport(designatedDisputeOutcomes, 1, False, sender=disputer)
     else:
         testFixture.chain.head_state.timestamp = market.getEndTime() + testFixture.constants.DESIGNATED_REPORTING_DURATION_SECONDS() + 1
 
@@ -67,7 +67,7 @@ def proceedToRound2Reporting(testFixture, market, makeReport, designatedDisputer
     assert market.getReportingState() == testFixture.constants.FIRST_DISPUTE()
 
     disputeRound1ReportOutcomeStake = testFixture.constants.DESIGNATED_REPORTER_DISPUTE_BOND_AMOUNT()
-    assert market.disputeRound1Reporters(round1ReportDisputeOutcomes, disputeRound1ReportOutcomeStake, sender=round1Disputer)
+    assert market.disputeRound1Reporters(round1ReportDisputeOutcomes, disputeRound1ReportOutcomeStake, False, sender=round1Disputer)
 
     # We're in the ROUND2 REPORTING phase now
     assert market.getReportingState() == testFixture.constants.ROUND2_REPORTING()


### PR DESCRIPTION
I opted for the argument option over the explicit separate contract method on `Market` just to reduce duplicated code paths.