### PR TITLE
Fixes failing Parity integration test.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@types/get-port": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
-            "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q=="
+            "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==",
+            "dev": true
         },
         "@types/mkdirp": {
             "version": "0.5.1",

--- a/source/libraries/AbiParser.ts
+++ b/source/libraries/AbiParser.ts
@@ -15,9 +15,7 @@ interface TransactionOptions {
 export type Contract = { [methodName: string]: ContractMethod };
 type ContractMethod = (...vargs: any[]) => Promise<any>;
 
-
-
-export function parseAbiIntoMethods(ethjsQuery: EthjsQuery, abi: (CompilerOutputContractAbi)[], defaultTransaction: TransactionOptions = {}): { [methodName: string]: ContractMethod } {
+export function parseAbiIntoMethods(ethjsQuery: EthjsQuery, abi: (CompilerOutputContractAbi)[], defaultTransaction: TransactionOptions = {}): Contract {
     const result: { [methodName: string]: ContractMethod } = {};
     const items = abi.filter(item => item.type === 'function').forEach(item => {
         result[item.name] = async function(this: TransactionOptions, ...vargs: any[]) {

--- a/source/tests-unit/Universe.ts
+++ b/source/tests-unit/Universe.ts
@@ -2,6 +2,8 @@ import * as binascii from "binascii";
 import { expect } from "chai";
 import { compileAndDeployContracts } from "../deployment/deployContracts";
 import { ContractDeployer } from "../libraries/ContractDeployer";
+import { parseAbiIntoMethods } from "../libraries/AbiParser";
+import { stringTo32ByteHex } from "../libraries/HelperFunctions";
 
 
 describe("Universe", () => {
@@ -11,9 +13,9 @@ describe("Universe", () => {
     });
     it("#getTypeName()", async () => {
         // TODO: Move this check into ContractDeployer
-        const genesisUniverse = await contractDeployer.universe;
+        const genesisUniverse = parseAbiIntoMethods(contractDeployer.ethjsQuery, contractDeployer.abis.get('Universe')!, { from: contractDeployer.testAccounts[0], to: contractDeployer.universeAddress, gasPrice: contractDeployer.gasPrice });
         const genesisUniverseTypeNameHex = (await genesisUniverse.getTypeName())[0];
-        const genesisUniverseTypeName = binascii.unhexlify(genesisUniverseTypeNameHex).replace(/\u0000/g, "");
+        const genesisUniverseTypeName = stringTo32ByteHex(genesisUniverseTypeNameHex);
         expect(genesisUniverseTypeName).to.equal("Universe");
     });
 });

--- a/typings/ethjs-query.d.ts
+++ b/typings/ethjs-query.d.ts
@@ -1,18 +1,17 @@
 declare module 'ethjs-query' {
     import EthjsHttpProvider = require('ethjs-provider-http');
     import EthjsRpc = require('ethjs-rpc');
-    import { Abi, TransactionForSend, TransactionForCall, TransactionReceipt, BN as BNInterface, Log } from 'ethjs-shared';
+    import { Abi, Block, TransactionForSend, TransactionForCall, TransactionReceipt, BN as BNInterface, Log } from 'ethjs-shared';
 
     class EthjsQuery {
         constructor(provider: EthjsHttpProvider);
         accounts(): Promise<Array<string>>;
-        contract(abi: Abi[], bytecode?: string, defaultTransactionObject?: TransactionForSend): any;
         estimateGas(transaction: TransactionForCall): Promise<BNInterface>;
         getBalance(address: string): Promise<BNInterface>;
-        getBlockByNumber(blockNumber: number|"earliest"|"latest"|"pending", returnFullBlock: boolean);
-        getLogs(options: { fromBlock: BNInterface | string, toBlock: BNInterface | string, address: string, topics: (string | null)[] }): Log[];
+        getBlockByNumber(blockNumber: number|"earliest"|"latest"|"pending", returnFullBlock: boolean): Promise<Block>;
+        getLogs(options: { fromBlock: BNInterface | string, toBlock: BNInterface | string, address: string, topics: (string | null)[] }): Promise<Array<Log>>;
         getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt>;
-        net_version(): string;
+        net_version(): Promise<string>;
         rpc: EthjsRpc;
     }
 

--- a/typings/ethjs-shared.d.ts
+++ b/typings/ethjs-shared.d.ts
@@ -69,6 +69,28 @@ declare module 'ethjs-shared' {
         status: number|string;
     }
 
+    export interface Block {
+        number: BN;
+        hash: string;
+        parentHash: string;
+        nonce: string;
+        sha3Uncles: string;
+        logsBloom: string;
+        transactionRoot: string;
+        stateRoot: string;
+        receiptRoot: string;
+        miner: string;
+        difficult: BN;
+        totalDifficulty: BN;
+        extraData: string;
+        size: BN;
+        gasLimit: BN;
+        gasUsed: BN;
+        timestamp: BN;
+        transactions: Array<TransactionReceipt>;
+        uncles: Array<string>;
+    }
+
     export interface Log {
         removed: boolean;
         logIndex: BN;


### PR DESCRIPTION
Parity yest was failing because the end time for the market was resulting in a floating point number and BN.js _hates_ floating point numbers.  Unfortunately, the failure was swallowed somewhere in the stack so we just got an obscure failure rather than a useful one.

Geth doesn't seem to correctly estimate gas when there is a nested contract creation (in this case Reputation token is created as part of `universe.initialize`), and the ethjs default call doesn't supply gas so Geth is forced to do whatever it does in that situation.  By switching over to `parseAbiIntoMethods` (our home grown thing), we instead do `eth_estimateGas` which Geth apparently _does_ get right and the initialize call succeeds.

TODO: create a bug report with Geth indicating the problem.  It is also possible Geth has some internal limit it sets on no-gas transactions that is being hit.  Regardless, it works in Parity but not in Geth before, now it works in both.
