### PR TITLE
Add events for disavowal

### DIFF
--- a/source/contracts/Augur.sol
+++ b/source/contracts/Augur.sol
@@ -32,6 +32,8 @@ contract Augur is Controlled, IAugur {
     event DisputeCrowdsourcerCompleted(address indexed universe, address indexed market, address disputeCrowdsourcer);
     event InitialReporterRedeemed(address indexed universe, address indexed reporter, address indexed market, uint256 amountRedeemed, uint256 repReceived, uint256 reportingFeesReceived, uint256[] payoutNumerators);
     event DisputeCrowdsourcerRedeemed(address indexed universe, address indexed reporter, address indexed market, address disputeCrowdsourcer, uint256 amountRedeemed, uint256 repReceived, uint256 reportingFeesReceived, uint256[] payoutNumerators);
+    event ReportingParticipantDisavowed(address indexed universe, address indexed market, address reportingParticipant);
+    event MarketParticipantsDisavowed(address indexed universe, address indexed market);
     event FeeWindowRedeemed(address indexed universe, address indexed reporter, address indexed feeWindow, uint256 amountRedeemed, uint256 reportingFeesReceived);
     event MarketFinalized(address indexed universe, address indexed market);
     event MarketMigrated(address indexed market, address indexed originalUniverse, address indexed newUniverse);
@@ -149,6 +151,21 @@ contract Augur is Controlled, IAugur {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForReportingParticipant(IReportingParticipant(msg.sender)));
         DisputeCrowdsourcerRedeemed(_universe, _reporter, _market, msg.sender, _amountRedeemed, _repReceived, _reportingFeesReceived, _payoutNumerators);
+        return true;
+    }
+
+    function logReportingParticipantDisavowed(IUniverse _universe, IMarket _market) public returns (bool) {
+        require(isKnownUniverse(_universe));
+        require(_universe.isContainerForReportingParticipant(IReportingParticipant(msg.sender)));
+        ReportingParticipantDisavowed(_universe, _market, msg.sender);
+        return true;
+    }
+
+    function logMarketParticipantsDisavowed(IUniverse _universe) public returns (bool) {
+        require(isKnownUniverse(_universe));
+        IMarket _market = IMarket(msg.sender);
+        require(_universe.isContainerForMarket(_market));
+        MarketParticipantsDisavowed(_universe, _market);
         return true;
     }
 

--- a/source/contracts/IAugur.sol
+++ b/source/contracts/IAugur.sol
@@ -21,6 +21,8 @@ contract IAugur {
     function logFeeWindowRedeemed(IUniverse _universe, address _reporter, uint256 _amountRedeemed, uint256 _reportingFeesReceived) public returns (bool);
     function logMarketFinalized(IUniverse _universe) public returns (bool);
     function logMarketMigrated(IMarket _market, IUniverse _originalUniverse) public returns (bool);
+    function logReportingParticipantDisavowed(IUniverse _universe, IMarket _market) public returns (bool);
+    function logMarketParticipantsDisavowed(IUniverse _universe) public returns (bool);
     function logOrderCanceled(IUniverse _universe, address _shareToken, address _sender, bytes32 _orderId, Order.Types _orderType, uint256 _tokenRefund, uint256 _sharesRefund) public returns (bool);
     function logOrderCreated(Order.Types _orderType, uint256 _amount, uint256 _price, address _creator, uint256 _moneyEscrowed, uint256 _sharesEscrowed, bytes32 _tradeGroupId, bytes32 _orderId, IUniverse _universe, address _shareToken) public returns (bool);
     function logOrderFilled(IUniverse _universe, address _shareToken, address _filler, bytes32 _orderId, uint256 _numCreatorShares, uint256 _numCreatorTokens, uint256 _numFillerShares, uint256 _numFillerTokens, uint256 _marketCreatorFees, uint256 _reporterFees, bytes32 _tradeGroupId) public returns (bool);

--- a/source/contracts/reporting/BaseReportingParticipant.sol
+++ b/source/contracts/reporting/BaseReportingParticipant.sol
@@ -42,6 +42,7 @@ contract BaseReportingParticipant is Controlled, IReportingParticipant {
         reputationToken.migrateOut(_newReputationToken, _balance);
         _newReputationToken.mintForReportingParticipant(_balance);
         reputationToken = _newReputationToken;
+        controller.getAugur().logReportingParticipantDisavowed(market.getUniverse(), market);
         market = IMarket(0);
         return true;
     }

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -309,6 +309,7 @@ contract Market is DelegationTarget, ITyped, Initializable, Ownable, IMarket {
         delete participants;
         participants.push(_initialParticipant);
         crowdsourcers = MapFactory(controller.lookup("MapFactory")).createMap(controller, this);
+        controller.getAugur().logMarketParticipantsDisavowed(universe);
         return true;
     }
 

--- a/tests/reporting/test_fee_distribution.py
+++ b/tests/reporting/test_fee_distribution.py
@@ -313,10 +313,18 @@ def test_forking(localFixture, universe, market, categoricalMarket, cash, reputa
         testerIndex = testerIndex % len(testers)
 
     # Have the participants fork and create new child universes
-    for i in range(market.getNumParticipants()):
+    reportingParticipant = localFixture.applySignature("DisputeCrowdsourcer", market.getReportingParticipant(0))
+    ReportingParticipantDisavowedLog = {
+        "universe": universe.address,
+        "market": market.address,
+        "reportingParticipant": reportingParticipant.address,
+    }
+    with AssertLog(localFixture, "ReportingParticipantDisavowed", ReportingParticipantDisavowedLog):
+        reportingParticipant.fork()
+
+    for i in range(1, market.getNumParticipants()):
         reportingParticipant = localFixture.applySignature("DisputeCrowdsourcer", market.getReportingParticipant(i))
-        with PrintGasUsed(localFixture, "Fork:", 0):
-            reportingParticipant.fork()
+        reportingParticipant.fork()
 
     # Finalize the fork
     finalizeFork(localFixture, market, universe)

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -190,7 +190,12 @@ def test_forking(finalizeByMigration, manuallyDisavow, localFixture, universe, m
     categoricalDisputeCrowdsourcer = localFixture.applySignature("DisputeCrowdsourcer", categoricalMarket.getReportingParticipant(1))
 
     if manuallyDisavow:
-        assert categoricalMarket.disavowCrowdsourcers()
+        marketParticipantsDisavowedLog = {
+            "universe": universe.address,
+            "market": categoricalMarket.address,
+        }
+        with AssertLog(localFixture, "MarketParticipantsDisavowed", marketParticipantsDisavowedLog):
+            assert categoricalMarket.disavowCrowdsourcers()
         # We can redeem before the fork finalizes since disavowal has occured
         assert categoricalDisputeCrowdsourcer.redeem(tester.a0)
 

--- a/tests/solidity_test_helpers/MockAugur.sol
+++ b/tests/solidity_test_helpers/MockAugur.sol
@@ -51,6 +51,14 @@ contract MockAugur is Controlled {
         return true;
     }
 
+    function logReportingParticipantDisavowed(IUniverse _universe, IMarket _market) public returns (bool) {
+        return true;
+    }
+
+    function logMarketParticipantsDisavowed(IUniverse _universe) public returns (bool) {
+        return true;
+    }
+
     function logInitialReporterRedeemed(IUniverse _universe, address _reporter, address _market, uint256 _amountRedeemed, uint256 _repReceived, uint256 _reportingFeesReceived, uint256[] _payoutNumerators) public returns (bool) {
         return true;
     }


### PR DESCRIPTION
Noted in discord as well but it should be noted we don't send an extra `MarketParticipantsDisavowed` event during market migration since the migration event itself should be sufficient for that.