### PR TITLE
Minor deployment fixes and QoL improvements (for me).

### DIFF
--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -46,6 +46,7 @@ RUN npm run build:interfaces
 
 
 COPY ./support/deploy/deploy.sh /app/support/deploy/deploy.sh
+COPY ./support/deploy/run.sh /app/support/deploy/run.sh
 COPY ./support/artifacts/run.sh /app/support/artifacts/run.sh
 COPY ./support/.npmrc /root/.npmrc.deploy
 

--- a/support/deploy/run.sh
+++ b/support/deploy/run.sh
@@ -14,7 +14,8 @@ case $2 in
     gasPrice=20
     ;;
   "rinkeby")
-    host="rinkeby.augur.net"
+    host="rinkeby.ethereum.nodes.augur.net"
+    port="80"
     privateKey=$RINKEBY_PRIVATE_KEY
     gasPrice=20
     ;;
@@ -30,11 +31,13 @@ case $2 in
     ;;
   "clique")
     host="clique.ethereum.nodes.augur.net"
+    port="80"
     privateKey="fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a"
     gasPrice=1
     ;;
   "aura")
     host="aura.ethereum.nodes.augur.net"
+    port="80"
     privateKey="fae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a"
     gasPrice=1
     ;;

--- a/support/test/integration/docker-compose-deployment.yml
+++ b/support/test/integration/docker-compose-deployment.yml
@@ -1,0 +1,37 @@
+version: "3.2"
+services:
+  clique-deploy:
+    image: augurproject/augur-core:latest
+    build:
+      context: ../../../
+      dockerfile: support/Dockerfile
+    entrypoint: [ "npx", "mocha", "output/tests-integration/**/*.js", "--no-timeouts", "--require", "source-map-support/register"]
+    environment:
+      - ETHEREUM_HOST=clique.ethereum.nodes.augur.net
+      - ETHEREUM_PORT=80
+      - ETHEREUM_GAS_PRICE_IN_NANOETH=1
+      - ETHEREUM_PRIVATE_KEY=0xfae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a
+
+  aura-deploy:
+    image: augurproject/augur-core:latest
+    build:
+      context: ../../../
+      dockerfile: support/Dockerfile
+    entrypoint: [ "npx", "mocha", "output/tests-integration/**/*.js", "--no-timeouts", "--require", "source-map-support/register"]
+    environment:
+      - ETHEREUM_HOST=aura.ethereum.nodes.augur.net
+      - ETHEREUM_PORT=80
+      - ETHEREUM_GAS_PRICE_IN_NANOETH=1
+      - ETHEREUM_PRIVATE_KEY=0xfae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a
+
+  instantseal-deploy:
+    image: augurproject/augur-core:latest
+    build:
+      context: ../../../
+      dockerfile: support/Dockerfile
+    entrypoint: [ "npx", "mocha", "output/tests-integration/**/*.js", "--no-timeouts", "--require", "source-map-support/register"]
+    environment:
+      - ETHEREUM_HOST=instantseal.ethereum.nodes.augur.net
+      - ETHEREUM_PORT=80
+      - ETHEREUM_GAS_PRICE_IN_NANOETH=1
+      - ETHEREUM_PRIVATE_KEY=0xfae42052f82bed612a724fec3632f325f377120592c75bb78adfcceae6470c5a


### PR DESCRIPTION
Fixes host/port combinations for the public test networks of ours.

Adds run script to Dockerfile so it can be executed from within a docker container.

Creates a deployment docker compose file so someone can deploy with `docker-compose -f support/test/integration/docker-compose-deployment.yml up --build --force-recreate --abort-on-container-exit clique-deploy`