### PR TITLE
Fixes integration tests and renames LegacyReputationToken.

### DIFF
--- a/source/contracts/LegacyReputationToken.sol
+++ b/source/contracts/LegacyReputationToken.sol
@@ -4,7 +4,7 @@ import 'libraries/ContractExists.sol';
 import 'libraries/token/VariableSupplyToken.sol';
 
 
-contract LegacyRepContract is VariableSupplyToken {
+contract LegacyReputationToken is VariableSupplyToken {
     using ContractExists for address;
     event FundedAccount(address indexed _universe, address indexed _sender, uint256 _repBalance, uint256 _timestamp);
 
@@ -15,7 +15,7 @@ contract LegacyRepContract is VariableSupplyToken {
     string public constant symbol = "REP";
     uint256 public constant decimals = 18;
 
-    function LegacyRepContract() public {
+    function LegacyReputationToken() public {
         // This is to confirm we are not on foundation network
         require(!FOUNDATION_REP_ADDRESS.exists());
     }

--- a/source/contracts/legacy_reputation/LegacyRepToken.sol
+++ b/source/contracts/legacy_reputation/LegacyRepToken.sol
@@ -11,7 +11,7 @@ import 'legacy_reputation/ERC20Basic.sol';
  * @dev REP2 Mintable Token with migration from legacy contract
  */
 contract LegacyRepToken is Initializable, PausableToken {
-    ERC20Basic public legacyRepContract;
+    ERC20Basic public legacyReputationToken;
     uint256 public targetSupply;
 
     string public constant name = "Reputation";
@@ -22,12 +22,12 @@ contract LegacyRepToken is Initializable, PausableToken {
 
     /**
      * @dev Creates a new RepToken instance
-     * @param _legacyRepContract Address of the legacy ERC20Basic REP contract to migrate balances from
+     * @param _legacyReputationToken Address of the legacy ERC20Basic REP contract to migrate balances from
      */
-    function LegacyRepToken(address _legacyRepContract, uint256 _amountUsedToFreeze, address _accountToSendFrozenRepTo) {
-        require(_legacyRepContract != 0);
-        legacyRepContract = ERC20Basic(_legacyRepContract);
-        targetSupply = legacyRepContract.totalSupply();
+    function LegacyRepToken(address _legacyReputationToken, uint256 _amountUsedToFreeze, address _accountToSendFrozenRepTo) {
+        require(_legacyReputationToken != 0);
+        legacyReputationToken = ERC20Basic(_legacyReputationToken);
+        targetSupply = legacyReputationToken.totalSupply();
         balances[_accountToSendFrozenRepTo] = _amountUsedToFreeze;
         totalSupply = _amountUsedToFreeze;
         pause();
@@ -55,7 +55,7 @@ contract LegacyRepToken is Initializable, PausableToken {
             return false; // Already copied, move on
         }
 
-        uint256 amount = legacyRepContract.balanceOf(_holder);
+        uint256 amount = legacyReputationToken.balanceOf(_holder);
         if (amount == 0) {
             return false; // Has no balance in legacy contract, move on
         }

--- a/source/contracts/reporting/ReputationToken.sol
+++ b/source/contracts/reporting/ReputationToken.sol
@@ -58,9 +58,9 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return true;
     }
 
-    function migrateFromLegacyRepContract() public afterInitialized returns (bool) {
-        var _legacyRepToken = ERC20(controller.lookup("LegacyRepContract"));
-        var _legacyBalance = _legacyRepToken.balanceOf(msg.sender);
+    function migrateFromLegacyReputationToken() public afterInitialized returns (bool) {
+        var _legacyRepToken = ERC20(controller.lookup("LegacyReputationToken"));
+        uint256 _legacyBalance = _legacyRepToken.balanceOf(msg.sender);
         _legacyRepToken.transferFrom(msg.sender, address(0), _legacyBalance);
         balances[msg.sender] = balances[msg.sender].add(_legacyBalance);
         supply = supply.add(_legacyBalance);

--- a/source/libraries/AbiParser.ts
+++ b/source/libraries/AbiParser.ts
@@ -21,7 +21,7 @@ export function parseAbiIntoMethods(ethjsQuery: EthjsQuery, abi: (CompilerOutput
     const result: { [methodName: string]: ContractMethod } = {};
     const items = abi.filter(item => item.type === 'function').forEach(item => {
         result[item.name] = async function(this: TransactionOptions, ...vargs: any[]) {
-            const callConvention = (this.constant || defaultTransaction.constant || item.constant) ? 'call' : 'sendTransaction';
+            const callConvention = (Object.assign({ constant: item.constant }, defaultTransaction, this)).constant ? 'call' : 'sendTransaction';
             const from = this.from || defaultTransaction.from;
             if (!from && callConvention === 'sendTransaction') throw new Error("Must have a `from`.");
             const to = this.to || defaultTransaction.to;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,13 +175,13 @@ class ContractsFixture:
         self.testerKey = self.generateTesterMap('k')
 
     def distributeRep(self, universe):
-        legacyRepContract = self.contracts['LegacyRepContract']
-        legacyRepContract.faucet(11 * 10**6 * 10**18)
+        legacyReputationToken = self.contracts['LegacyReputationToken']
+        legacyReputationToken.faucet(11 * 10**6 * 10**18)
 
         # Get the reputation token for this universe and migrate legacy REP to it
         reputationToken = self.applySignature('ReputationToken', universe.getReputationToken())
-        legacyRepContract.approve(reputationToken.address, 11 * 10**6 * 10**18)
-        reputationToken.migrateFromLegacyRepContract()
+        legacyReputationToken.approve(reputationToken.address, 11 * 10**6 * 10**18)
+        reputationToken.migrateFromLegacyReputationToken()
 
     def generateTesterMap(self, ch):
         testers = {}

--- a/tests/reporting/test_dispute_bond_token.py
+++ b/tests/reporting/test_dispute_bond_token.py
@@ -147,13 +147,13 @@ def test_dispute_bond_tokens(marketType, designatedReporterAccountNum, designate
     round2ReportersDisputeBondToken = None
 
     # Seed legacy REP contract with 11 million reputation tokens
-    legacyRepContract = contractsFixture.contracts['LegacyRepContract']
-    legacyRepContract.faucet(long(REP_TOTAL * REP_DIVISOR))
+    legacyReputationToken = contractsFixture.contracts['LegacyReputationToken']
+    legacyReputationToken.faucet(long(REP_TOTAL * REP_DIVISOR))
 
     # Get the reputation token for this universe and migrate legacy REP to it
     reputationToken = contractsFixture.applySignature('ReputationToken', universe.getReputationToken())
-    legacyRepContract.approve(reputationToken.address, REP_TOTAL * REP_DIVISOR)
-    reputationToken.migrateFromLegacyRepContract()
+    legacyReputationToken.approve(reputationToken.address, REP_TOTAL * REP_DIVISOR)
+    reputationToken.migrateFromLegacyReputationToken()
 
     initializeTestAccountBalances(reputationToken)
 

--- a/tests/reporting/test_reputation.py
+++ b/tests/reporting/test_reputation.py
@@ -11,10 +11,10 @@ def test_decimals(contractsFixture, universe):
 ''' TODO: When we get finer grained test fixture/setup in place make this use a more base fixture without the rep distributed, as without that there is nothing here to test
 def test_redeem_legacy_rep(contractsFixture, universe):
     reputationToken = contractsFixture.applySignature('ReputationToken', universe.getReputationToken())
-    legacyRepContract = contractsFixture.contracts['LegacyRepContract']
-    legacyRepContract.faucet(long(11 * 10**6 * 10**18))
-    legacyRepContract.approve(reputationToken.address, 11 * 10**6 * 10**18)
-    reputationToken.migrateFromLegacyRepContract()
+    legacyReputationToken = contractsFixture.contracts['LegacyReputationToken']
+    legacyReputationToken.faucet(long(11 * 10**6 * 10**18))
+    legacyReputationToken.approve(reputationToken.address, 11 * 10**6 * 10**18)
+    reputationToken.migrateFromLegacyReputationToken()
     balance = reputationToken.balanceOf(tester.a0)
     import pdb;pdb.set_trace()
     assert balance == 11 * 10**6 * 10**18

--- a/tests/reporting/test_universe.py
+++ b/tests/reporting/test_universe.py
@@ -102,13 +102,13 @@ def test_universe_contains_market(localFixture, cash, market):
     assert universe.isContainerForMarket(market.address) == False
 
     # Give some REP in this universe to tester0 to pay market creation fee
-    legacyRepContract = localFixture.contracts['LegacyRepContract']
-    legacyRepContract.faucet(11 * 10**6 * 10**18)
+    legacyReputationToken = localFixture.contracts['LegacyReputationToken']
+    legacyReputationToken.faucet(11 * 10**6 * 10**18)
 
     # Get the reputation token for this universe and migrate legacy REP to it
     reputationToken = localFixture.applySignature('ReputationToken', universe.getReputationToken())
-    legacyRepContract.approve(reputationToken.address, 11 * 10**6 * 10**18)
-    reputationToken.migrateFromLegacyRepContract()
+    legacyReputationToken.approve(reputationToken.address, 11 * 10**6 * 10**18)
+    reputationToken.migrateFromLegacyReputationToken()
 
     uni_market = localFixture.createReasonableBinaryMarket(universe, cash)
     assert universe.isContainerForMarket(uni_market.address)

--- a/tests/solidity_test_helpers/MockReputationToken.sol
+++ b/tests/solidity_test_helpers/MockReputationToken.sol
@@ -20,7 +20,7 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, Variabl
     bool private setTrustedTransferValue;
     IUniverse private setUniverseValue;
     IReputationToken private setTopMigrationDestinationValue;
-    bool private setMigrateFromLegacyRepContractValue;
+    bool private setMigrateFromLegacyReputationTokenValue;
     IUniverse private initializeUniverseValue;
     
     /*
@@ -44,8 +44,8 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, Variabl
     function setTopMigrationDestination(IReputationToken _setTopMigrationDestinationValue) public {
         setTopMigrationDestinationValue = _setTopMigrationDestinationValue;
     }
-    function setMigrateFromLegacyRepContract(bool _setMigrateFromLegacyRepContractValue) public {
-        setMigrateFromLegacyRepContractValue = _setMigrateFromLegacyRepContractValue;
+    function setMigrateFromLegacyReputationToken(bool _setMigrateFromLegacyReputationTokenValue) public {
+        setMigrateFromLegacyReputationTokenValue = _setMigrateFromLegacyReputationTokenValue;
     }
     function setInitializeUniverseValue() public returns(IUniverse) {
         return initializeUniverseValue;
@@ -79,7 +79,7 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, Variabl
     function getTopMigrationDestination() public view returns (IReputationToken) {
         return setTopMigrationDestinationValue;
     }
-    function migrateFromLegacyRepContract() public afterInitialized returns (bool) {
-        return setMigrateFromLegacyRepContractValue;
+    function migrateFromLegacyReputationToken() public afterInitialized returns (bool) {
+        return setMigrateFromLegacyReputationTokenValue;
     }
 }

--- a/tests/test_legacyRep.py
+++ b/tests/test_legacyRep.py
@@ -2,7 +2,7 @@ from ethereum.tools import tester
 
 ''' TODO: When we get finer grained test fixture/setup in place make this use a more base fixture without the rep distributed, as without that there is nothing here to test
 def test_legacyRepFaucet(contractsFixture):
-    legacyRep = contractsFixture.contracts['LegacyRepContract']
+    legacyRep = contractsFixture.contracts['LegacyReputationToken']
     assert legacyRep.decimals() == 18
     assert legacyRep.totalSupply() == 0
 

--- a/tests/trading/test_wcl_fuzzy.py
+++ b/tests/trading/test_wcl_fuzzy.py
@@ -55,14 +55,14 @@ def execute(contractsFixture, universe, cash, market, orderType, orderSize, orde
             otherShareToken = contractsFixture.applySignature('ShareToken', market.getShareToken(otherOutcome))
             assert otherShareToken.approve(approvalAddress, amount, sender = sender)
 
-    legacyRepContract = contractsFixture.contracts['LegacyRepContract']
-    legacyRepContract.faucet(long(11 * 10**6 * 10**18))
+    legacyReputationToken = contractsFixture.contracts['LegacyReputationToken']
+    legacyReputationToken.faucet(long(11 * 10**6 * 10**18))
     contractsFixture.chain.head_state.timestamp += 15000
 
     # Get the reputation token for this universe and migrate legacy REP to it
     reputationToken = contractsFixture.applySignature('ReputationToken', universe.getReputationToken())
-    legacyRepContract.approve(reputationToken.address, 11 * 10**6 * 10**18)
-    reputationToken.migrateFromLegacyRepContract()
+    legacyReputationToken.approve(reputationToken.address, 11 * 10**6 * 10**18)
+    reputationToken.migrateFromLegacyReputationToken()
 
     orders = contractsFixture.contracts['Orders']
     ordersFetcher = contractsFixture.contracts['OrdersFetcher']


### PR DESCRIPTION
The rename is to bring the naming convention in line with the rest of our contracts.

The fix was to wait for legacy reputation token to be approved before calling migrate reputation.  This is necessary because when we estimate the gas cost of migration, it must be _after_ approval otherwise it underestimates because the transaction fails.