### PR TITLE
Makes ContractDeployer do incremental uploads.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ETHEREUM_PORT=8545
       - ETHEREUM_GAS_PRICE_IN_NANOETH=1
       - ETHEREUM_PRIVATE_KEY=0xe2b0241b73cd78d450f85eca67188fb884e7ebe961f8981814474c500d581952
+      # - AUGUR_CONTROLLER_ADDRESS=0x65d8b74efe5ff13ea6254864814269320d2db8fd
     links:
       - parity-dev-node
   geth-integration-tests:
@@ -39,5 +40,6 @@ services:
       - ETHEREUM_PORT=8545
       - ETHEREUM_GAS_PRICE_IN_NANOETH=1
       - ETHEREUM_PRIVATE_KEY=0xe2b0241b73cd78d450f85eca67188fb884e7ebe961f8981814474c500d581952
+      # - AUGUR_CONTROLLER_ADDRESS=0x35d93ab4de2f58c495e8ec0654f6dcc95c690fd2
     links:
       - geth-dev-node

--- a/source/contracts/Controller.sol
+++ b/source/contracts/Controller.sol
@@ -12,7 +12,7 @@ contract Controller is IController {
         bytes32 name;
         address contractAddress;
         bytes20 commitHash;
-        bytes32 fileHash;
+        bytes32 bytecodeHash;
     }
 
     address public owner;
@@ -75,14 +75,14 @@ contract Controller is IController {
      * Registry for lookups [whitelisted augur contracts and dev mode can use it]
      */
 
-    function registerContract(bytes32 _key, address _address, bytes20 _commitHash, bytes32 _fileHash) public onlyOwnerCaller returns(bool) {
-        registry[_key] = ContractDetails(_key, _address, _commitHash, _fileHash);
+    function registerContract(bytes32 _key, address _address, bytes20 _commitHash, bytes32 _bytecodeHash) public onlyOwnerCaller returns(bool) {
+        registry[_key] = ContractDetails(_key, _address, _commitHash, _bytecodeHash);
         return true;
     }
 
     function getContractDetails(bytes32 _key) public view returns (address, bytes20, bytes32) {
         ContractDetails storage _details = registry[_key];
-        return (_details.contractAddress, _details.commitHash, _details.fileHash);
+        return (_details.contractAddress, _details.commitHash, _details.bytecodeHash);
     }
 
     function unregisterContract(bytes32 _key) public onlyOwnerCaller returns(bool) {

--- a/source/contracts/trading/Cash.sol
+++ b/source/contracts/trading/Cash.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.17;
 
-
 import 'trading/ICash.sol';
 import 'Controlled.sol';
 import 'libraries/ITyped.sol';
@@ -13,8 +12,6 @@ import 'libraries/Extractable.sol';
  * @dev ETH wrapper contract to make it look like an ERC20 token.
  */
 contract Cash is Controlled, Extractable, ITyped, VariableSupplyToken, ICash {
-    using SafeMathUint256 for uint256;
-
     string constant public name = "Cash";
     string constant public symbol = "CASH";
     uint256 constant public decimals = 18;

--- a/source/libraries/Configuration.ts
+++ b/source/libraries/Configuration.ts
@@ -9,14 +9,16 @@ export class Configuration {
     public readonly privateKey: string;
     public readonly contractSourceRoot: string;
     public readonly contractOutputPath: string;
+    public readonly controllerAddress: string|undefined;
 
-    public constructor(host: string, port: number, gasPrice: BN, privateKey: string, contractSourceRoot: string, contractOutputPath: string) {
+    public constructor(host: string, port: number, gasPrice: BN, privateKey: string, contractSourceRoot: string, contractOutputPath: string, controllerAddress: string|undefined) {
         this.httpProviderHost = host;
         this.httpProviderPort = port;
         this.gasPrice = gasPrice;
         this.privateKey = privateKey;
         this.contractSourceRoot = contractSourceRoot;
         this.contractOutputPath = contractOutputPath;
+        this.controllerAddress = controllerAddress;
     }
 
     public static create = async (): Promise<Configuration> => {
@@ -26,7 +28,8 @@ export class Configuration {
         const privateKey = process.env.ETHEREUM_PRIVATE_KEY || '0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d';
         const contractSourceRoot = path.join(__dirname, "../../source/contracts/");
         const contractOutputPath = path.join(__dirname, "../../output/contracts/contracts.json");
+        const controllerAddress = process.env.AUGUR_CONTROLLER_ADDRESS;
 
-        return new Configuration(host, port, gasPrice, privateKey, contractSourceRoot, contractOutputPath);
+        return new Configuration(host, port, gasPrice, privateKey, contractSourceRoot, contractOutputPath, controllerAddress);
     }
 }

--- a/source/libraries/ContractCompiler.ts
+++ b/source/libraries/ContractCompiler.ts
@@ -5,7 +5,7 @@ import readFile = require('fs-readfile-promise');
 import asyncMkdirp = require('async-mkdirp');
 import * as path from "path";
 import * as recursiveReadDir from "recursive-readdir";
-import { CompilerInput, CompilerOutput, CompilerOutputContracts, compileStandardWrapper } from "solc";
+import { CompilerInput, CompilerOutput, compileStandardWrapper } from "solc";
 import { Configuration } from './Configuration';
 
 export class ContractCompiler {
@@ -15,7 +15,7 @@ export class ContractCompiler {
         this.configuration = configuration
     }
 
-    public async compileContracts(): Promise<CompilerOutputContracts> {
+    public async compileContracts(): Promise<CompilerOutput> {
         // Check if all contracts are cached (and thus do not need to be compiled)
         try {
             const stats = await fs.stat(this.configuration.contractOutputPath);
@@ -48,9 +48,9 @@ export class ContractCompiler {
 
         // Output contract data to single file
         const contractOutputFilePath = this.configuration.contractOutputPath;
-        await fs.writeFile(contractOutputFilePath, JSON.stringify(compilerOutput.contracts));
+        await fs.writeFile(contractOutputFilePath, JSON.stringify(compilerOutput, null, '\t'));
 
-        return compilerOutput.contracts;
+        return compilerOutput;
     }
 
     public async generateCompilerInput(): Promise<CompilerInput> {

--- a/source/libraries/ContractInterfaces.ts
+++ b/source/libraries/ContractInterfaces.ts
@@ -1,6 +1,6 @@
 import BN = require('bn.js');
 import { encodeMethod, decodeParams } from 'ethjs-abi';
-import { AbiFunction } from 'ethjs-shared';
+import { AbiFunction } from 'ethereum';
 import { AccountManager } from './AccountManager';
 import { Connector } from './Connector';
 
@@ -77,6 +77,20 @@ export class Controller extends Contract {
         options = options || {};
         const abi: AbiFunction = {"constant":true,"inputs":[{"name":"_target","type":"address"}],"name":"addToWhitelist","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
         const result = await this.localCall(abi, [address], options.sender);
+        return <boolean>result[0];
+    }
+
+    public getContractDetails_ = async (key: string, options?: { sender?: string }): Promise<Array<string>> => {
+        options = options || {};
+        const abi: AbiFunction = {"constant":true,"inputs":[{"name":"_key","type":"bytes32"}],"name":"getContractDetails","outputs":[{"name":"","type":"address"},{"name":"","type":"bytes20"},{"name":"","type":"bytes32"}],"payable":false,"stateMutability":"view","type":"function"};
+        const result = await this.localCall(abi, [key], options.sender);
+        return <Array<string>>result;
+    }
+
+    public whitelist_ = async (key: string, options?: { sender?: string }): Promise<boolean> => {
+        options = options || {};
+        const abi: AbiFunction = {"constant":true,"inputs":[{"name":"","type":"address"}],"name":"whitelist","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"};
+        const result = await this.localCall(abi, [key], options.sender);
         return <boolean>result[0];
     }
 }

--- a/source/libraries/Contracts.ts
+++ b/source/libraries/Contracts.ts
@@ -1,0 +1,53 @@
+import { Abi } from 'ethereum';
+import { CompilerOutput } from 'solc';
+
+export class Contract {
+    public readonly relativeFilePath: string;
+    public readonly contractName: string;
+    public readonly abi: Abi;
+    public readonly bytecode: Buffer;
+    public address?: string;
+
+    public constructor(relativeFilePath: string, contractName: string, abi: Abi, bytecode: Buffer) {
+        this.relativeFilePath = relativeFilePath;
+        this.contractName = contractName;
+        this.abi = abi;
+        this.bytecode = bytecode;
+    }
+}
+
+export class Contracts implements Iterable<Contract> {
+    private readonly contracts = new Map<string, Contract>();
+
+    public constructor(compilerOutput: CompilerOutput) {
+        for (let relativeFilePath in compilerOutput.contracts) {
+            for (let contractName in compilerOutput.contracts[relativeFilePath]) {
+                // don't include helper libraries
+                if (!relativeFilePath.endsWith(`${contractName}.sol`)) continue;
+                const abi = compilerOutput.contracts[relativeFilePath][contractName].abi;
+                if (abi === undefined) continue;
+                const bytecodeString = compilerOutput.contracts[relativeFilePath][contractName].evm.bytecode.object;
+                if (bytecodeString === undefined) continue;
+                // don't include interfaces
+                if (bytecodeString.length === 0) continue;
+                const bytecode = Buffer.from(bytecodeString, 'hex');
+                const compiledContract = new Contract(relativeFilePath, contractName, abi, bytecode);
+                this.contracts.set(contractName, compiledContract);
+            }
+        }
+    }
+
+    public has = (contractName: string): boolean => {
+        return this.contracts.has(contractName);
+    }
+
+    public get = (contractName: string): Contract => {
+        if (!this.contracts.has(contractName)) throw new Error(`${contractName} does not exist.`);
+        return this.contracts.get(contractName)!;
+    }
+
+    [Symbol.iterator]() {
+        const contracts = this.contracts.values();
+        return { next: contracts.next.bind(contracts) }
+    }
+}

--- a/typings/ethereum.d.ts
+++ b/typings/ethereum.d.ts
@@ -1,0 +1,29 @@
+export type Primitive = 'uint256' | 'uint64' | 'uint8' | 'bool' | 'string' | 'address' | 'bytes20' | 'bytes32' | 'bytes';
+
+export interface AbiParameter {
+    name: string,
+    type: Primitive,
+}
+
+export interface AbiEventParameter extends AbiParameter {
+    indexed: boolean,
+}
+
+export interface AbiFunction {
+    name: string,
+    type: 'function' | 'constructor' | 'fallback',
+    stateMutability: 'pure' | 'view' | 'payable' | 'nonpayable',
+    constant: boolean,
+    payable: boolean,
+    inputs: Array<AbiParameter>,
+    outputs: Array<AbiParameter>,
+}
+
+export interface AbiEvent {
+    name: string,
+    type: 'event',
+    inputs: Array<AbiEventParameter>,
+    anonymous: boolean,
+}
+
+export type Abi = Array<AbiFunction | AbiEvent>;

--- a/typings/ethjs-abi.d.ts
+++ b/typings/ethjs-abi.d.ts
@@ -1,5 +1,5 @@
 declare module 'ethjs-abi' {
-    import { AbiFunction, AbiEvent, Primitive } from 'ethjs-shared';
+    import { AbiFunction, AbiEvent, Primitive } from 'ethereum';
     export function encodeMethod(abi: AbiFunction, parameters: Array<any>): string;
     export function decodeMethod(abi: AbiFunction, encoded: string): Array<any>;
     export function encodeEvent(abi: AbiEvent, parameters: Array<any>): string;

--- a/typings/ethjs-query.d.ts
+++ b/typings/ethjs-query.d.ts
@@ -2,7 +2,7 @@ declare module 'ethjs-query' {
     import EthjsHttpProvider = require('ethjs-provider-http');
     import EthjsRpc = require('ethjs-rpc');
     import BN = require('bn.js');
-    import { Abi, Block, Transaction, TransactionReceipt, Log } from 'ethjs-shared';
+    import { Block, Transaction, TransactionReceipt, Log } from 'ethjs-shared';
 
     class EthjsQuery {
         constructor(provider: EthjsHttpProvider);

--- a/typings/ethjs-shared.d.ts
+++ b/typings/ethjs-shared.d.ts
@@ -1,34 +1,5 @@
 declare module 'ethjs-shared' {
     import BN = require('bn.js');
-    export type Primitive = 'uint256' | 'uint64' | 'uint8' | 'bool' | 'string' | 'address' | 'bytes20' | 'bytes32' | 'bytes';
-
-    export interface AbiParameter {
-        name: string,
-        type: Primitive,
-    }
-
-    export interface AbiEventParameter extends AbiParameter {
-        indexed: boolean,
-    }
-
-    export interface AbiFunction {
-        name: string,
-        type: 'function',
-        stateMutability: 'pure' | 'constant' | 'view' | 'payable' | 'nonpayable',
-        constant: boolean,
-        payable: boolean,
-        inputs: AbiParameter[],
-        outputs: AbiParameter[],
-    }
-
-    export interface AbiEvent {
-        name: string,
-        type: 'event',
-        inputs: AbiEventParameter[],
-        anonymous: boolean,
-    }
-
-    export type Abi = AbiFunction | AbiEvent;
 
     export interface Transaction {
         from?: string;

--- a/typings/solc.d.ts
+++ b/typings/solc.d.ts
@@ -1,5 +1,5 @@
 declare module 'solc' {
-    export type Primitive = 'uint256' | 'bool' | 'address' | 'uint64' | 'bytes32' | 'bytes';
+    import { Abi, Primitive } from 'ethereum';
 
     interface CompilerInputSourceFile {
         keccak256?: string;
@@ -28,23 +28,6 @@ declare module 'solc' {
         message: string;
         formattedMessage?: string;
     }
-    interface CompilerOutputContractAbi {
-        type: "function"|"constructor"|"fallback"|"event";
-        name: string;
-        constant: boolean;
-        inputs: { name: string, type: Primitive }[];
-    }
-    interface CompilerOutputContractAbiFunction extends CompilerOutputContractAbi {
-        type: "function"|"constructor"|"fallback";
-        outputs?: { name: string, type: Primitive }[];
-        payable: boolean;
-        stateMutability: "pure"|"view"|"nonpayable"|"payable";
-        constant: boolean;
-    }
-    interface CompilerOutputContractAbiEvent extends CompilerOutputContractAbi {
-        type: "event";
-        anonymous: boolean;
-    }
     interface CompilerOutputEvmBytecode {
         object: string;
         opcodes: string;
@@ -62,11 +45,10 @@ declare module 'solc' {
             legacyAST: any;
         },
     }
-    type CompilerOutputAbi = CompilerOutputContractAbiFunction|CompilerOutputContractAbiEvent;
     interface CompilerOutputContracts {
         [globalName: string]: {
             [contractName: string]: {
-                abi: (CompilerOutputAbi)[];
+                abi: Abi;
                 metadata: string;
                 userdoc: any;
                 devdoc: any;


### PR DESCRIPTION
If the currently uploaded contract (as registered with Controller) has the same bytecode sha as the bytecode to be uploaded then skip uploading.  Similarly, skip whitelisting/initialization if it is already done for the target contract.  Contains some pretty significant refactoring along the way, recommend ignoring the changeset for `ContractDeployer` and instead just reading the code directly.

I also cleaned up some of the definition files that were duplicated.