### PR TITLE
make the automatic disavowal actually apply as disavowal. Add a function to markets to do disavowal of crowdsourcers

### DIFF
--- a/source/contracts/reporting/BaseReportingParticipant.sol
+++ b/source/contracts/reporting/BaseReportingParticipant.sol
@@ -72,7 +72,7 @@ contract BaseReportingParticipant is Controlled, IReportingParticipant {
     }
 
     function isDisavowed() public view returns (bool) {
-        return market == IMarket(0);
+        return market == IMarket(0) || !market.isContainerForReportingParticipant(this);
     }
 
     function getPayoutNumerator(uint8 _outcome) public view returns (uint256) {

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -271,12 +271,20 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
         // reset state back to Initial Reporter
         feeWindow = IFeeWindow(0);
         IInitialReporter _initialParticipant = getInitialReporter();
-        for (uint8 i = 1; i < participants.length; ++i) {
-            IDisputeCrowdsourcer(participants[i]).disavow();
-        }
         delete participants;
         participants.push(_initialParticipant);
         _initialParticipant.resetReportTimestamp();
+        crowdsourcers = MapFactory(controller.lookup("MapFactory")).createMap(controller, this);
+        return true;
+    }
+
+    function disavowCrowdsourcers() public onlyInGoodTimes returns (bool) {
+        IMarket _forkingMarket = getForkingMarket();
+        require(_forkingMarket != IMarket(0));
+        require(_forkingMarket != this);
+        IInitialReporter _initialParticipant = getInitialReporter();
+        delete participants;
+        participants.push(_initialParticipant);
         crowdsourcers = MapFactory(controller.lookup("MapFactory")).createMap(controller, this);
         return true;
     }


### PR DESCRIPTION
We have two ways (concerning state) of disconnecting a Reporting Participant from a market: making the reporting participant's market == 0, OR making the Market no longer contain the reporting participant.

The code in the Reporting participant however just checked for the first condition, which meant one would have to wait longer than intended to redeem in some cases (market finalization or migration).

In the case of a fork we can't even do automatic disavowal, which means they'd be waiting till fork finalization, which defeats the purpose of disavowing them. In the old reporting system we had a method for disavowing stake tokens in this case, but never added the equivalent for reporting participants. That is added and used in a test here as well.