### PR TITLE
log when complete sets are purchased or sold directly without trading

### DIFF
--- a/source/contracts/Augur.sol
+++ b/source/contracts/Augur.sol
@@ -30,6 +30,8 @@ contract Augur is Controlled, Extractable, IAugur {
     // The ordering here is to match functions higher in the call chain to avoid stack depth issues
     event OrderCreated(Order.Types orderType, uint256 amount, uint256 price, address indexed creator, uint256 moneyEscrowed, uint256 sharesEscrowed, bytes32 tradeGroupId, bytes32 orderId, address indexed universe, address indexed shareToken);
     event OrderFilled(address indexed universe, address indexed shareToken, address filler, bytes32 orderId, uint256 numCreatorShares, uint256 numCreatorTokens, uint256 numFillerShares, uint256 numFillerTokens, uint256 marketCreatorFees, uint256 reporterFees, bytes32 tradeGroupId);
+    event CompleteSetsPurchased(address indexed universe, address indexed market, address indexed account, uint256 numCompleteSets);
+    event CompleteSetsSold(address indexed universe, address indexed market, address indexed account, uint256 numCompleteSets);
     event TradingProceedsClaimed(address indexed universe, address indexed shareToken, address indexed sender, address market, uint256 numShares, uint256 numPayoutTokens, uint256 finalTokenBalance);
     event TokensTransferred(address indexed universe, address indexed token, address indexed from, address to, uint256 value);
     event TokensMinted(address indexed universe, address indexed token, address indexed target, uint256 amount);
@@ -151,6 +153,16 @@ contract Augur is Controlled, Extractable, IAugur {
 
     function logOrderFilled(IUniverse _universe, address _shareToken, address _filler, bytes32 _orderId, uint256 _numCreatorShares, uint256 _numCreatorTokens, uint256 _numFillerShares, uint256 _numFillerTokens, uint256 _marketCreatorFees, uint256 _reporterFees, bytes32 _tradeGroupId) public onlyWhitelistedCallers returns (bool) {
         OrderFilled(_universe, _shareToken, _filler, _orderId, _numCreatorShares, _numCreatorTokens, _numFillerShares, _numFillerTokens, _marketCreatorFees, _reporterFees, _tradeGroupId);
+        return true;
+    }
+
+    function logCompleteSetsPurchased(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public onlyWhitelistedCallers returns (bool) {
+        CompleteSetsPurchased(_universe, _market, _account, _numCompleteSets);
+        return true;
+    }
+
+    function logCompleteSetsSold(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public onlyWhitelistedCallers returns (bool) {
+        CompleteSetsSold(_universe, _market, _account, _numCompleteSets);
         return true;
     }
 

--- a/source/contracts/IAugur.sol
+++ b/source/contracts/IAugur.sol
@@ -21,6 +21,8 @@ contract IAugur {
     function logOrderCanceled(IUniverse _universe, address _shareToken, address _sender, bytes32 _orderId, Order.Types _orderType, uint256 _tokenRefund, uint256 _sharesRefund) public returns (bool);
     function logOrderCreated(Order.Types _orderType, uint256 _amount, uint256 _price, address _creator, uint256 _moneyEscrowed, uint256 _sharesEscrowed, bytes32 _tradeGroupId, bytes32 _orderId, IUniverse _universe, address _shareToken) public returns (bool);
     function logOrderFilled(IUniverse _universe, address _shareToken, address _filler, bytes32 _orderId, uint256 _numCreatorShares, uint256 _numCreatorTokens, uint256 _numFillerShares, uint256 _numFillerTokens, uint256 _marketCreatorFees, uint256 _reporterFees, bytes32 _tradeGroupId) public returns (bool);
+    function logCompleteSetsPurchased(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public returns (bool);
+    function logCompleteSetsSold(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public returns (bool);
     function logTradingProceedsClaimed(IUniverse _universe, address _shareToken, address _sender, address _market, uint256 _numShares, uint256 _numPayoutTokens, uint256 _finalTokenBalance) public returns (bool);
     function logUniverseForked() public returns (bool);
     function logUniverseCreated(IUniverse _childUniverse) public returns (bool);

--- a/source/contracts/trading/CompleteSets.sol
+++ b/source/contracts/trading/CompleteSets.sol
@@ -22,7 +22,9 @@ contract CompleteSets is Controlled, Extractable, CashAutoConverter, ReentrancyG
      * Buys `_amount` shares of every outcome in the specified market.
     **/
     function publicBuyCompleteSets(IMarket _market, uint256 _amount) external marketIsLegit(_market) payable convertToAndFromCash onlyInGoodTimes nonReentrant returns (bool) {
-        return this.buyCompleteSets(msg.sender, _market, _amount);
+        this.buyCompleteSets(msg.sender, _market, _amount);
+        controller.getAugur().logCompleteSetsPurchased(_market.getUniverse(), _market, msg.sender, _amount);
+        return true;
     }
 
     function buyCompleteSets(address _sender, IMarket _market, uint256 _amount) external onlyWhitelistedCallers returns (bool) {
@@ -45,6 +47,7 @@ contract CompleteSets is Controlled, Extractable, CashAutoConverter, ReentrancyG
 
     function publicSellCompleteSets(IMarket _market, uint256 _amount) external marketIsLegit(_market) convertToAndFromCash onlyInGoodTimes nonReentrant returns (bool) {
         this.sellCompleteSets(msg.sender, _market, _amount);
+        controller.getAugur().logCompleteSetsSold(_market.getUniverse(), _market, msg.sender, _amount);
         return true;
     }
 

--- a/source/libraries/ContractInterfaces.ts
+++ b/source/libraries/ContractInterfaces.ts
@@ -3750,6 +3750,20 @@
             return <BN>result[0];
         }
 
+        public migrateOutByPayout = async(payoutNumerators: Array<BN>, invalid: boolean, attotokens: BN, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_payoutNumerators","type":"uint256[]"},{"name":"_invalid","type":"bool"},{"name":"_attotokens","type":"uint256"}],"name":"migrateOutByPayout","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [payoutNumerators, invalid, attotokens], "migrateOutByPayout", options.sender, options.gasPrice);
+            return;
+        }
+
+        public migrateOutByPayout_ = async(payoutNumerators: Array<BN>, invalid: boolean, attotokens: BN, options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_payoutNumerators","type":"uint256[]"},{"name":"_invalid","type":"bool"},{"name":"_attotokens","type":"uint256"}],"name":"migrateOutByPayout","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [payoutNumerators, invalid, attotokens], options.sender);
+            return <boolean>result[0];
+        }
+
         public extractEther = async(destination: string, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
             options = options || {};
             const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_destination","type":"address"}],"name":"extractEther","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};

--- a/tests/reporting/test_fee_distribution.py
+++ b/tests/reporting/test_fee_distribution.py
@@ -101,7 +101,7 @@ def test_failed_crowdsourcer_fees(finalize, localFixture, universe, market, cash
 
     # We'll make the window active
     localFixture.contracts["Time"].setTimestamp(feeWindow.getStartTime() + 1)
-    
+
     # generate some fees
     generateFees(localFixture, universe, market)
 
@@ -147,7 +147,7 @@ def test_one_round_crowdsourcer_fees(localFixture, universe, market, cash, reput
 
     # generate some fees
     generateFees(localFixture, universe, market)
-    
+
     # We'll have testers push markets into the next round by funding dispute crowdsourcers
     amount = 2 * market.getTotalStake()
     with TokenDelta(reputationToken, -amount, tester.a1, "Disputing did not reduce REP balance correctly"):
@@ -268,7 +268,7 @@ def test_multiple_contributors_crowdsourcer_fees(localFixture, universe, market,
 
     # generate some fees
     generateFees(localFixture, universe, market)
-    
+
     # We'll have testers push markets into the next round by funding dispute crowdsourcers
     amount = market.getTotalStake()
     with TokenDelta(reputationToken, -amount, tester.a1, "Disputing did not reduce REP balance correctly"):

--- a/tests/solidity_test_helpers/MockAugur.sol
+++ b/tests/solidity_test_helpers/MockAugur.sol
@@ -85,6 +85,14 @@ contract MockAugur is Controlled {
         return true;
     }
 
+    function logCompleteSetsPurchased(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public onlyWhitelistedCallers returns (bool) {
+        return true;
+    }
+
+    function logCompleteSetsSold(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public onlyWhitelistedCallers returns (bool) {
+        return true;
+    }
+
     function logProceedsClaimed(IUniverse _universe, address _shareToken, address _sender, address _market, uint256 _numShares, uint256 _numPayoutTokens, uint256 _finalTokenBalance) public onlyWhitelistedCallers returns (bool) {
         return true;
     }


### PR DESCRIPTION
Adding log events for when complete sets are purchased outside of trading. Currently we don't log this explicitly so these assets are missing from the user's portfolio.