### PR TITLE
Market creator fees now go to a Mailbox contract associated with the market and owned by the creator.

### DIFF
--- a/source/contracts/factories/MailboxFactory.sol
+++ b/source/contracts/factories/MailboxFactory.sol
@@ -1,0 +1,16 @@
+pragma solidity 0.4.17;
+
+
+import 'libraries/Delegator.sol';
+import 'IController.sol';
+import 'libraries/IMailbox.sol';
+
+
+contract MailboxFactory {
+    function createMailbox(IController _controller, address _owner) public returns (IMailbox) {
+        Delegator _delegator = new Delegator(_controller, "Mailbox");
+        IMailbox _mailbox = IMailbox(_delegator);
+        _mailbox.initialize(_owner);
+        return _mailbox;
+    }
+}

--- a/source/contracts/libraries/IMailbox.sol
+++ b/source/contracts/libraries/IMailbox.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.4.17;
+
+
+contract IMailbox {
+    function initialize(address _owner) public returns (bool);
+}

--- a/source/contracts/libraries/IOwnable.sol
+++ b/source/contracts/libraries/IOwnable.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.17;
 
 
-
 contract IOwnable {
     function getOwner() public view returns (address);
     function transferOwnership(address newOwner) public returns (bool);

--- a/source/contracts/libraries/Mailbox.sol
+++ b/source/contracts/libraries/Mailbox.sol
@@ -1,0 +1,42 @@
+pragma solidity 0.4.17;
+
+import 'libraries/DelegationTarget.sol';
+import 'libraries/Ownable.sol';
+import 'libraries/token/ERC20Basic.sol';
+import 'libraries/IMailbox.sol';
+import 'libraries/Initializable.sol';
+import 'trading/ICash.sol';
+
+
+contract Mailbox is DelegationTarget, Ownable, Initializable, IMailbox {
+    function initialize(address _owner) public onlyInGoodTimes beforeInitialized returns (bool) {
+        endInitialization();
+        owner = _owner;
+        return true;
+    }
+
+    //As a delegation target we cannot override the fallback, so we provide a specific method to deposit ETH
+    function depositEther() public payable onlyInGoodTimes returns (bool) {
+        return true;
+    }
+
+    function withdrawEther() public onlyOwner returns (bool) {
+        // Withdraw any Cash balance
+        ICash _cash = ICash(controller.lookup("Cash"));
+        uint256 _tokenBalance = _cash.balanceOf(this);
+        if (_tokenBalance > 0) {
+            _cash.withdrawEtherTo(owner, _tokenBalance);
+        }
+        // Withdraw any ETH balance
+        if (this.balance > 0) {
+            require(owner.call.value(this.balance)());
+        }
+        return true;
+    }
+
+    function withdrawTokens(ERC20Basic _token) public onlyOwner returns (bool) {
+        uint256 _balance = _token.balanceOf(this);
+        require(_token.transfer(owner, _balance));
+        return true;
+    }
+}

--- a/source/contracts/reporting/IMarket.sol
+++ b/source/contracts/reporting/IMarket.sol
@@ -10,6 +10,7 @@ import 'reporting/IReportingWindow.sol';
 import 'reporting/IStakeToken.sol';
 import 'reporting/IDisputeBond.sol';
 import 'trading/IShareToken.sol';
+import 'libraries/IMailbox.sol';
 
 
 contract IMarket is ITyped, IOwnable {
@@ -59,6 +60,7 @@ contract IMarket is ITyped, IOwnable {
     function getTotalStake() public view returns (uint256);
     function getTotalWinningDisputeBondStake() public view returns (uint256);
     function getExtraDisputeBondRemainingToBePaidOut() public view returns (uint256);
+    function getMarketCreatorMailbox() public view returns (IMailbox);
     function decreaseExtraDisputeBondRemainingToBePaidOut(uint256 _amount) public returns (bool);
     function firstReporterCompensationCheck(address _reporter) public returns (uint256);
     function increaseTotalStake(uint256 _amount) public returns (bool);

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -20,6 +20,8 @@ import 'libraries/token/ERC20Basic.sol';
 import 'libraries/math/SafeMathUint256.sol';
 import 'libraries/math/SafeMathInt256.sol';
 import 'libraries/Extractable.sol';
+import 'factories/MailboxFactory.sol';
+import 'libraries/IMailbox.sol';
 import 'reporting/Reporting.sol';
 import 'Augur.sol';
 
@@ -59,6 +61,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
     uint256 private reporterGasCostsFeeAttoeth;
     uint256 private totalStake;
     uint256 private extraDisputeBondRemainingToBePaidOut;
+    IMailbox private marketCreatorMailbox;
 
     /**
      * @dev Makes the function trigger a migration before execution
@@ -87,6 +90,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
         designatedReporterAddress = _designatedReporterAddress;
         cash = _cash;
         stakeTokens = MapFactory(controller.lookup("MapFactory")).createMap(controller, this);
+        marketCreatorMailbox = MailboxFactory(controller.lookup("MailboxFactory")).createMailbox(controller, owner);
         for (uint8 _outcome = 0; _outcome < numOutcomes; _outcome++) {
             shareTokens.push(createShareToken(_outcome));
         }
@@ -513,6 +517,10 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
 
     function getExtraDisputeBondRemainingToBePaidOut() public view returns (uint256) {
         return extraDisputeBondRemainingToBePaidOut;
+    }
+
+    function getMarketCreatorMailbox() public view returns (IMailbox) {
+        return marketCreatorMailbox;
     }
 
     function getTotalWinningDisputeBondStake() public view returns (uint256) {

--- a/source/contracts/trading/ClaimTradingProceeds.sol
+++ b/source/contracts/trading/ClaimTradingProceeds.sol
@@ -47,9 +47,7 @@ contract ClaimTradingProceeds is CashAutoConverter, Extractable, ReentrancyGuard
                 require(_denominationToken.transferFrom(_market, msg.sender, _shareHolderShare));
             }
             if (_creatorShare > 0) {
-                // For this payout we transfer Cash to this contract and then convert it into ETH before giving it ot the market owner
-                require(_denominationToken.transferFrom(_market, this, _creatorShare));
-                _denominationToken.withdrawEtherTo(_market.getOwner(), _creatorShare);
+                require(_denominationToken.transferFrom(_market, _market.getMarketCreatorMailbox(), _creatorShare));
             }
             if (_reporterShare > 0) {
                 require(_denominationToken.transferFrom(_market, _market.getUniverse().getOrCreateNextReportingWindow(), _reporterShare));

--- a/source/contracts/trading/CompleteSets.sol
+++ b/source/contracts/trading/CompleteSets.sol
@@ -66,9 +66,7 @@ contract CompleteSets is Controlled, Extractable, CashAutoConverter, ReentrancyG
         }
 
         if (_creatorFee != 0) {
-            // For this payout we transfer Cash to this contract and then convert it into ETH before giving it ot the market owner
-            require(_denominationToken.transferFrom(_market, this, _creatorFee));
-            _denominationToken.withdrawEtherTo(_market.getOwner(), _creatorFee);
+            require(_denominationToken.transferFrom(_market, _market.getMarketCreatorMailbox(), _creatorFee));
         }
         if (_reportingFee != 0) {
             IReportingWindow _reportingWindow = _market.getUniverse().getOrCreateNextReportingWindow();

--- a/tests/libraries/test_mailbox.py
+++ b/tests/libraries/test_mailbox.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+from ethereum.tools import tester
+from ethereum.tools.tester import TransactionFailed
+from pytest import fixture, raises
+from utils import stringToBytes, EtherDelta, TokenDelta
+
+def test_mailbox_eth_happy_path(localFixture, mailbox):
+    # We can send some ETH to the mailbox
+    with EtherDelta(100, mailbox.address, localFixture.chain, "Deposit did not work"):
+        assert mailbox.depositEther(value=100)
+
+    # We can also withdraw the ETH balance of the mailbox
+    with EtherDelta(100, tester.a0, localFixture.chain, "Withdraw did not work"):
+        assert mailbox.withdrawEther()
+
+def test_mailbox_tokens_happy_path(localFixture, mailbox, token):
+    # We can send some Tokens to the mailbox
+    assert token.faucet(100)
+
+    with TokenDelta(token, 100, mailbox.address, "Token deposit did not work"):
+        with TokenDelta(token, -100, tester.a0, "Token deposit did not work"):
+            token.transfer(mailbox.address, 100)
+
+    # The mailbox owner can withdraw these tokens
+    with TokenDelta(token, 100, tester.a0, "Token withdraw did not work"):
+        with TokenDelta(token, -100, mailbox.address, "Token withdraw did not work"):
+            mailbox.withdrawTokens(token.address)
+
+def test_mailbox_eth_failure(localFixture, mailbox):
+    # We send some ETH to the mailbox
+    with EtherDelta(100, mailbox.address, localFixture.chain, "Deposit did not work"):
+        assert mailbox.depositEther(value=100)
+
+    # Withdrawing as someone other than the owner will fail
+    with raises(TransactionFailed):
+        mailbox.withdrawEther(sender=tester.k1)
+
+def test_mailbox_tokens_failure(localFixture, mailbox, token):
+    # We send some Tokens to the mailbox
+    assert token.faucet(100)
+
+    with TokenDelta(token, 100, mailbox.address, "Token deposit did not work"):
+        with TokenDelta(token, -100, tester.a0, "Token deposit did not work"):
+            token.transfer(mailbox.address, 100)
+
+    # Withdrawing as someone other than the owner will fail
+    with raises(TransactionFailed):
+        mailbox.withdrawTokens(token.address, sender=tester.k1)
+
+def test_mailbox_cash_happy_path(localFixture, mailbox, cash):
+    # We can send some Cash to the mailbox
+    assert cash.depositEther(value=100)
+    assert cash.balanceOf(tester.a0) == 100
+
+    with TokenDelta(cash, 100, mailbox.address, "Deposit did not work"):
+        assert cash.transfer(mailbox.address, 100)
+
+    # We can withdraw "Ether" and the Cash balance in the mailbox will be given to the owner as Ether
+    with EtherDelta(100, tester.a0, localFixture.chain, "Withdraw did not work"):
+        assert mailbox.withdrawEther()
+
+@fixture(scope="session")
+def localSnapshot(fixture, controllerSnapshot):
+    fixture.resetToSnapshot(controllerSnapshot)
+
+    # Upload a token
+    fixture.uploadAndAddToController("solidity_test_helpers/StandardTokenHelper.sol")
+
+    # Upload Cash
+    cash = fixture.uploadAndAddToController("../source/contracts/trading/Cash.sol")
+    cash.setController(fixture.contracts['Controller'].address)
+
+    # Upload the mailbox
+    name = "Mailbox"
+    targetName = "MailboxTarget"
+    fixture.uploadAndAddToController("../source/contracts/libraries/Mailbox.sol", targetName, name)
+    fixture.uploadAndAddToController("../source/contracts/libraries/Delegator.sol", name, "delegator", constructorArgs=[fixture.contracts['Controller'].address, stringToBytes(targetName)])
+    fixture.contracts[name] = fixture.applySignature(name, fixture.contracts[name].address)
+    fixture.contracts[name].initialize(tester.a0)
+    return fixture.createSnapshot()
+
+@fixture
+def localFixture(fixture, localSnapshot):
+    fixture.resetToSnapshot(localSnapshot)
+    return fixture
+
+@fixture
+def mailbox(localFixture):
+    return localFixture.contracts['Mailbox']
+
+@fixture
+def token(localFixture):
+    return localFixture.contracts['StandardTokenHelper']
+
+@fixture
+def cash(localFixture):
+    return localFixture.contracts['Cash']

--- a/tests/solidity_test_helpers/MockMarket.sol
+++ b/tests/solidity_test_helpers/MockMarket.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.17;
 import 'reporting/IMarket.sol';
 import 'reporting/IUniverse.sol';
 import 'libraries/ITyped.sol';
+import 'libraries/IMailbox.sol';
 
 
 contract MockMarket is IMarket {
@@ -55,6 +56,7 @@ contract MockMarket is IMarket {
     uint256 private setTotalStakeValue;
     uint256 private setExtraDisputeBondRemainingToBePaidOutValue;
     bool private setDecreaseExtraDisputeBondRemainingToBePaidOutValue;
+    IMailbox private setMarketCreatorMailbox;
     /*
     * setters to feed the getters and impl of IMarket
     */
@@ -286,6 +288,10 @@ contract MockMarket is IMarket {
         setDecreaseExtraDisputeBondRemainingToBePaidOutValue = _setDecreaseExtraDisputeBondRemainingToBePaidOutValue;
     }
 
+    function setMarketCreatorMailboxValue(IMailbox _setMarketCreatorMailbox) public {
+        setMarketCreatorMailbox = _setMarketCreatorMailbox;
+    }
+
     /*
     * IMarket methods
     */
@@ -466,5 +472,9 @@ contract MockMarket is IMarket {
 
     function decreaseExtraDisputeBondRemainingToBePaidOut(uint256 _amount) public returns (bool) {
         return setDecreaseExtraDisputeBondRemainingToBePaidOutValue;
+    }
+
+    function getMarketCreatorMailbox() public view returns (IMailbox) {
+        return setMarketCreatorMailbox;
     }
 }

--- a/tests/trading/test_claimTradingProceeds.py
+++ b/tests/trading/test_claimTradingProceeds.py
@@ -95,7 +95,7 @@ def test_redeem_shares_in_binary_market(kitchenSinkFixture, universe, cash, mark
     logs = []
     captureFilteredLogs(kitchenSinkFixture.chain.head_state, kitchenSinkFixture.contracts['Augur'], logs)
 
-    with EtherDelta(expectedMarketCreatorFees, tester.a0, kitchenSinkFixture.chain, "Market creator fees not paid"):
+    with TokenDelta(cash, expectedMarketCreatorFees, market.getMarketCreatorMailbox(), "Market creator fees not paid"):
         with TokenDelta(cash, expectedReporterFees, market.getReportingWindow(), "Reporter fees not paid"):
             # redeem shares with a1
             initialLongHolderETH = kitchenSinkFixture.chain.head_state.get_balance(tester.a1)

--- a/tests/trading/test_completeSets.py
+++ b/tests/trading/test_completeSets.py
@@ -72,7 +72,7 @@ def test_publicSellCompleteSets(contractsFixture, universe, cash, market):
     assert noShareToken.totalSupply() == 1
     assert contractsFixture.chain.head_state.get_balance(tester.a1) == initialTester1ETH + fix('8.9091')
     assert cash.balanceOf(market.address) == fix('1')
-    assert contractsFixture.chain.head_state.get_balance(tester.a0) == initialTester0ETH + fix('0.09')
+    assert cash.balanceOf(market.getMarketCreatorMailbox()) == fix('0.09')
     assert cash.balanceOf(market.getReportingWindow()) == fix('0.0009')
 
 def test_publicSellCompleteSets_failure(contractsFixture, universe, cash, market):


### PR DESCRIPTION
The withdrawEther function on the mailbox also handles Cash conversion. I opted to not use the autoconverter library as this, overall, reduces code and complication a lot to just directly convert in this contract.