### PR TITLE
add payoutNumerators to universe creation log

### DIFF
--- a/source/contracts/Augur.sol
+++ b/source/contracts/Augur.sol
@@ -35,7 +35,7 @@ contract Augur is Controlled, IAugur {
     event FeeWindowRedeemed(address indexed universe, address indexed reporter, address indexed feeWindow, uint256 amountRedeemed, uint256 reportingFeesReceived);
     event MarketFinalized(address indexed universe, address indexed market);
     event UniverseForked(address indexed universe);
-    event UniverseCreated(address indexed parentUniverse, address indexed childUniverse);
+    event UniverseCreated(address indexed parentUniverse, address indexed childUniverse, uint256[] payoutNumerators);
     event OrderCanceled(address indexed universe, address indexed shareToken, address indexed sender, bytes32 orderId, Order.Types orderType, uint256 tokenRefund, uint256 sharesRefund);
     // The ordering here is to match functions higher in the call chain to avoid stack depth issues
     event OrderCreated(Order.Types orderType, uint256 amount, uint256 price, address indexed creator, uint256 moneyEscrowed, uint256 sharesEscrowed, bytes32 tradeGroupId, bytes32 orderId, address indexed universe, address indexed shareToken);
@@ -200,11 +200,11 @@ contract Augur is Controlled, IAugur {
         return true;
     }
 
-    function logUniverseCreated(IUniverse _childUniverse) public returns (bool) {
+    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators) public returns (bool) {
         require(universes[msg.sender]);
         IUniverse _parentUniverse = IUniverse(msg.sender);
         require(_parentUniverse.isParentOf(_childUniverse));
-        UniverseCreated(_parentUniverse, _childUniverse);
+        UniverseCreated(_parentUniverse, _childUniverse, _payoutNumerators);
         return true;
     }
 

--- a/source/contracts/Augur.sol
+++ b/source/contracts/Augur.sol
@@ -35,7 +35,7 @@ contract Augur is Controlled, IAugur {
     event FeeWindowRedeemed(address indexed universe, address indexed reporter, address indexed feeWindow, uint256 amountRedeemed, uint256 reportingFeesReceived);
     event MarketFinalized(address indexed universe, address indexed market);
     event UniverseForked(address indexed universe);
-    event UniverseCreated(address indexed parentUniverse, address indexed childUniverse, uint256[] payoutNumerators);
+    event UniverseCreated(address indexed parentUniverse, address indexed childUniverse, uint256[] payoutNumerators, bool invalid);
     event OrderCanceled(address indexed universe, address indexed shareToken, address indexed sender, bytes32 orderId, Order.Types orderType, uint256 tokenRefund, uint256 sharesRefund);
     // The ordering here is to match functions higher in the call chain to avoid stack depth issues
     event OrderCreated(Order.Types orderType, uint256 amount, uint256 price, address indexed creator, uint256 moneyEscrowed, uint256 sharesEscrowed, bytes32 tradeGroupId, bytes32 orderId, address indexed universe, address indexed shareToken);
@@ -200,11 +200,11 @@ contract Augur is Controlled, IAugur {
         return true;
     }
 
-    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators) public returns (bool) {
+    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators, bool _invalid) public returns (bool) {
         require(universes[msg.sender]);
         IUniverse _parentUniverse = IUniverse(msg.sender);
         require(_parentUniverse.isParentOf(_childUniverse));
-        UniverseCreated(_parentUniverse, _childUniverse, _payoutNumerators);
+        UniverseCreated(_parentUniverse, _childUniverse, _payoutNumerators, _invalid);
         return true;
     }
 

--- a/source/contracts/IAugur.sol
+++ b/source/contracts/IAugur.sol
@@ -27,7 +27,7 @@ contract IAugur {
     function logCompleteSetsSold(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public returns (bool);
     function logTradingProceedsClaimed(IUniverse _universe, address _shareToken, address _sender, address _market, uint256 _numShares, uint256 _numPayoutTokens, uint256 _finalTokenBalance) public returns (bool);
     function logUniverseForked() public returns (bool);
-    function logUniverseCreated(IUniverse _childUniverse) public returns (bool);
+    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators) public returns (bool);
     function logFeeWindowTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool);
     function logReputationTokensTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool);
     function logDisputeCrowdsourcerTokensTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool);

--- a/source/contracts/IAugur.sol
+++ b/source/contracts/IAugur.sol
@@ -27,7 +27,7 @@ contract IAugur {
     function logCompleteSetsSold(IUniverse _universe, IMarket _market, address _account, uint256 _numCompleteSets) public returns (bool);
     function logTradingProceedsClaimed(IUniverse _universe, address _shareToken, address _sender, address _market, uint256 _numShares, uint256 _numPayoutTokens, uint256 _finalTokenBalance) public returns (bool);
     function logUniverseForked() public returns (bool);
-    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators) public returns (bool);
+    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators, bool _invalid) public returns (bool);
     function logFeeWindowTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool);
     function logReputationTokensTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool);
     function logDisputeCrowdsourcerTokensTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool);

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -174,7 +174,7 @@ contract Universe is DelegationTarget, ITyped, Initializable, IUniverse {
         if (_childUniverse == IUniverse(0)) {
             _childUniverse = _augur.createChildUniverse(_parentPayoutDistributionHash);
             childUniverses[_parentPayoutDistributionHash] = _childUniverse;
-            _augur.logUniverseCreated(_childUniverse);
+            _augur.logUniverseCreated(_childUniverse, _parentPayoutNumerators);
         }
         return _childUniverse;
     }

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -174,7 +174,7 @@ contract Universe is DelegationTarget, ITyped, Initializable, IUniverse {
         if (_childUniverse == IUniverse(0)) {
             _childUniverse = _augur.createChildUniverse(_parentPayoutDistributionHash);
             childUniverses[_parentPayoutDistributionHash] = _childUniverse;
-            _augur.logUniverseCreated(_childUniverse, _parentPayoutNumerators);
+            _augur.logUniverseCreated(_childUniverse, _parentPayoutNumerators, _parentInvalid);
         }
         return _childUniverse;
     }

--- a/tests/solidity_test_helpers/MockAugur.sol
+++ b/tests/solidity_test_helpers/MockAugur.sol
@@ -146,7 +146,7 @@ contract MockAugur is Controlled {
 
     function logUniverseCreatedCalled() public returns(bool) { return logUniverseCreatedCalledValue;}
 
-    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators) public returns (bool) {
+    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators, bool _invalid) public returns (bool) {
         logUniverseCreatedCalledValue = true;
         return true;
     }

--- a/tests/solidity_test_helpers/MockAugur.sol
+++ b/tests/solidity_test_helpers/MockAugur.sol
@@ -146,7 +146,7 @@ contract MockAugur is Controlled {
 
     function logUniverseCreatedCalled() public returns(bool) { return logUniverseCreatedCalledValue;}
 
-    function logUniverseCreated(IUniverse _childUniverse) public returns (bool) {
+    function logUniverseCreated(IUniverse _childUniverse, uint256[] _payoutNumerators) public returns (bool) {
         logUniverseCreatedCalledValue = true;
         return true;
     }


### PR DESCRIPTION
Turns out we need this to reasonably process universe creation for later use in the UI. We need to be able to easily match a payout with a child universe.