### PR TITLE
Prevent most reporting interactions during a fork. Fix bug with fee window assignment when migrating a market in a fork.

### DIFF
--- a/source/contracts/reporting/FeeWindow.sol
+++ b/source/contracts/reporting/FeeWindow.sol
@@ -73,6 +73,7 @@ contract FeeWindow is DelegationTarget, VariableSupplyToken, Extractable, Initia
     function buy(uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
         require(_attotokens > 0);
         require(isActive());
+        require(!universe.isForking());
         getReputationToken().trustedFeeWindowTransfer(msg.sender, this, _attotokens);
         mint(msg.sender, _attotokens);
         return true;

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -155,9 +155,9 @@ def test_roundsOfReporting(rounds, localFixture, market, universe):
 
 @mark.parametrize('finalizeByMigration, manuallyDisavow', [
     (True, True),
-    #(False, True),
-    #(True, False),
-    #(False, False),
+    (False, True),
+    (True, False),
+    (False, False),
 ])
 def test_forking(finalizeByMigration, manuallyDisavow, localFixture, universe, market, categoricalMarket, scalarMarket):
     # Let's go into the one dispute round for the categorical market

--- a/tests/unit/test_fee_window.py
+++ b/tests/unit/test_fee_window.py
@@ -35,7 +35,7 @@ def test_fee_window_note_initial_reporting_gas_price(localFixture, initializedFe
 
     assert initializedFeeWindow.noteInitialReportingGasPrice(gasprice=gasPrice) == True
     assert initializedFeeWindow.getAvgReportingGasPrice() == (gasPrice + gasValue) / 2
-    
+
 def test_fee_window_on_market_finalization(localFixture, initializedFeeWindow, mockUniverse, mockMarket):
     with raises(TransactionFailed, message="on market finalized needs to be called from market"):
         initializedFeeWindow.onMarketFinalized()
@@ -87,7 +87,7 @@ def test_fee_window_buy(localFixture, initializedFeeWindow, Time, mockReputation
     assert mockReputationToken.getTrustedTransferDestinationValue() == initializedFeeWindow.address
     assert mockReputationToken.getTrustedTransferAttotokensValue() == attoToken
     assert initializedFeeWindow.balanceOf(tester.a0) == user_balance + attoToken
-    
+
 def test_fee_window_redeem_for_reporting_participant_zero(localFixture, initializedFeeWindow, mockUniverse, Time, mockReputationToken, mockFeeToken, constants, mockCash):
     assert initializedFeeWindow.isOver() == False
     mockUniverse.setIsForking(False)
@@ -107,7 +107,6 @@ def test_fee_window_redeem_for_reporting_participant_zero(localFixture, initiali
     assert mockReputationToken.getTransferValueFor(tester.a0) == 0
 
 def test_fee_window_redeem_for_reporting_participant_with_balance(localFixture, initializedFeeWindow, mockUniverse, Time, mockReputationToken, mockFeeToken, constants, mockCash):
-    mockUniverse.setIsForking(True)
     attoToken = 10 ** 10
     feeTokenBalance = 10 ** 2
     feeWindowBalance = 10 ** 4
@@ -142,7 +141,6 @@ def test_fee_window_redeem_for_reporting_participant_with_balance(localFixture, 
 
 
 def test_fee_window_redeem_with_balance(localFixture, initializedFeeWindow, mockUniverse, Time, mockReputationToken, mockFeeToken, constants, mockCash):
-    mockUniverse.setIsForking(True)
     attoToken = 10 ** 10
     feeTokenBalance = 10 ** 2
     feeWindowBalance = 10 ** 4
@@ -163,7 +161,7 @@ def test_fee_window_redeem_with_balance(localFixture, initializedFeeWindow, mock
     Time.setTimestamp(feeWindowId * mockUniverse.getDisputeRoundDurationInSeconds() + constants.DISPUTE_ROUND_DURATION_SECONDS())
     assert initializedFeeWindow.isOver() == True
     assert mockFeeToken.balanceOf(tester.a1) == feeTokenBalance
-    
+
     assert initializedFeeWindow.redeem(tester.a1) == True
     assert mockReputationToken.getTransferValueFor(tester.a1) == attoToken
 
@@ -185,7 +183,7 @@ def test_fee_window_mint_fee_tokens(localFixture, initializedFeeWindow, mockUniv
     mockUniverse.setIsContainerForReportingParticipant(False)
     with raises(TransactionFailed, message="IReporting Participant needs to be in same Universe"):
         mockInitialReporter.callMintFeeTokens(initializedFeeWindow.address, amount)
-    
+
     mockUniverse.setIsContainerForReportingParticipant(True)
     assert mockInitialReporter.callMintFeeTokens(initializedFeeWindow.address, amount) == True
     assert mockFeeToken.getMintForReportingParticipantTargetValue() == mockInitialReporter.address
@@ -213,6 +211,7 @@ def localSnapshot(fixture, augurInitializedWithMocksSnapshot):
     mockUniverse.setDisputeRoundDurationInSeconds(5040)
     mockUniverse.setForkingMarket(5040)
     mockUniverse.setForkingMarket(longToHexString(0))
+    mockUniverse.setIsForking(False)
     fixture.contracts["Time"].setTimestamp(feeWindowId)
     feeWindow.initialize(mockUniverse.address, feeWindowId)
     return fixture.createSnapshot()


### PR DESCRIPTION
Make it so disputes cannot be contributed to and participation tokens may not be purchased once a fork has begun.

In looking at this I realized the migration code had a bug as well in that we were always assigning the fee window to 0, which is not correct. If the market has a fee window we should be assigned it to the next available window in the new universe.