### PR TITLE
Changes polling interval to follow an exponential backoff.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - ETHEREUM_HOST=parity-dev-node
       - ETHEREUM_PORT=8545
       - ETHEREUM_GAS_PRICE_IN_NANOETH=1
-      - ETHEREUM_POLLING_INTERVAL_MILLISECONDS=10
     links:
       - parity-dev-node
   geth-integration-tests:
@@ -38,6 +37,5 @@ services:
       - ETHEREUM_HOST=geth-dev-node
       - ETHEREUM_PORT=8545
       - ETHEREUM_GAS_PRICE_IN_NANOETH=1
-      - ETHEREUM_POLLING_INTERVAL_MILLISECONDS=10
     links:
       - geth-dev-node

--- a/source/libraries/HelperFunctions.ts
+++ b/source/libraries/HelperFunctions.ts
@@ -6,7 +6,6 @@ import { TransactionReceipt } from 'ethjs-shared';
 const DEFAULT_TEST_ACCOUNT_BALANCE = 1 * 10 ** 20; // Denominated in wei
 // Set gas block limit extremely high so new blocks don"t have to be mined while uploading contracts
 const GAS_BLOCK_AMOUNT = Math.pow(2, 32);
-const ETHEREUM_POLLING_INTERVAL_MILLISECONDS = process.env.ETHEREUM_POLLING_INTERVAL_MILLISECONDS ? parseInt(process.env.ETHEREUM_POLLING_INTERVAL_MILLISECONDS!, 10) : 1200;
 
 export interface TestAccount {
     privateKey: string;
@@ -80,10 +79,12 @@ export async function sleep(milliseconds: number): Promise<void> {
 }
 
 export async function waitForTransactionReceipt(ethjsQuery: EthjsQuery, transactionHash: string, failureDetails: string): Promise<TransactionReceipt> {
+    let pollingInterval = 10;
     let receipt = await ethjsQuery.getTransactionReceipt(transactionHash);
     while (!receipt || !receipt.blockHash) {
-        await sleep(ETHEREUM_POLLING_INTERVAL_MILLISECONDS);
+        await sleep(pollingInterval);
         receipt = await ethjsQuery.getTransactionReceipt(transactionHash);
+        pollingInterval = Math.min(pollingInterval*2, 5000);
     }
     const status = (typeof receipt.status === 'number') ? receipt.status : parseInt(receipt.status, 16);
     if (!status) {


### PR DESCRIPTION
This reduces the amount of configuration necessary to run the node while supporting both fast chains and slow chains.  It also minimizes the negative impact of spamming a node with requests by having the interval slow down over time.

Note: When working against a remote node, the round-trip time to the node is included as part of the delay between transactions, so this actually starts at `round_trip+10` then increases to `round_trip+20` on the first iteration, `round_trip+30` on the next iteration, etc.