### PR TITLE
Changes polling interval to follow an exponential backoff.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - ETHEREUM_HOST=parity-dev-node
       - ETHEREUM_PORT=8545
       - ETHEREUM_GAS_PRICE_IN_NANOETH=1
-      - ETHEREUM_BLOCK_INTERVAL_IN_MILLISECONDS=10
     links:
       - parity-dev-node
   # geth-integration-tests:

--- a/source/libraries/HelperFunctions.ts
+++ b/source/libraries/HelperFunctions.ts
@@ -2,11 +2,9 @@ import * as binascii from "binascii";
 import * as EthjsAccount from "ethjs-account";
 import * as EthjsQuery from 'ethjs-query';
 
-const DEFAULT_ETHEREUM_BLOCK_INTERVAL_MILLISECONDS = 1200;
 const DEFAULT_TEST_ACCOUNT_BALANCE = 1 * 10 ** 20; // Denominated in wei
 // Set gas block limit extremely high so new blocks don"t have to be mined while uploading contracts
 const GAS_BLOCK_AMOUNT: number = Math.pow(2, 32);
-const ETHEREUM_BLOCK_INTERVAL_MILLISECONDS: number = process.env.ETHEREUM_BLOCK_INTERVAL_MILLSECONDS ? parseInt(process.env.ETHEREUM_BLOCK_INTERVAL_MILLISECONDS!, 10) : DEFAULT_ETHEREUM_BLOCK_INTERVAL_MILLISECONDS;
 
 export interface TestAccount {
     privateKey: string;
@@ -80,9 +78,11 @@ async function sleep(milliseconds: number): Promise<object> {
 }
 
 export async function waitForTransactionToBeSealed(ethjsQuery: EthjsQuery, transactionHash: string): Promise<void> {
+    let pollingInterval = 10;
     let transaction = await ethjsQuery.getTransactionByHash(transactionHash);
-    while (transaction.blockNumber == null) {
-        await sleep(ETHEREUM_BLOCK_INTERVAL_MILLISECONDS);
+    while (transaction.blockNumber === null) {
+        await sleep(pollingInterval);
         transaction = await ethjsQuery.getTransactionByHash(transactionHash);
+        pollingInterval = Math.min(pollingInterval*2, 5000);
     }
 }


### PR DESCRIPTION
This reduces the amount of configuration necessary to run the node while supporting both fast chains and slow chains.  It also minimizes the negative impact of spamming a node with requests by having the interval slow down over time.

Note: When working against a remote node, the round-trip time to the node is included as part of the delay between transactions, so this actually starts at `round_trip+10` then increases to `round_trip+20` on the first iteration, `round_trip+30` on the next iteration, etc.