### PR TITLE
Auto rep migration support

### DIFF
--- a/source/contracts/TestNetReputationToken.sol
+++ b/source/contracts/TestNetReputationToken.sol
@@ -1,0 +1,26 @@
+pragma solidity 0.4.20;
+
+import 'libraries/ContractExists.sol';
+import 'reporting/ReputationToken.sol';
+
+
+contract TestNetReputationToken is ReputationToken {
+    using ContractExists for address;
+
+    uint256 private constant DEFAULT_FAUCET_AMOUNT = 47 ether;
+    address private constant FOUNDATION_REP_ADDRESS = address(0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6);
+
+    function TestNetReputationToken() public {
+        // This is to confirm we are not on foundation network
+        require(!FOUNDATION_REP_ADDRESS.exists());
+    }
+
+    function faucet(uint256 _amount) public whenNotMigratingFromLegacy returns (bool) {
+        if (_amount == 0) {
+            _amount = DEFAULT_FAUCET_AMOUNT;
+        }
+        require(_amount < 2 ** 128);
+        mint(msg.sender, _amount);
+        return true;
+    }
+}

--- a/source/contracts/libraries/token/StandardToken.sol
+++ b/source/contracts/libraries/token/StandardToken.sol
@@ -42,8 +42,7 @@ contract StandardToken is ERC20, BasicToken {
     * @param _value The amount of tokens to be spent.
     */
     function approve(address _spender, uint256 _value) public returns (bool) {
-        allowed[msg.sender][_spender] = _value;
-        Approval(msg.sender, _spender, _value);
+        approveInternal(msg.sender, _spender, _value);
         return true;
     }
 
@@ -65,8 +64,7 @@ contract StandardToken is ERC20, BasicToken {
    * @param _addedValue The amount of tokens to increase the allowance by.
    */
     function increaseApproval(address _spender, uint _addedValue) public returns (bool) {
-        allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_addedValue);
-        Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+        approveInternal(msg.sender, _spender, allowed[msg.sender][_spender].add(_addedValue));
         return true;
     }
 
@@ -80,11 +78,16 @@ contract StandardToken is ERC20, BasicToken {
     function decreaseApproval(address _spender, uint _subtractedValue) public returns (bool) {
         uint oldValue = allowed[msg.sender][_spender];
         if (_subtractedValue > oldValue) {
-            allowed[msg.sender][_spender] = 0;
+            approveInternal(msg.sender, _spender, 0);
         } else {
-            allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);
+            approveInternal(msg.sender, _spender, oldValue.sub(_subtractedValue));
         }
-        Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+        return true;
+    }
+
+    function approveInternal(address _owner, address _spender, uint256 _value) internal returns (bool) {
+        allowed[_owner][_spender] = _value;
+        Approval(_owner, _spender, _value);
         return true;
     }
 }

--- a/source/contracts/reporting/ReputationToken.sol
+++ b/source/contracts/reporting/ReputationToken.sol
@@ -26,15 +26,39 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
     uint256 private parentTotalTheoreticalSupply;
     uint256 private totalTheoreticalSupply;
 
+    // Auto migration related state
+    bool private isMigratingFromLegacy;
+    uint256 private targetSupply;
+
+    /**
+     * @dev modifier to allow actions only when the contract IS paused
+     */
+    modifier whenMigratingFromLegacy() {
+        require(isMigratingFromLegacy);
+        _;
+    }
+
+    /**
+     * @dev modifier to allow actions only when the contract IS paused
+     */
+    modifier whenNotMigratingFromLegacy() {
+        require(!isMigratingFromLegacy);
+        _;
+    }
+
     function initialize(IUniverse _universe) public onlyInGoodTimes beforeInitialized returns (bool) {
         endInitialization();
         require(_universe != address(0));
         universe = _universe;
         updateParentTotalTheoreticalSupply();
+        ERC20 _legacyRepToken = getLegacyRepToken();
+        // Initialize migration related state. If this is Genesis universe REP the balances from the Legacy contract must be migrated before we enable usage
+        isMigratingFromLegacy = _universe.getParentUniverse() == IUniverse(0);
+        targetSupply = _legacyRepToken.totalSupply();
         return true;
     }
 
-    function migrateOutByPayout(uint256[] _payoutNumerators, bool _invalid, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function migrateOutByPayout(uint256[] _payoutNumerators, bool _invalid, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         require(_attotokens > 0);
         IUniverse _destinationUniverse = universe.createChildUniverse(_payoutNumerators, _invalid);
         IReputationToken _destination = _destinationUniverse.getReputationToken();
@@ -43,7 +67,7 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return true;
     }
 
-    function migrateOut(IReputationToken _destination, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function migrateOut(IReputationToken _destination, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         require(_attotokens > 0);
         assertReputationTokenIsLegitSibling(_destination);
         burn(msg.sender, _attotokens);
@@ -51,7 +75,7 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return true;
     }
 
-    function migrateIn(address _reporter, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function migrateIn(address _reporter, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         IUniverse _parentUniverse = universe.getParentUniverse();
         require(ReputationToken(msg.sender) == _parentUniverse.getReputationToken());
         mint(_reporter, _attotokens);
@@ -69,15 +93,7 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return true;
     }
 
-    function migrateFromLegacyReputationToken() public onlyInGoodTimes afterInitialized returns (bool) {
-        ERC20 _legacyRepToken = ERC20(controller.lookup("LegacyReputationToken"));
-        uint256 _legacyBalance = _legacyRepToken.balanceOf(msg.sender);
-        require(_legacyRepToken.transferFrom(msg.sender, address(0), _legacyBalance));
-        mint(msg.sender, _legacyBalance);
-        return true;
-    }
-
-    function mintForReportingParticipant(uint256 _amountMigrated) public onlyInGoodTimes afterInitialized returns (bool) {
+    function mintForReportingParticipant(uint256 _amountMigrated) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         IUniverse _parentUniverse = universe.getParentUniverse();
         IReportingParticipant _reportingParticipant = IReportingParticipant(msg.sender);
         require(_parentUniverse.isContainerForReportingParticipant(_reportingParticipant));
@@ -87,22 +103,30 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return true;
     }
 
-    function trustedUniverseTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function transfer(address _to, uint _value) public whenNotMigratingFromLegacy returns (bool) {
+        return super.transfer(_to, _value);
+    }
+
+    function transferFrom(address _from, address _to, uint _value) public whenNotMigratingFromLegacy returns (bool) {
+        return super.transferFrom(_from, _to, _value);
+    }
+
+    function trustedUniverseTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         require(IUniverse(msg.sender) == universe);
         return internalTransfer(_source, _destination, _attotokens);
     }
 
-    function trustedMarketTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function trustedMarketTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         require(universe.isContainerForMarket(IMarket(msg.sender)));
         return internalTransfer(_source, _destination, _attotokens);
     }
 
-    function trustedReportingParticipantTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function trustedReportingParticipantTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         require(universe.isContainerForReportingParticipant(IReportingParticipant(msg.sender)));
         return internalTransfer(_source, _destination, _attotokens);
     }
 
-    function trustedFeeWindowTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes afterInitialized returns (bool) {
+    function trustedFeeWindowTransfer(address _source, address _destination, uint256 _attotokens) public onlyInGoodTimes whenNotMigratingFromLegacy afterInitialized returns (bool) {
         require(universe.isContainerForFeeWindow(IFeeWindow(msg.sender)));
         return internalTransfer(_source, _destination, _attotokens);
     }
@@ -127,7 +151,11 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return totalMigrated;
     }
 
-    function updateSiblingMigrationTotal(IReputationToken _token) public returns (bool) {
+    function getLegacyRepToken() public view returns (ERC20) {
+        return ERC20(controller.lookup("LegacyReputationToken"));
+    }
+
+    function updateSiblingMigrationTotal(IReputationToken _token) public whenNotMigratingFromLegacy returns (bool) {
         require(_token != this);
         IUniverse _shadyUniverse = _token.getUniverse();
         require(_token == universe.getParentUniverse().getChildUniverse(_shadyUniverse.getParentPayoutDistributionHash()).getReputationToken());
@@ -137,7 +165,7 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
         return true;
     }
 
-    function updateParentTotalTheoreticalSupply() public returns (bool) {
+    function updateParentTotalTheoreticalSupply() public whenNotMigratingFromLegacy returns (bool) {
         IUniverse _parentUniverse = universe.getParentUniverse();
         totalTheoreticalSupply -= parentTotalTheoreticalSupply;
         if (_parentUniverse == IUniverse(0)) {
@@ -166,5 +194,66 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
     function onBurn(address _target, uint256 _amount) internal returns (bool) {
         controller.getAugur().logReputationTokenBurned(universe, _target, _amount);
         return true;
+    }
+
+        /**
+     * @dev Copies the balance of a batch of addresses from the legacy contract
+     * @param _holders Array of addresses to migrate balance
+     * @return True if operation was completed
+     */
+    function migrateBalancesFromLegacyRep(address[] _holders) public onlyInGoodTimes whenMigratingFromLegacy afterInitialized returns (bool) {
+        ERC20 _legacyRepToken = getLegacyRepToken();
+        for (uint256 i = 0; i < _holders.length; i++) {
+            migrateBalanceFromLegacyRep(_holders[i], _legacyRepToken);
+        }
+        return true;
+    }
+
+    /**
+     * @dev Copies the balance of a single addresses from the legacy contract
+     * @param _holder Address to migrate balance
+     * @return True if balance was copied, false if was already copied or address had no balance
+     */
+    function migrateBalanceFromLegacyRep(address _holder, ERC20 _legacyRepToken) private onlyInGoodTimes whenMigratingFromLegacy afterInitialized returns (bool) {
+        if (balances[_holder] > 0) {
+            return false; // Already copied, move on
+        }
+
+        uint256 amount = _legacyRepToken.balanceOf(_holder);
+        if (amount == 0) {
+            return false; // Has no balance in legacy contract, move on
+        }
+
+        mint(_holder, amount);
+
+        if (targetSupply == supply) {
+            isMigratingFromLegacy = false;
+        }
+        return true;
+    }
+
+    /**
+     * @dev Copies the allowances of a batch of addresses from the legacy contract. This is an optional step which may only be done before the migration is complete but is not required to complete it.
+     * @param _owners Array of owner addresses to migrate allowances
+     * @param _spenders Array of spender addresses to migrate allowances
+     * @return True if operation was completed
+     */
+    function migrateAllowancesFromLegacyRep(address[] _owners, address[] _spenders) public onlyInGoodTimes whenMigratingFromLegacy afterInitialized returns (bool) {
+        ERC20 _legacyRepToken = getLegacyRepToken();
+        for (uint256 i = 0; i < _owners.length; i++) {
+            address _owner = _owners[i];
+            address _spender = _spenders[i];
+            uint256 _allowance = _legacyRepToken.allowance(_owner, _spender);
+            approveInternal(_owner, _spender, _allowance);
+        }
+        return true;
+    }
+
+    function getIsMigratingFromLegacy() public view returns (bool) {
+        return isMigratingFromLegacy;
+    }
+
+    function getTargetSupply() public view returns (uint256) {
+        return targetSupply;
     }
 }

--- a/source/libraries/ContractDeployer.ts
+++ b/source/libraries/ContractDeployer.ts
@@ -152,8 +152,10 @@ Deploying to: ${networkConfiguration.networkName}
         if (contractName === 'Controller') return;
         if (contractName === 'Delegator') return;
         if (contractName === 'TimeControlled') return;
+        if (contractName === 'TestNetReputationToken') return;
         if (contractName === 'Augur') return;
-        if (contractName === 'Time') contract = this.configuration.useNormalTime ? contract: this.contracts.get('TimeControlled');
+        if (contractName === 'Time') contract = this.configuration.useNormalTime ? contract : this.contracts.get('TimeControlled');
+        if (contractName === 'ReputationToken') contract = this.configuration.isProduction ? contract : this.contracts.get('TestNetReputationToken');
         if (contract.relativeFilePath.startsWith('legacy_reputation/')) return;
         if (contractName !== 'Map' && contract.relativeFilePath.startsWith('libraries/')) return;
         // Check to see if we have already uploded this version of the contract

--- a/source/libraries/ContractDeployer.ts
+++ b/source/libraries/ContractDeployer.ts
@@ -65,7 +65,7 @@ Deploying to: ${networkConfiguration.networkName}
             this.universe = await this.createGenesisUniverse();
 
             if (!this.configuration.isProduction) {
-                this.migrateFromlegacyRep();
+                this.migrateFromLegacyRep();
             }
         }
 
@@ -282,7 +282,7 @@ Deploying to: ${networkConfiguration.networkName}
         return universe;
     }
 
-    private async migrateFromlegacyRep(): Promise<void> {
+    private async migrateFromLegacyRep(): Promise<void> {
         const reputationTokenAddress = await this.universe.getReputationToken_();
         const reputationToken = new ReputationToken(this.connector, this.accountManager, reputationTokenAddress, this.connector.gasPrice);
         await reputationToken.migrateBalancesFromLegacyRep([this.accountManager.defaultAddress]);

--- a/source/libraries/ContractInterfaces.ts
+++ b/source/libraries/ContractInterfaces.ts
@@ -3631,17 +3631,31 @@
             return <BN>result[0];
         }
 
-        public migrateFromLegacyReputationToken = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+        public getLegacyRepToken_ = async( options?: { sender?: string }): Promise<string> => {
             options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"migrateFromLegacyReputationToken","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            await this.remoteCall(abi, [], "migrateFromLegacyReputationToken", options.sender, options.gasPrice);
+            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"getLegacyRepToken","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <string>result[0];
+        }
+
+        public getIsMigratingFromLegacy_ = async( options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"getIsMigratingFromLegacy","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <boolean>result[0];
+        }
+
+        public migrateBalancesFromLegacyRep = async(holders: Array<string>, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_holders","type":"address[]"}],"name":"migrateBalancesFromLegacyRep","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [holders], "migrateBalancesFromLegacyRep", options.sender, options.gasPrice);
             return;
         }
 
-        public migrateFromLegacyReputationToken_ = async( options?: { sender?: string }): Promise<boolean> => {
+        public migrateBalancesFromLegacyRep_ = async(holders: Array<string>, options?: { sender?: string }): Promise<boolean> => {
             options = options || {};
-            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"migrateFromLegacyReputationToken","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
-            const result = await this.localCall(abi, [], options.sender);
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_holders","type":"address[]"}],"name":"migrateBalancesFromLegacyRep","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [holders], options.sender);
             return <boolean>result[0];
         }
 
@@ -3824,6 +3838,27 @@
             options = options || {};
             const abi: AbiFunction = {"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"remaining","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"};
             const result = await this.localCall(abi, [owner, spender], options.sender);
+            return <BN>result[0];
+        }
+
+        public migrateAllowancesFromLegacyRep = async(owners: Array<string>, spenders: Array<string>, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_owners","type":"address[]"},{"name":"_spenders","type":"address[]"}],"name":"migrateAllowancesFromLegacyRep","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [owners, spenders], "migrateAllowancesFromLegacyRep", options.sender, options.gasPrice);
+            return;
+        }
+
+        public migrateAllowancesFromLegacyRep_ = async(owners: Array<string>, spenders: Array<string>, options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_owners","type":"address[]"},{"name":"_spenders","type":"address[]"}],"name":"migrateAllowancesFromLegacyRep","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [owners, spenders], options.sender);
+            return <boolean>result[0];
+        }
+
+        public getTargetSupply_ = async( options?: { sender?: string }): Promise<BN> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"getTargetSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
             return <BN>result[0];
         }
 

--- a/source/libraries/DeployerConfiguration.ts
+++ b/source/libraries/DeployerConfiguration.ts
@@ -8,8 +8,10 @@ export class DeployerConfiguration {
     public readonly controllerAddress: string|undefined;
     public readonly createGenesisUniverse: boolean;
     public readonly useNormalTime: boolean;
+    public readonly isProduction: boolean;
 
     public constructor(contractInputRoot: string, artifactOutputRoot: string, controllerAddress: string|undefined, createGenesisUniverse: boolean=true, isProduction: boolean=false, useNormalTime: boolean=true) {
+        this.isProduction = isProduction;
         this.controllerAddress = controllerAddress;
         this.createGenesisUniverse = createGenesisUniverse;
         this.useNormalTime = isProduction || useNormalTime;

--- a/source/tests-integration/TestFixture.ts
+++ b/source/tests-integration/TestFixture.ts
@@ -7,7 +7,7 @@ import { ContractDeployer } from '../libraries/ContractDeployer';
 import { CompilerConfiguration } from '../libraries/CompilerConfiguration';
 import { DeployerConfiguration } from '../libraries/DeployerConfiguration';
 import { NetworkConfiguration } from '../libraries/NetworkConfiguration';
-import { FeeWindow, ShareToken, CompleteSets, TimeControlled, LegacyReputationToken, Cash, Universe, ReputationToken, Market, CreateOrder, Orders, Trade, CancelOrder } from '../libraries/ContractInterfaces';
+import { FeeWindow, ShareToken, CompleteSets, TimeControlled, Cash, Universe, Market, CreateOrder, Orders, Trade, CancelOrder } from '../libraries/ContractInterfaces';
 import { stringTo32ByteHex } from '../libraries/HelperFunctions';
 
 export class TestFixture {
@@ -52,16 +52,6 @@ export class TestFixture {
     }
 
     public async createMarket(universe: Universe, outcomes: string[], endTime: BN, feePerEthInWei: BN, denominationToken: string, designatedReporter: string): Promise<Market> {
-        const legacyReputationToken = new LegacyReputationToken(this.connector, this.accountManager, this.contractDeployer.getContract('LegacyReputationToken').address, TestFixture.GAS_PRICE);
-        const reputationTokenAddress = await universe.getReputationToken_();
-        const reputationToken = new ReputationToken(this.connector, this.accountManager, reputationTokenAddress, TestFixture.GAS_PRICE);
-
-        // get some REP
-        // TODO: just get enough REP to cover the bonds rather than over-allocating
-        await legacyReputationToken.faucet(new BN(0));
-        await legacyReputationToken.approve(reputationTokenAddress, new BN(2).pow(new BN(256)).sub(new BN(1)));
-        await reputationToken.migrateFromLegacyReputationToken();
-
         const marketCreationFee = await universe.getOrCacheMarketCreationCost_();
 
         const marketAddress = await universe.createCategoricalMarket_(endTime, feePerEthInWei, denominationToken, designatedReporter, outcomes, stringTo32ByteHex(" "), 'description', '', { attachedEth: marketCreationFee });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,13 +182,9 @@ class ContractsFixture:
         self.testerAddressToKey = dict(zip(self.testerAddress.values(), self.testerKey.values()))
 
     def distributeRep(self, universe):
-        legacyReputationToken = self.contracts['LegacyReputationToken']
-        legacyReputationToken.faucet(11 * 10**6 * 10**18)
-
         # Get the reputation token for this universe and migrate legacy REP to it
         reputationToken = self.applySignature('ReputationToken', universe.getReputationToken())
-        legacyReputationToken.approve(reputationToken.address, 11 * 10**6 * 10**18)
-        reputationToken.migrateFromLegacyReputationToken()
+        reputationToken.migrateBalancesFromLegacyRep([tester.a0])
 
     def generateTesterMap(self, ch):
         testers = {}
@@ -455,6 +451,8 @@ def augurInitializedWithMocksSnapshot(fixture, augurInitializedSnapshot):
 def kitchenSinkSnapshot(fixture, augurInitializedSnapshot):
     fixture.resetToSnapshot(augurInitializedSnapshot)
     # TODO: remove assignments to the fixture as they don't get rolled back, so can bleed across tests.  We should be accessing things via `fixture.contracts[...]`
+    legacyReputationToken = fixture.contracts['LegacyReputationToken']
+    legacyReputationToken.faucet(11 * 10**6 * 10**18)
     universe = fixture.createUniverse()
     cash = fixture.getSeededCash()
     augur = fixture.contracts['Augur']
@@ -516,4 +514,9 @@ def sessionFixture(fixture, kitchenSinkSnapshot):
 @pytest.fixture
 def contractsFixture(fixture, kitchenSinkSnapshot):
     fixture.resetToSnapshot(kitchenSinkSnapshot)
+    return fixture
+
+@pytest.fixture
+def augurInitializedFixture(fixture, augurInitializedSnapshot):
+    fixture.resetToSnapshot(augurInitializedSnapshot)
     return fixture

--- a/tests/fuzzy/test_wcl_fuzzy.py
+++ b/tests/fuzzy/test_wcl_fuzzy.py
@@ -57,11 +57,6 @@ def execute(fixture, snapshot, universe, market, orderType, orderSize, orderPric
     legacyReputationToken.faucet(long(11 * 10**6 * 10**18))
     fixture.chain.head_state.timestamp += 15000
 
-    # Get the reputation token for this universe and migrate legacy REP to it
-    reputationToken = fixture.applySignature('ReputationToken', universe.getReputationToken())
-    legacyReputationToken.approve(reputationToken.address, 11 * 10**6 * 10**18)
-    reputationToken.migrateFromLegacyReputationToken()
-
     orders = fixture.contracts['Orders']
     createOrder = fixture.contracts['CreateOrder']
     fillOrder = fixture.contracts['FillOrder']

--- a/tests/reporting/test_reputation.py
+++ b/tests/reporting/test_reputation.py
@@ -1,4 +1,6 @@
 from ethereum.tools import tester
+from ethereum.tools.tester import TransactionFailed
+from pytest import raises
 from utils import captureFilteredLogs, bytesToHexString
 
 def test_init(contractsFixture, universe):
@@ -40,3 +42,42 @@ def test_reputation_token_logging(contractsFixture, universe):
     assert logs[1]['universe'] == universe.address
     assert logs[0]['tokenType'] == 0
     assert logs[1]['value'] == 12
+
+def test_legacy_migration(augurInitializedFixture):
+    # Initialize the legacy REP contract with some balances
+    legacyReputationToken = augurInitializedFixture.contracts['LegacyReputationToken']
+    legacyReputationToken.faucet(11 * 10**6 * 10**18)
+    legacyReputationToken.transfer(tester.a1, 100)
+    legacyReputationToken.transfer(tester.a2, 100)
+    legacyReputationToken.approve(tester.a1, 1000)
+    legacyReputationToken.approve(tester.a2, 2000)
+
+    # When we create a genesis universe we'll need to migrate the legacy REP before the contract can be used
+    universe = augurInitializedFixture.createUniverse()
+    reputationToken = augurInitializedFixture.applySignature("ReputationToken", universe.getReputationToken())
+
+    # We'll only partially migrate right now
+    reputationToken.migrateBalancesFromLegacyRep([tester.a1])
+    assert reputationToken.balanceOf(tester.a1) == 100
+
+    # Since the migration has not completed we can't transfer or do normal token actions
+    assert reputationToken.getIsMigratingFromLegacy()
+    with raises(TransactionFailed):
+        reputationToken.transfer(tester.a2, 1, sender=tester.k1)
+
+    # Before we finish the migration we'll migrate some allowances
+    assert reputationToken.migrateAllowancesFromLegacyRep([tester.a0, tester.a0], [tester.a1, tester.a2])
+    assert reputationToken.allowance(tester.a0, tester.a1) == 1000
+    assert reputationToken.allowance(tester.a0, tester.a2) == 2000
+
+    # We'll finish the migration now and confirm we can transfer
+    reputationToken.migrateBalancesFromLegacyRep([tester.a0, tester.a2])
+    assert not reputationToken.getIsMigratingFromLegacy()
+    assert reputationToken.transfer(tester.a2, 1, sender=tester.k1)
+
+    # Now that the migration is complete we can no longer migrate balances or allowances from the legacy contract
+    with raises(TransactionFailed):
+        reputationToken.migrateBalancesFromLegacyRep([tester.a2])
+
+    with raises(TransactionFailed):
+        reputationToken.migrateAllowancesFromLegacyRep([tester.a0, tester.a2])


### PR DESCRIPTION
When a genesis universe is created it will assume the legacy REP contract is frozen and until all balances are migrated it will be frozen except in migrating balances and allowances.

I added a test net rep contract that we can use so we still have faucet capabilities on test nets.