### PR TITLE
Migrate REP of market / initial reporter during fork migration

### DIFF
--- a/source/contracts/reporting/IInitialReporter.sol
+++ b/source/contracts/reporting/IInitialReporter.sol
@@ -12,4 +12,5 @@ contract IInitialReporter is IReportingParticipant {
     function designatedReporterWasCorrect() public view returns (bool);
     function getDesignatedReporter() public view returns (address);
     function getReportTimestamp() public view returns (uint256);
+    function migrateREP() public returns (bool);
 }

--- a/source/contracts/reporting/InitialReporter.sol
+++ b/source/contracts/reporting/InitialReporter.sol
@@ -73,6 +73,18 @@ contract InitialReporter is DelegationTarget, Ownable, Extractable, BaseReportin
         return true;
     }
 
+    function migrateREP() public returns (bool) {
+        require(IMarket(msg.sender) == market);
+        IUniverse _newUniverse = market.getUniverse();
+        IReputationToken _newReputationToken = _newUniverse.getReputationToken();
+        uint256 _balance = reputationToken.balanceOf(this);
+        if (_balance > 0) {
+            reputationToken.migrateOut(_newReputationToken, _balance);
+        }
+        reputationToken = _newReputationToken;
+        return true;
+    }
+
     function getStake() public view returns (uint256) {
         return size;
     }
@@ -96,7 +108,7 @@ contract InitialReporter is DelegationTarget, Ownable, Extractable, BaseReportin
     function getReputationToken() public view returns (IReputationToken) {
         return reputationToken;
     }
-    
+
     function designatedReporterWasCorrect() public view returns (bool) {
         return payoutDistributionHash == market.getWinningPayoutDistributionHash();
     }

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -240,9 +240,10 @@ def test_forking(finalizeByMigration, manuallyDisavow, localFixture, universe, m
     reputationToken = localFixture.applySignature("ReputationToken", universe.getReputationToken())
     previousREPBalance = reputationToken.balanceOf(scalarMarket.address)
     assert previousREPBalance > 0
+    bonus = previousREPBalance / localFixture.contracts["Constants"].FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR() if finalizeByMigration else 0
     assert scalarMarket.migrateThroughOneFork()
     newUniverseREP = localFixture.applySignature("ReputationToken", newUniverse.getReputationToken())
-    assert newUniverseREP.balanceOf(scalarMarket.address) == previousREPBalance
+    assert newUniverseREP.balanceOf(scalarMarket.address) == previousREPBalance + bonus
 
     # We can finalize this market as well
     proceedToNextRound(localFixture, scalarMarket)

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -230,8 +230,26 @@ def test_forking(finalizeByMigration, manuallyDisavow, localFixture, universe, m
     # We can also purchase Participation Tokens in this fee window
     assert categoricalMarketFeeWindow.buy(1)
 
-    # We can migrate a market that has not had its initial reporting completed as well
+    # We will finalize the categorical market in the new universe
+    feeWindow = localFixture.applySignature('FeeWindow', categoricalMarket.getFeeWindow())
+    localFixture.contracts["Time"].setTimestamp(feeWindow.getEndTime() + 1)
+
+    assert categoricalMarket.finalize()
+
+    # We can migrate a market that has not had its initial reporting completed as well, and confirm its REP no show bond is in the new universe REP
+    reputationToken = localFixture.applySignature("ReputationToken", universe.getReputationToken())
+    previousREPBalance = reputationToken.balanceOf(scalarMarket.address)
+    assert previousREPBalance > 0
     assert scalarMarket.migrateThroughOneFork()
+    newUniverseREP = localFixture.applySignature("ReputationToken", newUniverse.getReputationToken())
+    assert newUniverseREP.balanceOf(scalarMarket.address) == previousREPBalance
+
+    # We can finalize this market as well
+    proceedToNextRound(localFixture, scalarMarket)
+    feeWindow = localFixture.applySignature('FeeWindow', scalarMarket.getFeeWindow())
+    localFixture.contracts["Time"].setTimestamp(feeWindow.getEndTime() + 1)
+
+    assert scalarMarket.finalize()
 
 def test_forking_values(localFixture, universe, market, cash):
     reputationToken = localFixture.applySignature("ReputationToken", universe.getReputationToken())

--- a/tests/solidity_test_helpers/MockInitialReporter.sol
+++ b/tests/solidity_test_helpers/MockInitialReporter.sol
@@ -105,4 +105,8 @@ contract MockInitialReporter is IInitialReporter {
     function callFinishedCrowdsourcingDisputeBond(IMarket _market) public returns(bool) {
         return _market.finishedCrowdsourcingDisputeBond();
     }
+
+    function migrateREP() public returns (bool) {
+        return true;
+    }
 }


### PR DESCRIPTION
Fix for a bug case. When migrating a market through a fork we need to migrate the REP no show bond as well, whether it be in the initial reporter or the market itself. Most things would continue working if we did not do this and it would simply be an inconvenience for the recipient of the bond, but if the initial reporter lies then the market finalization would have failed when attempting to redistribute its REP to truthful dispute bonds, as it wouldn't have enough new-Universe REP.