### PR TITLE
WIP: Feature/608 enable mythril tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ script: docker pull $IMAGE_BUILD;
         npm run docker:run:test:integration:geth;
         elif [[ "$TESTS" == "integration:parity" ]]; then
         npm run docker:run:test:integration:parity;
+        elif [[ "$TESTS" == "security:mythril" ]]; then
+        npm run docker:run:test:security:mythril;
+        cat source/contracts/test-result.log;
         else
           npm run docker:run:test:unit -- $TESTS;
         fi
@@ -73,4 +76,4 @@ env:
     - TESTS="tests/unit"
     - TESTS="integration:geth"
     - TESTS="integration:parity"
-
+    - TESTS="security:mythril"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "docker:run:test:unit:all": "npm run docker:run:npm -- run test:unit:all",
     "docker:run:test:integration:geth": "docker-compose -f ./source/support/test/integration/docker-compose-parity.yml up --abort-on-container-exit --force-recreate",
     "docker:run:test:integration:parity": "docker-compose -f ./source/support/test/integration/docker-compose-geth.yml up --abort-on-container-exit --force-recreate",
+    "docker:run:test:security:mythril": "docker run -v `pwd`:/augur-core --workdir /augur-core/source/contracts cryptomental/augur-mythril-ci python /scripts/processor.py",
     "docker:run:test": "npm run docker:run:test:unit:all && npm run docker:run:test:integration",
     "docker:run:deploy:net": "bash support/deploy/run.sh docker",
     "docker:run:deploy:rinkeby": "npm run docker:run:deploy:net -- rinkeby",


### PR DESCRIPTION
This PR solves #608 - running augur-core contracts on CI against Mythril.

augur-mythril-ci Docker image is based on mythril-ci fork  
`https://github.com/cryptomental/mythril-ci/commits/master`

Changes vs original mythril-ci repository were required due to Microsoft's z3
theorem solver being unstable for augur-core contracts, randomly failing 
to evaluate the contract model. After a few retries the solver is always able
to parse the model and return data. This behaviour can be verified against 
a failing z3 solver running `mythril -x contracts/contract_name.sol` several times.

Test results are provided in markdown format and returned as test-result.log file. 
Content of the file is displayed during security:mythril test run on Travis.

If no issues with type Error are found, the test runner exits with '0' return code 
and Mythril test passes. All issues of 'Informational' and 'Warning' type are available
in the Travis log.

Mythril test run takes around 10 minutes on i7 and up to 20 minutes on older dual-core CPUs.

Refs: #608