### PR TITLE
5x -> 7.5x to accomodate adjustment of expecting 20% fork participation

### DIFF
--- a/source/contracts/reporting/Reporting.sol
+++ b/source/contracts/reporting/Reporting.sol
@@ -8,7 +8,7 @@ library Reporting {
     uint256 private constant FORK_DURATION_SECONDS = 60 days;
 
     uint256 private constant INITIAL_REP_SUPPLY = 11 * 10 ** 6 * 10 ** 18; // 11 Million REP
-    
+
     uint256 private constant DEFAULT_VALIDITY_BOND = 1 ether / 100;
     uint256 private constant VALIDITY_BOND_FLOOR = 1 ether / 100;
     uint256 private constant DEFAULT_REPORTING_FEE_DIVISOR = 100; // 1% fees
@@ -22,7 +22,8 @@ library Reporting {
     uint256 private constant TARGET_INVALID_MARKETS_DIVISOR = 100; // 1% of markets are expected to be invalid
     uint256 private constant TARGET_INCORRECT_DESIGNATED_REPORT_MARKETS_DIVISOR = 100; // 1% of markets are expected to have an incorrect designate report
     uint256 private constant TARGET_DESIGNATED_REPORT_NO_SHOWS_DIVISOR = 100; // 1% of markets are expected to have an incorrect designate report
-    uint256 private constant TARGET_REP_MARKET_CAP_MULTIPLIER = 5;
+    uint256 private constant TARGET_REP_MARKET_CAP_MULTIPLIER = 15; // We multiply and divide by constants since we want to multiply by a fractional amount (7.5)
+    uint256 private constant TARGET_REP_MARKET_CAP_DIVISOR = 2;
 
     uint256 private constant FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR = 20; // 5% bonus to any REP migrated during a fork
 
@@ -38,6 +39,7 @@ library Reporting {
     function getTargetIncorrectDesignatedReportMarketsDivisor() internal pure returns (uint256) { return TARGET_INCORRECT_DESIGNATED_REPORT_MARKETS_DIVISOR; }
     function getTargetDesignatedReportNoShowsDivisor() internal pure returns (uint256) { return TARGET_DESIGNATED_REPORT_NO_SHOWS_DIVISOR; }
     function getTargetRepMarketCapMultiplier() internal pure returns (uint256) { return TARGET_REP_MARKET_CAP_MULTIPLIER; }
+    function getTargetRepMarketCapDivisor() internal pure returns (uint256) { return TARGET_REP_MARKET_CAP_DIVISOR; }
     function getForkMigrationPercentageBonusDivisor() internal pure returns (uint256) { return FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR; }
     function getMaximumReportingFeeDivisor() internal pure returns (uint256) { return MAXIMUM_REPORTING_FEE_DIVISOR; }
     function getMinimumReportingFeeDivisor() internal pure returns (uint256) { return MINIMUM_REPORTING_FEE_DIVISOR; }

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -298,7 +298,7 @@ contract Universe is DelegationTarget, Extractable, ITyped, Initializable, IUniv
     }
 
     function getTargetRepMarketCapInAttoeth() public view returns (uint256) {
-        return getOpenInterestInAttoEth() * Reporting.getTargetRepMarketCapMultiplier();
+        return getOpenInterestInAttoEth() * Reporting.getTargetRepMarketCapMultiplier() / Reporting.getTargetRepMarketCapDivisor();
     }
 
     function getOrCacheValidityBond() public onlyInGoodTimes returns (uint256) {

--- a/tests/solidity_test_helpers/Constants.sol
+++ b/tests/solidity_test_helpers/Constants.sol
@@ -25,6 +25,7 @@ contract Constants {
     uint256 public constant TARGET_INCORRECT_DESIGNATED_REPORT_MARKETS_DIVISOR = Reporting.getTargetIncorrectDesignatedReportMarketsDivisor();
     uint256 public constant TARGET_DESIGNATED_REPORT_NO_SHOWS_DIVISOR = Reporting.getTargetDesignatedReportNoShowsDivisor();
     uint256 public constant TARGET_REP_MARKET_CAP_MULTIPLIER = Reporting.getTargetRepMarketCapMultiplier();
+    uint256 public constant TARGET_REP_MARKET_CAP_DIVISOR = Reporting.getTargetRepMarketCapDivisor();
 
     uint256 public constant INITIAL_REP_SUPPLY = Reporting.getInitialREPSupply();
     uint256 public constant FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR = Reporting.getForkMigrationPercentageBonusDivisor();

--- a/tests/unit/test_universe.py
+++ b/tests/unit/test_universe.py
@@ -102,15 +102,15 @@ def test_universe_contains(localFixture, populatedUniverse, mockMarket, chain, m
     assert populatedUniverse.isContainerForShareToken(mockShareToken.address) == True
 
 def test_open_interest(localFixture, populatedUniverse):
-    multiplier = localFixture.contracts['Constants'].TARGET_REP_MARKET_CAP_MULTIPLIER()
+    multiplier = localFixture.contracts['Constants'].TARGET_REP_MARKET_CAP_MULTIPLIER() / float(localFixture.contracts['Constants'].TARGET_REP_MARKET_CAP_DIVISOR())
     assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 0
     assert populatedUniverse.getOpenInterestInAttoEth() == 0
-    populatedUniverse.incrementOpenInterest(10)
-    assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 10 * multiplier
+    populatedUniverse.incrementOpenInterest(20)
+    assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 20 * multiplier
+    assert populatedUniverse.getOpenInterestInAttoEth() == 20
+    populatedUniverse.decrementOpenInterest(10)
     assert populatedUniverse.getOpenInterestInAttoEth() == 10
-    populatedUniverse.decrementOpenInterest(5)
-    assert populatedUniverse.getOpenInterestInAttoEth() == 5
-    assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 5 * multiplier
+    assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 10 * multiplier
 
 def test_universe_rep_price_oracle(localFixture, populatedUniverse, mockReputationToken, mockShareToken):
     controller = localFixture.contracts['Controller']
@@ -209,7 +209,7 @@ def test_universe_reporting_fee_divisor(localFixture, chain, populatedUniverse, 
     mockFeeWindowFactory.setCreateFeeWindowValue(previousFeeWindow.address)
     assert populatedUniverse.getOrCreatePreviousFeeWindow() == previousFeeWindow.address
 
-    multiplier = localFixture.contracts['Constants'].TARGET_REP_MARKET_CAP_MULTIPLIER()
+    multiplier = localFixture.contracts['Constants'].TARGET_REP_MARKET_CAP_MULTIPLIER() / float(localFixture.contracts['Constants'].TARGET_REP_MARKET_CAP_DIVISOR())
     # default value
     defaultValue = 10000
     assert populatedUniverse.getRepMarketCapInAttoeth() == 0
@@ -254,12 +254,12 @@ def test_universe_reporting_fee_divisor(localFixture, chain, populatedUniverse, 
 
     mockReputationToken.setTotalSupply(1)
     repPriceOracle.setRepPriceInAttoEth(1)
-    populatedUniverse.decrementOpenInterest(15)
+    populatedUniverse.decrementOpenInterest(10)
     assert populatedUniverse.getRepMarketCapInAttoeth() == 1
-    assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 5 * multiplier
-    assert populatedUniverse.getOpenInterestInAttoEth() == 5
+    assert populatedUniverse.getTargetRepMarketCapInAttoeth() == 10 * multiplier
+    assert populatedUniverse.getOpenInterestInAttoEth() == 10
 
-    assert populatedUniverse.getOrCacheReportingFeeDivisor() == defaultValue / 5 * multiplier
+    assert populatedUniverse.getOrCacheReportingFeeDivisor() == defaultValue
 
 def test_universe_create_market(localFixture, chain, populatedUniverse, mockMarket, mockMarketFactory, mockCash, mockReputationToken, mockAugur, mockFeeWindowFactory, mockFeeWindow):
     timestamp = localFixture.contracts["Time"].getTimestamp()
@@ -280,7 +280,7 @@ def test_universe_create_market(localFixture, chain, populatedUniverse, mockMark
     mockMarketFactory.setMarket(mockMarket.address)
 
     newMarket = populatedUniverse.createBinaryMarket(endTimeValue, feePerEthInWeiValue, mockCash.address, designatedReporterAddressValue, "topic", "description", "info")
-    
+
     assert mockMarketFactory.getCreateMarketUniverseValue() == populatedUniverse.address
     assert populatedUniverse.isContainerForMarket(mockMarket.address)
     assert mockAugur.logMarketCreatedCalled() == True


### PR DESCRIPTION
We're changing the expectation from 30% fork participation to 20%. Contract side this results in a change to the formula for calculating reporting fees, specifically in what our target MCAP is.