### PR TITLE
Moves filtering to ContractCompiler.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,13 @@
             "problemMatcher": [
                 "$tsc-watch"
             ]
+        },
+        {
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "problemMatcher": [
+                "$tsc"
+            ]
         }
     ]
 }

--- a/Dockerfile-integration-tests
+++ b/Dockerfile-integration-tests
@@ -10,6 +10,8 @@ COPY source/contracts/ /app/source/contracts/
 COPY source/deployment/compileContracts.ts /app/source/deployment/compileContracts.ts
 COPY source/libraries/Configuration.ts /app/source/libraries/Configuration.ts
 COPY source/libraries/ContractCompiler.ts /app/source/libraries/ContractCompiler.ts
+RUN npx tsc
+RUN node ./output/deployment/compileContracts.js
 COPY source/libraries/ContractInterfacesGenerator.ts /app/source/libraries/ContractInterfacesGenerator.ts
 COPY source/tools/generateContractInterfaces.ts /app/source/tools/generateContractInterfaces.ts
 RUN npx tsc

--- a/source/libraries/Configuration.ts
+++ b/source/libraries/Configuration.ts
@@ -9,17 +9,19 @@ export class Configuration {
     public readonly privateKey: string;
     public readonly contractSourceRoot: string;
     public readonly contractOutputPath: string;
+    public readonly contractAddressesOutputPath: string;
     public readonly contractInterfacesOutputPath: string;
     public readonly controllerAddress: string|undefined;
 
-    public constructor(host: string, port: number, gasPrice: BN, privateKey: string, contractSourceRoot: string, contractOutputPath: string, contractInterfacesOutputPath: string, controllerAddress: string|undefined) {
+    public constructor(host: string, port: number, gasPrice: BN, privateKey: string, contractSourceRoot: string, contractOutputRoot: string, controllerAddress: string|undefined) {
         this.httpProviderHost = host;
         this.httpProviderPort = port;
         this.gasPrice = gasPrice;
         this.privateKey = privateKey;
         this.contractSourceRoot = contractSourceRoot;
-        this.contractOutputPath = contractOutputPath;
-        this.contractInterfacesOutputPath = contractInterfacesOutputPath;
+        this.contractOutputPath = path.join(contractOutputRoot, 'contracts.json');
+        this.contractAddressesOutputPath = path.join(contractOutputRoot, 'addresses.json');
+        this.contractInterfacesOutputPath = path.join(contractSourceRoot, 'libraries', 'ContractInterfaces.ts');
         this.controllerAddress = controllerAddress;
     }
 
@@ -29,10 +31,9 @@ export class Configuration {
         const gasPrice = (typeof process.env.ETHEREUM_GAS_PRICE_IN_NANOETH === "undefined") ? new BN(20) : new BN(process.env.ETHEREUM_GAS_PRICE_IN_NANOETH!).mul(new BN(1000000000));
         const privateKey = process.env.ETHEREUM_PRIVATE_KEY || '0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d';
         const contractSourceRoot = path.join(__dirname, "../../source/contracts/");
-        const contractOutputPath = path.join(__dirname, "../../output/contracts/contracts.json");
-        const contractInterfacesOutputPath = path.join(__dirname, "../../source/libraries/ContractInterfaces.ts");
+        const contractOutputRoot = path.join(__dirname, "../../output/contracts/");
         const controllerAddress = process.env.AUGUR_CONTROLLER_ADDRESS;
 
-        return new Configuration(host, port, gasPrice, privateKey, contractSourceRoot, contractOutputPath, contractInterfacesOutputPath, controllerAddress);
+        return new Configuration(host, port, gasPrice, privateKey, contractSourceRoot, contractOutputRoot, controllerAddress);
     }
 }

--- a/source/libraries/Contracts.ts
+++ b/source/libraries/Contracts.ts
@@ -22,16 +22,8 @@ export class Contracts implements Iterable<Contract> {
     public constructor(compilerOutput: CompilerOutput) {
         for (let relativeFilePath in compilerOutput.contracts) {
             for (let contractName in compilerOutput.contracts[relativeFilePath]) {
-                // don't include helper libraries
-                if (!relativeFilePath.endsWith(`${contractName}.sol`)) continue;
-                const abi = compilerOutput.contracts[relativeFilePath][contractName].abi;
-                if (abi === undefined) continue;
-                const bytecodeString = compilerOutput.contracts[relativeFilePath][contractName].evm.bytecode.object;
-                if (bytecodeString === undefined) continue;
-                // don't include interfaces
-                if (bytecodeString.length === 0) continue;
-                const bytecode = Buffer.from(bytecodeString, 'hex');
-                const compiledContract = new Contract(relativeFilePath, contractName, abi, bytecode);
+                const bytecode = Buffer.from(compilerOutput.contracts[relativeFilePath][contractName].evm.bytecode.object, 'hex');
+                const compiledContract = new Contract(relativeFilePath, contractName, compilerOutput.contracts[relativeFilePath][contractName].abi, bytecode);
                 this.contracts.set(contractName, compiledContract);
             }
         }
@@ -46,7 +38,7 @@ export class Contracts implements Iterable<Contract> {
         return this.contracts.get(contractName)!;
     }
 
-    [Symbol.iterator]() {
+    [Symbol.iterator](): Iterator<Contract> {
         const contracts = this.contracts.values();
         return { next: contracts.next.bind(contracts) }
     }

--- a/typings/solc.d.ts
+++ b/typings/solc.d.ts
@@ -30,9 +30,9 @@ declare module 'solc' {
     }
     interface CompilerOutputEvmBytecode {
         object: string;
-        opcodes: string;
-        sourceMap: string;
-        linkReferences: {} | {
+        opcodes?: string;
+        sourceMap?: string;
+        linkReferences?: {} | {
             [globalName: string]: {
                 [name: string]: {start: number, length: number}[];
             };
@@ -49,19 +49,19 @@ declare module 'solc' {
         [globalName: string]: {
             [contractName: string]: {
                 abi: Abi;
-                metadata: string;
-                userdoc: any;
-                devdoc: any;
-                ir: string;
+                metadata?: string;
+                userdoc?: any;
+                devdoc?: any;
+                ir?: string;
                 evm: {
-                    assembly: string;
-                    legacyAssembly: any;
+                    assembly?: string;
+                    legacyAssembly?: any;
                     bytecode: CompilerOutputEvmBytecode;
-                    deployedBytecode: CompilerOutputEvmBytecode;
-                    methodIdentifiers: {
+                    deployedBytecode?: CompilerOutputEvmBytecode;
+                    methodIdentifiers?: {
                         [methodName: string]: string;
                     };
-                    gasEstimates: {
+                    gasEstimates?: {
                         creation: {
                             codeDepositCost: string;
                             executionCost: string;
@@ -75,7 +75,7 @@ declare module 'solc' {
                         };
                     };
                 };
-                ewasm: {
+                ewasm?: {
                     wast: string;
                     wasm: string;
                 }
@@ -84,7 +84,7 @@ declare module 'solc' {
     }
     interface CompilerOutput {
         errors?: CompilerOutputError[];
-        sources: CompilerOutputSources;
+        sources?: CompilerOutputSources;
         contracts: CompilerOutputContracts;
     }
     type ReadCallback = (path: string) => { contents?: string, error?: string};


### PR DESCRIPTION
This will greatly reduce the on-disk file, which makes it more usable for the front-end and also speeds things up marginally (no more need to read/parse a 12.5MB file JSON file).

@pgebheim `output/contracts/contracts.json` is ready to be shipped off to `augur-contracts`.