### PR TITLE
Linter: Enable (pre-installed) security plugin

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,5 +1,6 @@
 {
   "extends": "solium:all",
+  "plugins": ["security"],
   "rules": {
     "imports-on-top": 0,
     "variable-declarations": 0,

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -9,6 +9,11 @@
     "no-empty-blocks": 0,
     "arg-overflow": 0,
     "uppercase": 0,
-    "operator-whitespace": 0
+    "operator-whitespace": 0,
+    "security/no-low-level-calls": 0,
+    "security/no-inline-assembly": 0,
+    "security/no-call-value": 0,
+    "security/no-block-members": 0,
+    "security/enforce-explicit-visibility": 0
   }
 }


### PR DESCRIPTION
Hi guys,
Solium's [official security plugin](https://github.com/duaraghav8/solium-plugin-security) checks for security based on [recommendations from Consensys](https://consensys.github.io/smart-contract-best-practices/recommendations/).

The plugin simply needs to be enabled, no installation or other steps required.

Configuring in `.soliumrc.json` is simple:
```
{
    "plugins": ["security"],
    "rules": {
        "security/no-throw": 0
    }
}
```

[Usage Guide & List of Rules](https://github.com/duaraghav8/solium-plugin-security) (2 minute read)
[Release blog](https://medium.com/solium/soliums-official-security-plugin-4d604e708c3c)

Although not mandatory, its highly recommended that you enable the plugin. So its your decision:)

(This PR will probably fail your CI tests because all security lint rules are treated as errors by default).