### PR TITLE
Send fee reimbursments to the mailbox instead of directly to the market creator

### DIFF
--- a/source/contracts/libraries/IMailbox.sol
+++ b/source/contracts/libraries/IMailbox.sol
@@ -3,4 +3,5 @@ pragma solidity 0.4.17;
 
 contract IMailbox {
     function initialize(address _owner) public returns (bool);
+    function depositEther() public payable returns (bool);
 }

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -141,7 +141,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
         // The owner gets the no-show REP bond
         _reputationToken.transfer(owner, _reputationToken.balanceOf(this));
         // The owner gets the reporter gas costs
-        require(getOwner().call.value(reporterGasCostsFeeAttoeth)());
+        marketCreatorMailbox.depositEther.value(reporterGasCostsFeeAttoeth)();
         return true;
     }
 
@@ -275,7 +275,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
         controller.getAugur().logMarketFinalized(getUniverse(), this);
         // The validity bond is paid to the owner in any valid outcome and the reporting window otherwise
         if (isValid()) {
-            require(getOwner().call.value(validityBondAttoeth)());
+            marketCreatorMailbox.depositEther.value(validityBondAttoeth)();
         } else {
             cash.depositEtherFor.value(validityBondAttoeth)(getReportingWindow());
         }

--- a/tests/reporting/test_market_unit.py
+++ b/tests/reporting/test_market_unit.py
@@ -80,7 +80,7 @@ def test_market_designated_report(localFixture, constants, mockUniverse, chain, 
 
     numTicks = 10 ** 10
     payoutDesignatedNumerators = [numTicks, 0, 0, 0, 0]
-    push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
+    push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
 
 def test_market_dispute_report_with_attoeth(localFixture, constants, initializeMarket, chain, mockUniverse, mockDisputeBond, mockDisputeBondFactory, mockStakeToken, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, mockAugur):
     numTicks = 10 ** 10
@@ -91,7 +91,7 @@ def test_market_dispute_report_with_attoeth(localFixture, constants, initializeM
     with raises(TransactionFailed, message="market needs to be in DESIGNATED_DISPUTE state"):
         initializeMarket.disputeDesignatedReport(payoutDesignatedNumerators, 100, False)
 
-    push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
+    push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
     mockReportingWindow.reset()
     mockDisputeBondFactory.setCreateDisputeBond(mockDisputeBond.address)
 
@@ -140,7 +140,7 @@ def test_market_dispute_report_with_no_attoeth(localFixture, constants, initiali
     payoutDesignatedHash = initializeMarket.derivePayoutDistributionHash(payoutDesignatedNumerators, False)
     payoutFirstDisputeHash = initializeMarket.derivePayoutDistributionHash(payoutFirstDisputeNumeratorsDispute, False)
 
-    push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
+    push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
     assert initializeMarket.getTentativeWinningPayoutDistributionHash() == payoutDesignatedHash
     assert initializeMarket.getBestGuessSecondPlaceTentativeWinningPayoutDistributionHash() == stringToBytes("")
     # set value for original designated report so that calcuations for tent. winning token doesn't blow up
@@ -210,7 +210,7 @@ def test_market_update_tentative_winning_payout(localFixture, constants, initial
     payoutThirdHashValue = initializeMarket.derivePayoutDistributionHash(payoutThirdNumerators, False)
     payoutFourthHashValue = initializeMarket.derivePayoutDistributionHash(payoutFourthNumerators, False)
 
-    push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
+    push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
     assert initializeMarket.getTentativeWinningPayoutDistributionHash() == payoutDesignatedHashValue
 
     mockReportingWindow.reset()
@@ -282,7 +282,7 @@ def test_market_get_payout_distr_hash_stake(localFixture, initializeMarket, mock
 def test_market_dispute_last_reporter(localFixture, initializeMarket, constants, mockAugur, mockReportingWindow, mockDisputeBondFactory, mockReputationToken, mockDisputeBond, chain, mockUniverse, mockStakeToken, mockStakeTokenFactory, mockNextReportingWindow):
     numTicks = 10 ** 10
 
-    push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, [0,numTicks,0,0,0], mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
+    push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, [0,numTicks,0,0,0], mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
 
     push_first_dispute_last_reporting(localFixture, chain, mockReputationToken, initializeMarket, mockStakeTokenFactory, mockReportingWindow, mockUniverse, constants, mockDisputeBond, mockDisputeBondFactory, mockNextReportingWindow)
 
@@ -356,7 +356,8 @@ def test_market_try_finalize_valid(localFixture, chain, initializeMarket, consta
     assert mockForkReportingWindow.getUpdateMarketPhaseCalled() == True
     assert mockAugur.logMarketFinalizedCalled() == True
     # market is valid market owner gets validity bond back
-    assert chain.head_state.get_balance(tester.a1) == ownerBalance + mockUniverse.getOrCacheValidityBond()
+    assert chain.head_state.get_balance(tester.a1) == ownerBalance
+    assert chain.head_state.get_balance(initializeMarket.getMarketCreatorMailbox()) == mockUniverse.getOrCacheValidityBond() + mockUniverse.getOrCacheTargetReporterGasCosts()
     mockReputationToken.getTransferValueFor(finalPayoutStakeToken.address) == 34
     mockReputationToken.getTransferValueFor(finalPayoutStakeToken.address) == 55
 
@@ -453,7 +454,7 @@ def test_market_migrate_through_one_fork(localFixture, initializeMarket, constan
 
 def push_to_last_dispute(localFixture, initializeMarket, constants, mockAugur, mockReportingWindow, mockDisputeBondFactory, mockReputationToken, mockDisputeBond, chain, mockUniverse, mockStakeToken, mockStakeTokenFactory, mockNextReportingWindow, mockForkReportingWindow):
     numTicks = 10 ** 10
-    push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, [0, numTicks, 0, 0, 0], mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
+    push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, [0, numTicks, 0, 0, 0], mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants)
     push_first_dispute_last_reporting(localFixture, chain, mockReputationToken, initializeMarket, mockStakeTokenFactory, mockReportingWindow, mockUniverse, constants, mockDisputeBond, mockDisputeBondFactory, mockNextReportingWindow)
     chain.head_state.timestamp = mockNextReportingWindow.getEndTime() - 1
 
@@ -523,7 +524,7 @@ def push_first_dispute_last_reporting(localFixture, chain, mockReputationToken, 
     chain.head_state.timestamp = mockNextReportingWindow.getEndTime() - 1
     assert initializeMarket.getReportingState() == constants.LAST_REPORTING()
 
-def push_to_designated_despute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants):
+def push_to_designated_dispute_state(localFixture, mockUniverse, chain, initializeMarket, mockStakeToken, payoutDesignatedNumerators, mockStakeTokenFactory, mockReportingWindow, mockReputationToken, constants):
     chain.head_state.timestamp = initializeMarket.getDesignatedReportDueTimestamp() - 1
     payoutDesignatedHashValue = initializeMarket.derivePayoutDistributionHash(payoutDesignatedNumerators, False)
     mockStakeToken.setPayoutDistributionHash(payoutDesignatedHashValue)
@@ -545,7 +546,7 @@ def push_to_designated_despute_state(localFixture, mockUniverse, chain, initiali
     assert mockReportingWindow.getUpdateMarketPhaseCalled() == True
     assert mockReportingWindow.getNoteDesignatedReport() == True
     assert mockReputationToken.getTransferValueFor(tester.a1) == 105
-    assert chain.head_state.get_balance(tester.a1) == ownerBalance + mockUniverse.getOrCacheTargetReporterGasCosts()
+    assert chain.head_state.get_balance(tester.a1) == ownerBalance
     assert initializeMarket.getReportingState() == constants.DESIGNATED_DISPUTE()
 
 @fixture(scope="session")

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -147,7 +147,7 @@ def test_reportingFullHappyPath(getStakeBonus, localFixture, universe, cash, mar
     captureFilteredLogs(localFixture.chain.head_state, localFixture.contracts['Augur'], logs)
 
     # We can finalize the market now since a mjaority of REP has moved. Alternatively we could "localFixture.chain.head_state.timestamp = universe.getForkEndTime() + 1" to move
-    initialMarketCreatorETHBalance = localFixture.chain.head_state.get_balance(market.getOwner())
+    initialMarketCreatorETHBalance = localFixture.chain.head_state.get_balance(market.getMarketCreatorMailbox())
     assert market.tryFinalize()
 
     # Confirm market finalization logging works
@@ -160,7 +160,7 @@ def test_reportingFullHappyPath(getStakeBonus, localFixture, universe, cash, mar
     assert market.getFinalWinningStakeToken() == stakeTokenNo.address
 
     # Since the designated report was not invalid the market creator gets back the validity bond
-    increaseInMarketCreatorBalance = localFixture.chain.head_state.get_balance(market.getOwner()) - initialMarketCreatorETHBalance
+    increaseInMarketCreatorBalance = localFixture.chain.head_state.get_balance(market.getMarketCreatorMailbox()) - initialMarketCreatorETHBalance
     assert increaseInMarketCreatorBalance == expectedMarketCreatorFeePayout
 
     # We can redeem forked REP on any universe we didn't dispute
@@ -470,7 +470,7 @@ def test_invalid_designated_report(localFixture, universe, cash, market):
     proceedToDesignatedReporting(localFixture, universe, market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)])
 
     # To progress into the DESIGNATED DISPUTE phase we do a designated report of invalid
-    initialMarketCreatorETHBalance = localFixture.chain.head_state.get_balance(market.getOwner())
+    initialMarketCreatorETHBalance = localFixture.chain.head_state.get_balance(market.getMarketCreatorMailbox())
     assert localFixture.designatedReport(market, [long(0.5 * 10 ** 18), long(0.5 * 10 ** 18)], tester.k0, True)
 
     # We're now in the DESIGNATED DISPUTE PHASE
@@ -493,7 +493,7 @@ def test_invalid_designated_report(localFixture, universe, cash, market):
     assert increaseInReportingWindowBalance == expectedReportingWindowFeePayout
 
     # Since the designated reporter showed up the market creator still gets back the reporter gas cost fee
-    increaseInMarketCreatorBalance = localFixture.chain.head_state.get_balance(market.getOwner()) - initialMarketCreatorETHBalance
+    increaseInMarketCreatorBalance = localFixture.chain.head_state.get_balance(market.getMarketCreatorMailbox()) - initialMarketCreatorETHBalance
     assert increaseInMarketCreatorBalance == expectedMarketCreatorFeePayout
 
 def test_cannot_fork_twice(localFixture, universe, cash, market):


### PR DESCRIPTION
We ended up using `depositEther` after all!