### PR TITLE
implement escape hatch via upgrade

### DIFF
--- a/source/contracts/Controller.sol
+++ b/source/contracts/Controller.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.20;
 /**
  * The Controller is used to manage whitelisting of contracts and and halt the normal use of Augur’s contracts (e.g., if there is a vulnerability found in Augur).  There is only one instance of the Controller, and it gets uploaded to the blockchain before all of the other contracts.  The `owner` attribute of the Controller is set to the address that called the constructor of the Controller.  The Augur team can then call functions from this address to interact with the Controller.
  *
- * If Augur needs to be halted for some reason (such as a bug being found that needs to be fixed before trading can continue), the `owner` address can call the `emergencyStop` function (and later the `release` function) to make the system stop/resume.  When in the stopped state, users can only call the `withdrawInEmergency` function on dispute bonds, markets, participation tokens, and stake tokens to withdraw any funds they have in Augur as REP.  All other functionality in Augur is disabled when it is in the stopped state.  (Additionally, the `withdrawInEmergency` function cannot be called when Augur is not in the stopped state.)  The modifier `onlyInGoodTimes` is used for functions that should only be useable when Augur is not stopped, and the modifier `onlyInBadTimes` is used for functions that should only be useable when Augur is stopped.
+ * If Augur needs to be halted for some reason (such as a bug being found that needs to be fixed before trading can continue), the dev `owner` address can upload a contract to the key "EmergencyStop" which will halt all normal activity on the platform.  When in the stopped state, users can only call the `withdrawInEmergency` function on dispute bonds, markets, participation tokens, and stake tokens to withdraw any funds they have in Augur as REP.  All other functionality in Augur is disabled when it is in the stopped state.  (Additionally, the `withdrawInEmergency` function cannot be called when Augur is not in the stopped state.)  The modifier `onlyInGoodTimes` is used for functions that should only be useable when Augur is not stopped, and the modifier `onlyInBadTimes` is used for functions that should only be useable when Augur is stopped.
  *
  * Initially, Augur will have a “dev mode” that that can be enabled to allow Augur’s team to suicide funds, extract Ether or Tokens from a specific contract (in case funds inadvertently get sent somewhere they shouldn’t have), and update the Controller of a target contract to a new Controller.  Eventually, the plan is to remove this mode so that this functionality will no longer be available to anyone, including the Augur team.  At that point, the `owner` address will only be able to the `emergencyStop` and `release` functions.
  */
@@ -26,7 +26,6 @@ contract Controller is IController {
     address public owner;
     mapping(address => bool) public whitelist;
     mapping(bytes32 => ContractDetails) public registry;
-    bool public stopped = false;
 
     modifier onlyWhitelistedCallers {
         assertIsWhitelisted(msg.sender);
@@ -45,12 +44,12 @@ contract Controller is IController {
     }
 
     modifier onlyInBadTimes {
-        require(stopped);
+        require(isStopped());
         _;
     }
 
     modifier onlyInGoodTimes {
-        require(!stopped);
+        require(!isStopped());
         _;
     }
 
@@ -127,7 +126,7 @@ contract Controller is IController {
         return true;
     }
 
-    function switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed() public devModeOwnerOnly returns (bool) {
+    function switchModeToDecentralized() public devModeOwnerOnly returns (bool) {
         whitelist[owner] = false;
         return true;
     }
@@ -136,15 +135,9 @@ contract Controller is IController {
      * Emergency Stop Functions [dev can use it anytime in or out of dev mode]
      */
 
-    function emergencyStop() public onlyOwnerCaller onlyInGoodTimes returns (bool) {
-        stopped = true;
-        return true;
-    }
-
-    // WARNING: This should only be called in a development or experimental context. Once the emergency stop has been called funds can be withdrawn in a way that will leave our system broken and unusable. After the emergency stop has been used we need to actually do a full redeploy with a new controller in order to get the system running again.
-    function release() public onlyOwnerCaller onlyInBadTimes returns (bool) {
-        stopped = false;
-        return true;
+    // The emergency stop hatch check is performed and controlled in this unusual way to avoid it simply being a boolean in storage that dev mode owner can manipulate. This is entirely a stipulation of legal that we need to do it this way and it is admittedly very silly.
+    function isStopped() public view returns (bool) {
+        return registry["EmergencyStop"].contractAddress != address(0);
     }
 
     function stopInEmergency() public view onlyInGoodTimes returns (bool) {

--- a/source/contracts/Controller.sol
+++ b/source/contracts/Controller.sol
@@ -135,7 +135,7 @@ contract Controller is IController {
      * Emergency Stop Functions [dev can use it anytime in or out of dev mode]
      */
 
-    // The emergency stop hatch check is performed and controlled in this unusual way to avoid it simply being a boolean in storage that dev mode owner can manipulate. This is entirely a stipulation of legal that we need to do it this way and it is admittedly very silly.
+    // The emergency stop hatch check is performed and controlled in this unusual way to avoid it simply being a boolean in storage that dev mode owner can manipulate..
     function isStopped() public view returns (bool) {
         return registry["EmergencyStop"].contractAddress != address(0);
     }

--- a/source/libraries/ContractInterfaces.ts
+++ b/source/libraries/ContractInterfaces.ts
@@ -705,20 +705,6 @@
             super(connector, accountManager, address, defaultGasPrice);
         }
 
-        public switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            await this.remoteCall(abi, [], "switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed", options.sender, options.gasPrice);
-            return;
-        }
-
-        public switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed_ = async( options?: { sender?: string }): Promise<boolean> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            const result = await this.localCall(abi, [], options.sender);
-            return <boolean>result[0];
-        }
-
         public unregisterContract = async(key: string, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
             options = options || {};
             const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_key","type":"bytes32"}],"name":"unregisterContract","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
@@ -782,6 +768,13 @@
             return <boolean>result[0];
         }
 
+        public isStopped_ = async( options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"isStopped","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <boolean>result[0];
+        }
+
         public getAugur_ = async( options?: { sender?: string }): Promise<string> => {
             options = options || {};
             const abi: AbiFunction = {"constant":true,"inputs":[],"name":"getAugur","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"};
@@ -803,46 +796,11 @@
             return <boolean>result[0];
         }
 
-        public emergencyStop = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"emergencyStop","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            await this.remoteCall(abi, [], "emergencyStop", options.sender, options.gasPrice);
-            return;
-        }
-
-        public emergencyStop_ = async( options?: { sender?: string }): Promise<boolean> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"emergencyStop","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            const result = await this.localCall(abi, [], options.sender);
-            return <boolean>result[0];
-        }
-
-        public stopped_ = async( options?: { sender?: string }): Promise<boolean> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"stopped","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"};
-            const result = await this.localCall(abi, [], options.sender);
-            return <boolean>result[0];
-        }
-
         public registry_ = async(arg0: string, options?: { sender?: string }): Promise<Array<string>> => {
             options = options || {};
             const abi: AbiFunction = {"constant":true,"inputs":[{"name":"","type":"bytes32"}],"name":"registry","outputs":[{"name":"name","type":"bytes32"},{"name":"contractAddress","type":"address"},{"name":"commitHash","type":"bytes20"},{"name":"bytecodeHash","type":"bytes32"}],"payable":false,"stateMutability":"view","type":"function"};
             const result = await this.localCall(abi, [arg0], options.sender);
             return <Array<string>>result;
-        }
-
-        public release = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"release","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            await this.remoteCall(abi, [], "release", options.sender, options.gasPrice);
-            return;
-        }
-
-        public release_ = async( options?: { sender?: string }): Promise<boolean> => {
-            options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"release","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            const result = await this.localCall(abi, [], options.sender);
-            return <boolean>result[0];
         }
 
         public removeFromWhitelist = async(target: string, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
@@ -920,6 +878,20 @@
             const abi: AbiFunction = {"constant":true,"inputs":[{"name":"_key","type":"bytes32"}],"name":"lookup","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"};
             const result = await this.localCall(abi, [key], options.sender);
             return <string>result[0];
+        }
+
+        public switchModeToDecentralized = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"switchModeToDecentralized","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [], "switchModeToDecentralized", options.sender, options.gasPrice);
+            return;
+        }
+
+        public switchModeToDecentralized_ = async( options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"switchModeToDecentralized","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <boolean>result[0];
         }
     }
 

--- a/tests/reporting/test_escape_hatches.py
+++ b/tests/reporting/test_escape_hatches.py
@@ -10,7 +10,7 @@ def test_market_escape_hatch_all_fees(localFixture, controller, market, reputati
         market.withdrawInEmergency()
 
     # Emergency Stop
-    assert controller.emergencyStop()
+    assert controller.registerContract("EmergencyStop", 1, "0", "0")
 
     # Now we can call the market escape hatch and get back all the fees paid in creation
     with EtherDelta(localFixture.chain.head_state.get_balance(market.address), market.getOwner(), localFixture.chain, "ETH balance was not given to the market owner"):
@@ -23,7 +23,7 @@ def test_market_escape_hatch_partial_fees(localFixture, market, reputationToken,
     proceedToNextRound(localFixture, market, contributor = tester.k1)
 
     # Emergency Stop
-    assert controller.emergencyStop()
+    assert controller.registerContract("EmergencyStop", 1, "0", "0")
 
     # We will only get back the validity bond since our REP bond and first reporter bond were forfeit already
     with EtherDelta(constants.DEFAULT_VALIDITY_BOND(), market.getOwner(), localFixture.chain, "Remaining ETH balance was not given to the market owner"):
@@ -42,7 +42,7 @@ def test_participation_token_escape_hatch(localFixture, universe, reputationToke
         feeWindow.withdrawInEmergency()
 
     # Emergency Stop
-    assert controller.emergencyStop()
+    assert controller.registerContract("EmergencyStop", 1, "0", "0")
 
     # We can redeem any participation tokens purchased
     with TokenDelta(reputationToken, amount, tester.a0, "REP was not given back"):
@@ -71,12 +71,12 @@ def test_reporting_participant_escape_hatch(localFixture, controller, reputation
         crowdsourcer2.withdrawInEmergency()
 
     # Emergency Stop
-    assert controller.emergencyStop()
+    assert controller.registerContract("EmergencyStop", 1, "0", "0")
 
     # We can now call the escape hatch
     with TokenDelta(reputationToken, reputationToken.balanceOf(initialReporter.address), tester.a0, "REP was not given back"):
         assert initialReporter.withdrawInEmergency()
-    
+
     with TokenDelta(reputationToken, reputationToken.balanceOf(crowdsourcer1.address), tester.a0, "REP was not given back"):
         assert crowdsourcer1.withdrawInEmergency()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -67,19 +67,19 @@ def test_transferOwnership(controller, decentralizedController):
     assert decentralizedController.owner() == bytesToHexString(tester.a1)
 
 def test_emergencyStop(controller):
-    with raises(TransactionFailed): controller.emergencyStop(sender = tester.k2)
-    with raises(TransactionFailed): controller.release(sender = tester.k2)
+    with raises(TransactionFailed): controller.registerContract("EmergencyStop", 1, "0", "0", sender = tester.k2)
+    with raises(TransactionFailed): controller.unregisterContract("EmergencyStop", sender = tester.k2)
     assert controller.stopInEmergency(sender = tester.k2)
     with raises(TransactionFailed): controller.onlyInEmergency(sender = tester.k2)
-    assert controller.emergencyStop(sender = tester.k0)
+    assert controller.registerContract("EmergencyStop", 1, "0", "0", sender = tester.k0)
     assert controller.onlyInEmergency(sender = tester.k2)
     with raises(TransactionFailed): controller.stopInEmergency(sender = tester.k2)
-    assert controller.release(sender = tester.k0)
+    assert controller.unregisterContract("EmergencyStop", sender = tester.k0)
     assert controller.stopInEmergency(sender = tester.k2)
     with raises(TransactionFailed): controller.onlyInEmergency(sender = tester.k2)
 
 def test_switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed_failures(controller):
-    with raises(TransactionFailed): controller.switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed(sender = tester.k2)
+    with raises(TransactionFailed): controller.switchModeToDecentralized(sender = tester.k2)
 
 def test_getContractDetails(controller):
     key = stringToBytes('lookup key')
@@ -97,7 +97,7 @@ def localSnapshot(fixture, controllerSnapshot):
     fixture.upload('solidity_test_helpers/ControllerUser.sol')
     fixture.uploadAugur()
     decentralizedController = fixture.upload('../source/contracts/Controller.sol', 'decentralizedController')
-    decentralizedController.switchModeSoOnlyEmergencyStopsAndEscapeHatchesCanBeUsed(sender = tester.k0)
+    decentralizedController.switchModeToDecentralized(sender = tester.k0)
     return fixture.createSnapshot()
 
 @fixture

--- a/tests/trading/test_tradingEscapeHatch.py
+++ b/tests/trading/test_tradingEscapeHatch.py
@@ -33,7 +33,7 @@ def test_escapeHatch(contractsFixture, cash, market):
         tradingEscapeHatch.claimSharesInUpdate(market.address)
 
     # emergency stop and then have everyone liquidate their position
-    controller.emergencyStop()
+    controller.registerContract("EmergencyStop", 1, "0", "0")
     assert tradingEscapeHatch.claimSharesInUpdate(market.address, sender = tester.k1)
     assert tradingEscapeHatch.claimSharesInUpdate(market.address, sender = tester.k2)
 


### PR DESCRIPTION
This would be a basic implementation of turning the escape hatch on via contract upload instead of a specific function call.

This now means the escape hatch is only pull-able while dev mode is on.