### PR TITLE
#3936 reputation token tests

### DIFF
--- a/source/contracts/reporting/ReputationToken.sol
+++ b/source/contracts/reporting/ReputationToken.sol
@@ -95,6 +95,7 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         IUniverse _parentUniverse = universe.getParentUniverse();
         require(_parentUniverse.isContainerForDisputeBondToken(IDisputeBond(msg.sender)));
         mint(msg.sender, _amount);
+        return true;
     }
 
     // AUDIT: check for reentrancy issues here, _source and _destination will be called as contracts during validation

--- a/source/contracts/reporting/ReputationToken.sol
+++ b/source/contracts/reporting/ReputationToken.sol
@@ -125,7 +125,6 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
     function internalTrustedTransfer(address _source, address _destination, uint256 _attotokens) internal onlyInGoodTimes afterInitialized returns (bool) {
         balances[_source] = balances[_source].sub(_attotokens);
         balances[_destination] = balances[_destination].add(_attotokens);
-        supply = supply.add(_attotokens);
         Transfer(_source, _destination, _attotokens);
         return true;
     }

--- a/tests/libraries/token/test_reputation_token.py
+++ b/tests/libraries/token/test_reputation_token.py
@@ -1,0 +1,119 @@
+from ethereum.tools import tester
+from datetime import timedelta
+from utils import longToHexString, stringToBytes, bytesToHexString
+from pytest import fixture, raises
+from ethereum.tools.tester import ABIContract, TransactionFailed
+from reporting_utils import proceedToDesignatedReporting, proceedToFirstReporting, proceedToLastReporting, proceedToForking, finalizeForkingMarket, initializeReportingFixture
+
+
+def test_reputation_token_creation(localFixture, mockUniverse):
+    reputationToken = localFixture.upload('../source/contracts/reporting/ReputationToken.sol', 'reputationToken')
+    reputationToken.setController(localFixture.contracts['Controller'].address)
+    with raises(TransactionFailed, message="universe has to have address"):
+        reputationToken.initialize(longToHexString(0))
+
+    assert reputationToken.initialize(mockUniverse.address)
+
+
+def test_reputation_token_migrate_out_stake_token(localFixture, mockUniverse, initializedReputationToken, mockStakeToken, mockReputationToken, mockMarket):
+    with raises(TransactionFailed, message="universe has to contain stake token && called from stake token"):
+        initializedReputationToken.migrateOutStakeToken(mockUniverse.address)
+    
+    mockUniverse.setIsContainerForStakeToken(True)
+    with raises(TransactionFailed, message="destination reputation tokens universe needs to be parent of local universe"):
+        mockStakeToken.callMigrateOutStakeToken(initializedReputationToken.address, mockReputationToken.address, tester.a1, 100)
+
+    mockReputationToken.setUniverse(mockUniverse.address)
+    with raises(TransactionFailed, message="destination reputation tokens needs to be its universes reputation token"):
+        mockStakeToken.callMigrateOutStakeToken(initializedReputationToken.address, mockReputationToken.address, tester.a1, 100)
+
+    mockMarket.setReportingState(localFixture.contracts['Constants'].FINALIZED()) 
+    parentUniverse = localFixture.upload('solidity_test_helpers/MockUniverse.sol', 'parentUniverse')    
+    parentUniverse.setForkingMarket(mockMarket.address)
+    parentUniverse.setReputationToken(mockReputationToken.address)
+    mockReputationToken.setUniverse(parentUniverse.address)
+    mockUniverse.setParentUniverse(parentUniverse.address)
+    mockUniverse.setIsParentOf(True)
+    assert mockReputationToken.callMigrateIn(initializedReputationToken.address, mockStakeToken.address, 1011, False)
+    assert initializedReputationToken.totalSupply() == 1011
+    mockReputationToken.setTotalSupply(1005)
+    # sender and reporter is the same
+    mockStakeToken.callMigrateOutStakeToken(initializedReputationToken.address, mockReputationToken.address, mockStakeToken.address, 54)
+    # total repu token supply 1000
+    # 110 - 54, 1000 - 54
+    assert initializedReputationToken.totalSupply() == 1011 - 54
+    assert mockReputationToken.getMigrateInReporterValue() == stringToBytes(mockStakeToken.address)
+    assert mockReputationToken.getMigrateInAttoTokensValue() == 54
+    assert mockReputationToken.getMigrateInBonusIfInForkWindowValue() == True
+    assert initializedReputationToken.getTopMigrationDestination() == stringToBytes(mockReputationToken.address)
+
+def test_reputation_token_migrate_in(localFixture, mockUniverse, initializedReputationToken, mockReputationToken, mockMarket):
+    with raises(TransactionFailed, message="caller needs to be reputation token"):
+        initializedReputationToken.migrateIn(tester.a1, 100, False)
+    
+    mockUniverse.setIsContainerForStakeToken(True)
+    with raises(TransactionFailed, message="calling reputation token has to be parent universe's reputation token"):
+        mockReputationToken.callMigrateIn(initializedReputationToken.address, tester.a1, 1000, False)
+    
+    parentUniverse = localFixture.upload('solidity_test_helpers/MockUniverse.sol', 'parentUniverse')    
+    parentUniverse.setReputationToken(mockReputationToken.address)
+    mockUniverse.setParentUniverse(parentUniverse.address)
+    mockReputationToken.setUniverse(mockUniverse.address)
+    with raises(TransactionFailed, message="parent universe needs to have a forking market"):
+        mockReputationToken.callMigrateIn(initializedReputationToken.address, tester.a1, 100, False)
+    
+    mockMarket.setReportingState(localFixture.contracts['Constants'].FINALIZED()) 
+    parentUniverse.setForkingMarket(mockMarket.address)
+
+    assert initializedReputationToken.totalSupply() == 0
+    mockReputationToken.callMigrateIn(initializedReputationToken.address, tester.a1, 100, False)
+    assert initializedReputationToken.totalSupply() == 100
+
+def migrate_reputation_for_sender(localFixture, initializedReputationToken, sender, amount, mockReputationToken, mockMarket, mockUniverse):
+    mockMarket.setReportingState(localFixture.contracts['Constants'].FINALIZED()) 
+    parentUniverse = localFixture.upload('solidity_test_helpers/MockUniverse.sol', 'parentUniverse')    
+    parentUniverse.setForkingMarket(mockMarket.address)
+    parentUniverse.setReputationToken(mockReputationToken.address)
+    mockUniverse.setParentUniverse(parentUniverse.address)
+    assert mockReputationToken.callMigrateIn(initializedReputationToken.address, sender, amount, False)
+
+@fixture(scope="session")
+def localSnapshot(fixture, augurInitializedWithMocksSnapshot):
+    fixture.resetToSnapshot(augurInitializedWithMocksSnapshot)
+    controller = fixture.contracts['Controller']
+    mockLegacyReputationToken = fixture.contracts['MockLegacyReputationToken']
+    controller.setValue(stringToBytes('LegacyReputationToken'), mockLegacyReputationToken.address)
+    return fixture.createSnapshot()
+
+@fixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@fixture
+def mockStakeToken(localFixture):
+    mockStakeToken = localFixture.contracts['MockStakeToken']
+    return mockStakeToken
+
+@fixture
+def mockUniverse(localFixture):
+    mockUniverse = localFixture.contracts['MockUniverse']
+    return mockUniverse
+
+@fixture
+def mockReputationToken(localFixture):
+    mockReputationToken = localFixture.contracts['MockReputationToken']
+    return mockReputationToken
+
+@fixture
+def mockMarket(localFixture, mockUniverse):
+    # wire up mock market
+    mockMarket = localFixture.contracts['MockMarket']
+    return mockMarket
+
+@fixture
+def initializedReputationToken(localFixture, mockUniverse):
+    reputationToken = localFixture.upload('../source/contracts/reporting/ReputationToken.sol', 'reputationToken')
+    reputationToken.setController(localFixture.contracts['Controller'].address)
+    assert reputationToken.initialize(mockUniverse.address)
+    return reputationToken

--- a/tests/libraries/token/test_reputation_token.py
+++ b/tests/libraries/token/test_reputation_token.py
@@ -154,17 +154,25 @@ def test_reputation_token_trusted_transfer(localFixture, mockUniverse, initializ
     with raises(TransactionFailed, message="source balance can not be 0"):
         mockReportingWindow.callTrustedReportingWindowTransfer(initializedReputationToken.address, tester.a1, tester.a2, 100)
     
+
     assert initializedReputationToken.totalSupply() == 0
     assert initializedReputationToken.balanceOf(tester.a1) == 0
     give_some_rep_to(mockLegacyReputationToken, initializedReputationToken, tester.k1, 35)
     assert initializedReputationToken.totalSupply() == 35
     assert initializedReputationToken.balanceOf(tester.a2) == 0
     assert initializedReputationToken.balanceOf(tester.a1) == 35
+
+    with raises(TransactionFailed, message="transfer has to be approved"):
+        mockReportingWindow.callTrustedReportingWindowTransfer(initializedReputationToken.address, tester.a1, tester.a2, 100)
+
+    assert initializedReputationToken.approve(mockStakeToken.address, 35, sender=tester.k1)
+    assert initializedReputationToken.allowance(tester.a1, mockStakeToken.address) == 35
+
     assert mockReportingWindow.callTrustedReportingWindowTransfer(initializedReputationToken.address, tester.a1, tester.a2, 35)
     # TODO find out why total supply grows
-    assert initializedReputationToken.totalSupply() == 70 
-    assert initializedReputationToken.balanceOf(tester.a1) == 0
+    assert initializedReputationToken.totalSupply() == 35 
     assert initializedReputationToken.balanceOf(tester.a2) == 35
+    assert initializedReputationToken.balanceOf(tester.a1) == 0
 
 def give_some_rep_to(mockLegacyReputationToken, targetReputationToken, userAccount, amount):
     mockLegacyReputationToken.setBalanceOf(amount)

--- a/tests/libraries/token/test_reputation_token.py
+++ b/tests/libraries/token/test_reputation_token.py
@@ -68,7 +68,7 @@ def test_reputation_token_migrate_out(localFixture, mockUniverse, initializedRep
     assert mockReputationToken.getMigrateInAttoTokensValue() == 35
     assert mockReputationToken.getMigrateInBonusIfInForkWindowValue() == True
 
-    newReputationToken = localFixture.upload('solidity_test_helpers/MockReputationtoken.sol', 'newReputationToken')   
+    newReputationToken = localFixture.upload('solidity_test_helpers/MockReputationToken.sol', 'newReputationToken')   
     parentUniverse.setReputationToken(newReputationToken.address)
     newReputationToken.setUniverse(parentUniverse.address)
     newReputationToken.setTotalSupply(6005)

--- a/tests/reporting/test_reporting_windows.py
+++ b/tests/reporting/test_reporting_windows.py
@@ -544,26 +544,15 @@ def finializeMarket(localFixture, mockMarket, reportingWindow, totalSupply, disp
     assert mockMarket.callReportingWindowUpdateMarketPhase(reportingWindow.address)
 
 @fixture(scope="session")
-def localSnapshot(fixture, augurInitializedSnapshot):
-    fixture.resetToSnapshot(augurInitializedSnapshot)
+def localSnapshot(fixture, augurInitializedWithMocksSnapshot):
+    fixture.resetToSnapshot(augurInitializedWithMocksSnapshot)
     controller = fixture.contracts['Controller']
-    fixture.uploadAndAddToController("solidity_test_helpers/Constants.sol")
-    fixture.uploadAndAddToController('solidity_test_helpers/MockStakeToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockMarket.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockUniverse.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockReportingWindow.sol')    
-    fixture.uploadAndAddToController('solidity_test_helpers/MockReputationToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockDisputeBondToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockParticipationToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockVariableSupplyToken.sol')
-    mockReportingParticipationTokenFactory = fixture.upload('solidity_test_helpers/MockParticipationTokenFactory.sol')
-    mockCash = fixture.upload('solidity_test_helpers/MockCash.sol')
-    mockMarketFactory = fixture.upload('solidity_test_helpers/MockMarketFactory.sol')
-    mockAugur = fixture.uploadAndAddToController("solidity_test_helpers/MockAugur.sol")    
+    mockReportingParticipationTokenFactory = fixture.contracts['MockParticipationTokenFactory']
+    mockCash = fixture.contracts['MockCash']
+    mockMarketFactory = fixture.contracts['MockMarketFactory']
     controller.setValue(stringToBytes('MarketFactory'), mockMarketFactory.address)
     controller.setValue(stringToBytes('Cash'), mockCash.address)
     controller.setValue(stringToBytes('ParticipationTokenFactory'), mockReportingParticipationTokenFactory.address)
-    controller.setValue(stringToBytes('Augur'), mockAugur.address)
     return fixture.createSnapshot()
 
 @fixture

--- a/tests/reporting/test_universe.py
+++ b/tests/reporting/test_universe.py
@@ -323,25 +323,15 @@ def test_universe_reporting_fee_divisor(localFixture, chain, populatedUniverse, 
     
 
 @fixture
-def localSnapshot(fixture, augurInitializedSnapshot):
-    fixture.resetToSnapshot(augurInitializedSnapshot)
+def localSnapshot(fixture, augurInitializedWithMocksSnapshot):
+    fixture.resetToSnapshot(augurInitializedWithMocksSnapshot)
     controller = fixture.contracts['Controller']
-    fixture.uploadAndAddToController("solidity_test_helpers/Constants.sol")
-    fixture.uploadAndAddToController('solidity_test_helpers/MockShareToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockStakeToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockDisputeBondToken.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockMarket.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockUniverse.sol')
-    fixture.uploadAndAddToController('solidity_test_helpers/MockReportingWindow.sol')    
-    fixture.uploadAndAddToController('solidity_test_helpers/MockReputationToken.sol')    
-    mockReputationTokenFactory = fixture.upload('solidity_test_helpers/MockReputationTokenFactory.sol')
-    mockReportingWindowFactory = fixture.upload('solidity_test_helpers/MockReportingWindowFactory.sol')
-    mockUniverseFactory = fixture.upload('solidity_test_helpers/MockUniverseFactory.sol')
-    mockAugur = fixture.uploadAndAddToController("solidity_test_helpers/MockAugur.sol")
+    mockReputationTokenFactory = fixture.contracts['MockReputationTokenFactory']
+    mockReportingWindowFactory = fixture.contracts['MockReportingWindowFactory']
+    mockUniverseFactory = fixture.contracts['MockUniverseFactory']
     controller.setValue(stringToBytes('ReputationTokenFactory'), mockReputationTokenFactory.address)
     controller.setValue(stringToBytes('ReportingWindowFactory'), mockReportingWindowFactory.address)
     controller.setValue(stringToBytes('UniverseFactory'), mockUniverseFactory.address)
-    controller.setValue(stringToBytes('Augur'), mockAugur.address)
     return fixture.createSnapshot()
 
 @fixture

--- a/tests/solidity_test_helpers/MockAugur.sol
+++ b/tests/solidity_test_helpers/MockAugur.sol
@@ -89,7 +89,12 @@ contract MockAugur is Controlled {
         return true;
     }
 
+    bool private logReputationTokensTransferredCalledValue;
+
+    function logReputationTokensTransferredCalled() public returns(bool) { return logReputationTokensTransferredCalledValue;}
+
     function logReputationTokensTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool) {
+        logReputationTokensTransferredCalledValue = true;
         return true;
     }
 

--- a/tests/solidity_test_helpers/MockDisputeBondToken.sol
+++ b/tests/solidity_test_helpers/MockDisputeBondToken.sol
@@ -61,6 +61,10 @@ contract MockDisputeBondToken is ITyped, IDisputeBond {
         return _reputationToken.migrateOutDisputeBondToken(_destination, _reporter, _attotokens);
     }
 
+    function callMintForDisputeBondMigration(IReputationToken _reputationToken, uint256 _attotokens) public returns(bool) {
+        return _reputationToken.mintForDisputeBondMigration(_attotokens);
+    }
+
     /*
     * Impl of IReportingWindow and ITyped
      */

--- a/tests/solidity_test_helpers/MockDisputeBondToken.sol
+++ b/tests/solidity_test_helpers/MockDisputeBondToken.sol
@@ -57,6 +57,10 @@ contract MockDisputeBondToken is ITyped, IDisputeBond {
         return _universe.decreaseExtraDisputeBondRemainingToBePaidOut(_amount);
     }
 
+    function callMigrateOutDisputeBondToken(IReputationToken _reputationToken, IReputationToken  _destination, address _reporter, uint256 _attotokens) public returns(bool) {
+        return _reputationToken.migrateOutDisputeBondToken(_destination, _reporter, _attotokens);
+    }
+
     /*
     * Impl of IReportingWindow and ITyped
      */

--- a/tests/solidity_test_helpers/MockLegacyReputationToken.sol
+++ b/tests/solidity_test_helpers/MockLegacyReputationToken.sol
@@ -12,10 +12,6 @@ contract MockLegacyReputationToken is MockVariableSupplyToken {
         return faucetAmountValue;
     }
 
-    function MockLegacyReputationToken() public {
-
-    }
-
     function faucet(uint256 _amount) public returns (bool) {
         faucetAmountValue = _amount;
         return true;

--- a/tests/solidity_test_helpers/MockLegacyReputationToken.sol
+++ b/tests/solidity_test_helpers/MockLegacyReputationToken.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.4.17;
+
+import 'libraries/ContractExists.sol';
+import 'TEST/MockVariableSupplyToken.sol';
+
+
+contract MockLegacyReputationToken is MockVariableSupplyToken {
+    using ContractExists for address;
+    uint256 private faucetAmountValue;
+
+    function getFaucetAmountValue() public returns(uint256) {
+        return faucetAmountValue;
+    }
+
+    function MockLegacyReputationToken() public {
+
+    }
+
+    function faucet(uint256 _amount) public returns (bool) {
+        faucetAmountValue = _amount;
+        return true;
+    }
+}

--- a/tests/solidity_test_helpers/MockMarket.sol
+++ b/tests/solidity_test_helpers/MockMarket.sol
@@ -276,6 +276,10 @@ contract MockMarket is IMarket {
         setMigrateDueToNoReportsNextStateValue = _reportingWindow;
     }
     
+    function callTrustedMarketTransfer(IReputationToken _reputationToken, address _source, address _destination, uint256 _attotokens) public returns (bool) {
+        return _reputationToken.trustedMarketTransfer(_source, _destination, _attotokens);
+    }
+
     /*
     * IMarket methods
     */

--- a/tests/solidity_test_helpers/MockParticipationToken.sol
+++ b/tests/solidity_test_helpers/MockParticipationToken.sol
@@ -53,6 +53,10 @@ contract MockParticipationToken is ITyped, Initializable, MockVariableSupplyToke
         return _reportingWindow.collectParticipationTokenReportingFees(_reporterAddress, _attoStake, _forgoFees);
     }
     
+    function callTrustedParticipationTokenTransfer(IReputationToken _reputationToken, address _source, address _destination, uint256 _attotokens) public returns (bool) {
+        return _reputationToken.trustedParticipationTokenTransfer(_source, _destination, _attotokens);
+    }
+
     function getTypeName() public view returns (bytes32) {
         return "ParticipationToken";
     }

--- a/tests/solidity_test_helpers/MockReportingWindow.sol
+++ b/tests/solidity_test_helpers/MockReportingWindow.sol
@@ -215,6 +215,10 @@ contract MockReportingWindow is Initializable, IReportingWindow {
         return _reportingWindow.migrateFeesDueToFork();
     }
 
+    function callTrustedReportingWindowTransfer(IReputationToken _reputationToken, address _source, address _destination, uint256 _attotokens) public returns (bool) {
+        return _reputationToken.trustedReportingWindowTransfer(_source, _destination, _attotokens);
+    }
+
     /*
     * Impl of IReportingWindow and ITyped
      */

--- a/tests/solidity_test_helpers/MockReputationToken.sol
+++ b/tests/solidity_test_helpers/MockReputationToken.sol
@@ -29,6 +29,9 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, MockVar
     address private trustedTransferSourceValue; 
     address private trustedTransferDestinationValue; 
     uint256 private trustedTransferAttotokensValue;
+    address private migrateInReporterValue;
+    uint256 private migrateInAttoTokensValue;
+    bool private migrateInBonusIfInForkWindowValue;
 
     /*
     * setters to feed the getters and impl of IUniverse
@@ -88,11 +91,26 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, MockVar
     function getMigrateOutAttoTokens() public returns(uint256) {
         return migrateOutAttoTokens;
     }
+    
+    function getMigrateInReporterValue() public returns(address) {
+        return migrateInReporterValue;
+    }
+
+    function getMigrateInAttoTokensValue() public returns(uint256) {
+        return migrateInAttoTokensValue;
+    }
+
+    function getMigrateInBonusIfInForkWindowValue() public returns(bool) {
+        return migrateInBonusIfInForkWindowValue;
+    }
 
     function callIncreaseRepAvailableForExtraBondPayouts(IUniverse _universe, uint256 _amount) public returns(bool) {
         return _universe.increaseRepAvailableForExtraBondPayouts(_amount);
     }
 
+    function callMigrateIn(IReputationToken _reputationToken, address _reporter, uint256 _attotokens, bool _bonusIfInForkWindow) public returns (bool) {
+        return _reputationToken.migrateIn(_reporter, _attotokens, _bonusIfInForkWindow);
+    }
     /*
     * Impl of IReputationToken and ITyped
      */
@@ -128,6 +146,9 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, MockVar
     }
     
     function migrateIn(address _reporter, uint256 _attotokens, bool _bonusIfInForkWindow) public returns (bool) {
+        migrateInReporterValue = _reporter;
+        migrateInAttoTokensValue = _attotokens;
+        migrateInBonusIfInForkWindowValue = _bonusIfInForkWindow;
         return setMigrateInValue;
     }
     

--- a/tests/solidity_test_helpers/MockReputationToken.sol
+++ b/tests/solidity_test_helpers/MockReputationToken.sol
@@ -111,6 +111,7 @@ contract MockReputationToken is DelegationTarget, ITyped, Initializable, MockVar
     function callMigrateIn(IReputationToken _reputationToken, address _reporter, uint256 _attotokens, bool _bonusIfInForkWindow) public returns (bool) {
         return _reputationToken.migrateIn(_reporter, _attotokens, _bonusIfInForkWindow);
     }
+    
     /*
     * Impl of IReputationToken and ITyped
      */

--- a/tests/solidity_test_helpers/MockStakeToken.sol
+++ b/tests/solidity_test_helpers/MockStakeToken.sol
@@ -79,6 +79,10 @@ contract MockStakeToken is ITyped, MockVariableSupplyToken, IStakeToken {
         return _reputationToken.migrateOutStakeToken(_destination, _reporter, _attotokens);
     }
 
+    function callMigrateOut(IReputationToken _reputationToken, IReputationToken  _destination, address _reporter, uint256 _attotokens) public returns(bool) {
+        return _reputationToken.migrateOut(_destination, _reporter, _attotokens);
+    }
+
     function initialize(IMarket _market, uint256[] _payoutNumerators, bool _invalid) public returns (bool) {
         initializeMarketValue = _market;
         initializePayoutNumeratorsValue = _payoutNumerators;

--- a/tests/solidity_test_helpers/MockStakeToken.sol
+++ b/tests/solidity_test_helpers/MockStakeToken.sol
@@ -75,6 +75,10 @@ contract MockStakeToken is ITyped, MockVariableSupplyToken, IStakeToken {
         return _reportingWindow.collectStakeTokenReportingFees(_reporterAddress, _attoStake, _forgoFees);
     }
 
+    function callMigrateOutStakeToken(IReputationToken _reputationToken, IReputationToken  _destination, address _reporter, uint256 _attotokens) public returns(bool) {
+        return _reputationToken.migrateOutStakeToken(_destination, _reporter, _attotokens);
+    }
+
     function initialize(IMarket _market, uint256[] _payoutNumerators, bool _invalid) public returns (bool) {
         initializeMarketValue = _market;
         initializePayoutNumeratorsValue = _payoutNumerators;

--- a/tests/solidity_test_helpers/MockStakeToken.sol
+++ b/tests/solidity_test_helpers/MockStakeToken.sol
@@ -83,6 +83,10 @@ contract MockStakeToken is ITyped, MockVariableSupplyToken, IStakeToken {
         return _reputationToken.migrateOut(_destination, _reporter, _attotokens);
     }
 
+    function callTrustedStakeTokenTransfer(IReputationToken _reputationToken, address _source, address _destination, uint256 _attotokens) public returns (bool) {
+        return _reputationToken.trustedStakeTokenTransfer(_source, _destination, _attotokens);
+    }
+
     function initialize(IMarket _market, uint256[] _payoutNumerators, bool _invalid) public returns (bool) {
         initializeMarketValue = _market;
         initializePayoutNumeratorsValue = _payoutNumerators;

--- a/tests/solidity_test_helpers/MockStandardToken.sol
+++ b/tests/solidity_test_helpers/MockStandardToken.sol
@@ -1,0 +1,70 @@
+pragma solidity 0.4.17;
+
+
+import 'libraries/token/BasicToken.sol';
+import 'libraries/token/ERC20.sol';
+
+
+contract MockStandardToken is ERC20, BasicToken {
+    using SafeMathUint256 for uint256;
+    address transferFromFromValue;
+    address transferFromToValue;
+    uint256 transferFromValueValue;
+    address approveSpenderValue;
+    uint256 approveValueValue;
+    address allowanceOwnerValue;
+    address allowanceSpenderValue;
+    uint256 allowanceValue;
+
+    function getTransferFromFromValue() public returns(address) {
+        return transferFromFromValue;
+    }
+
+    function getTransferFromToValue() public returns(address) {
+        return transferFromToValue;
+    }
+
+    function getTransferFromValueValue() public returns(uint256) {
+        return transferFromValueValue;
+    }
+
+    function getApproveSpenderValue() public returns(address) {
+        return approveSpenderValue;
+    }
+    
+    function getApproveValueValue() public returns(uint256) {
+        return approveValueValue;
+    }
+
+    function getAllowanceOwnerValue() public returns(address) {
+        return allowanceOwnerValue;
+    }
+    
+    function getAllowanceSpenderValue() public returns(address) {
+        return allowanceSpenderValue;
+    }
+
+    function setAllowanceValue(uint256 _amount) public {
+        allowanceValue = _amount;
+    }
+
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+        transferFromFromValue = _from;
+        transferFromToValue = _to;
+        transferFromValueValue = _value;
+        return true;
+    }
+
+    function approve(address _spender, uint256 _value) public returns (bool) {
+        approveSpenderValue = _spender;
+        approveValueValue = _value;
+        return true;
+    }
+
+
+    function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
+        allowanceOwnerValue = _owner;
+        allowanceSpenderValue = _spender;
+        return allowanceValue;
+    }
+}

--- a/tests/solidity_test_helpers/MockStandardToken.sol
+++ b/tests/solidity_test_helpers/MockStandardToken.sol
@@ -61,7 +61,6 @@ contract MockStandardToken is ERC20, BasicToken {
         return true;
     }
 
-
     function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
         allowanceOwnerValue = _owner;
         allowanceSpenderValue = _spender;

--- a/tests/solidity_test_helpers/MockVariableSupplyToken.sol
+++ b/tests/solidity_test_helpers/MockVariableSupplyToken.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.17;
 
 import 'TEST/MockStandardToken.sol';
 
+
 contract MockVariableSupplyToken is MockStandardToken {
     uint256 private setBalanceOfValue;
     address private transferToValue;

--- a/tests/solidity_test_helpers/MockVariableSupplyToken.sol
+++ b/tests/solidity_test_helpers/MockVariableSupplyToken.sol
@@ -11,7 +11,9 @@ contract MockVariableSupplyToken is MockStandardToken {
     address[] private transferAddresses;
     uint256[] private balanceOfAmounts;
     address[] private balanceOfAddresses;
-
+    address private transferFromFromValue;
+    address private transferFromToValue;
+    uint256 private transferFromValueValue;
     event Mint(address indexed target, uint256 value);
     event Burn(address indexed target, uint256 value);
 
@@ -57,6 +59,18 @@ contract MockVariableSupplyToken is MockStandardToken {
     function setTotalSupply(uint256 _totalSupply) public {
         setTotalSupplyValue = _totalSupply;
     }
+    
+    function getTransferFromFromValue() public returns(address) {
+        return transferFromFromValue;
+    }
+    
+    function getTransferFromToValue() public returns (address) {
+        return transferFromToValue;
+    }
+
+    function getTransferFromValueValue() public returns (uint256) {
+        return transferFromValueValue;
+    }
 
     function mint(address _target, uint256 _amount) internal returns (bool) {
         return true;
@@ -85,5 +99,12 @@ contract MockVariableSupplyToken is MockStandardToken {
     
     function totalSupply() public view returns (uint256) {
         return setTotalSupplyValue;
+    }
+
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+        transferFromFromValue = _from;
+        transferFromToValue = _to;
+        transferFromValueValue = _value;
+        return true;
     }
 }

--- a/tests/solidity_test_helpers/MockVariableSupplyToken.sol
+++ b/tests/solidity_test_helpers/MockVariableSupplyToken.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.17;
 
-import 'libraries/token/StandardToken.sol';
+import 'TEST/MockStandardToken.sol';
 
-
-contract MockVariableSupplyToken is StandardToken {
+contract MockVariableSupplyToken is MockStandardToken {
     uint256 private setBalanceOfValue;
     address private transferToValue;
     uint256 private transferValueValue;


### PR DESCRIPTION
unit tests for reputation token.
slimmed down creating mock test fixture, by using existing pattern of loading mock contracts.
added more call methods to existing mocks
removed offending/bug line from ReputationToken that adds to total supply on internalTrustedTransfer
