### PR TITLE
Fix various forking issues

### DIFF
--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -165,11 +165,11 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
     }
 
     function finalize() public onlyInGoodTimes returns (bool) {
-        require(winningPayoutDistributionHash == bytes32(0));
-
         if (universe.getForkingMarket() == this) {
             return finalizeFork();
         }
+
+        require(winningPayoutDistributionHash == bytes32(0));
 
         require(getInitialReporter().getReportTimestamp() != 0);
         require(feeWindow.isOver());
@@ -185,6 +185,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
 
     function finalizeFork() public onlyInGoodTimes returns (bool) {
         require(universe.getForkingMarket() == this);
+        require(winningPayoutDistributionHash == bytes32(0));
         IUniverse _winningUniverse = universe.getWinningChildUniverse();
         winningPayoutDistributionHash = _winningUniverse.getParentPayoutDistributionHash();
         finalizationTime = controller.getTimestamp();
@@ -263,6 +264,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
         // only proceed if the forking market is finalized
         IMarket _forkingMarket = universe.getForkingMarket();
         require(_forkingMarket.isFinalized());
+        require(!isFinalized());
 
         IUniverse _currentUniverse = universe;
         bytes32 _winningForkPayoutDistributionHash = _forkingMarket.getWinningPayoutDistributionHash();
@@ -300,6 +302,7 @@ contract Market is DelegationTarget, Extractable, ITyped, Initializable, Ownable
         IMarket _forkingMarket = getForkingMarket();
         require(_forkingMarket != IMarket(0));
         require(_forkingMarket != this);
+        require(!isFinalized());
         IInitialReporter _initialParticipant = getInitialReporter();
         delete participants;
         participants.push(_initialParticipant);

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -185,7 +185,7 @@ contract Universe is DelegationTarget, Extractable, ITyped, Initializable, IUniv
         IUniverse _updatedUniverse = getChildUniverse(_parentPayoutDistributionHash);
         uint256 _currentTentativeWinningChildUniverseRepMigrated = 0;
         if (_tentativeWinningUniverse != IUniverse(0)) {
-            _tentativeWinningUniverse.getReputationToken().getTotalMigrated();
+            _currentTentativeWinningChildUniverseRepMigrated = _tentativeWinningUniverse.getReputationToken().getTotalMigrated();
         }
         uint256 _updatedUniverseRepMigrated = _updatedUniverse.getReputationToken().getTotalMigrated();
         if (_updatedUniverseRepMigrated > _currentTentativeWinningChildUniverseRepMigrated) {

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -268,11 +268,11 @@ def test_finalized_fork_migration(localFixture, universe, market, categoricalMar
     localFixture.contracts["Time"].setTimestamp(feeWindow.getEndTime() + 1)
     assert categoricalMarket.finalize()
 
-    # Proceed to Forking for the binary market and finzlie it
+    # Proceed to Forking for the binary market and finalize it
     proceedToFork(localFixture, market, universe)
     finalizeFork(localFixture, market, universe)
 
-    # The categorical market is finzlied and cannot be migrated to the new universe
+    # The categorical market is finazlied and cannot be migrated to the new universe
     with raises(TransactionFailed):
         categoricalMarket.migrateThroughOneFork()
 

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -272,7 +272,7 @@ def test_finalized_fork_migration(localFixture, universe, market, categoricalMar
     proceedToFork(localFixture, market, universe)
     finalizeFork(localFixture, market, universe)
 
-    # The categorical market is finazlied and cannot be migrated to the new universe
+    # The categorical market is finalized and cannot be migrated to the new universe
     with raises(TransactionFailed):
         categoricalMarket.migrateThroughOneFork()
 

--- a/tests/reporting_utils.py
+++ b/tests/reporting_utils.py
@@ -118,7 +118,9 @@ def finalizeFork(fixture, market, universe, finalizeByMigration = True):
     with TokenDelta(yesUniverseReputationToken, amountAdded, tester.a0, "reputation migration bonus did not work correctly"):
         reputationToken.migrateOut(yesUniverseReputationToken.address, amount)
 
-    assert market.finalizeFork()
+    # Finalize fork cannot be called again
+    with raises(TransactionFailed):
+        market.finalizeFork()
 
 def generateFees(fixture, universe, market):
     completeSets = fixture.contracts['CompleteSets']


### PR DESCRIPTION
Address various forking issues:

- Finalized markets (including the forking market) cannot be migrated or have crowdsourcers disavowed
- Fork finalization can only be done once
- Actually compare REP migration totals as intended so the correct Universe wins the fork migration contest