### PR TITLE
feature/maian-tests-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script: docker pull $IMAGE_BUILD;
         elif [[ "$TESTS" == "security:mythril" ]]; then
         npm run docker:run:test:security:mythril;
         cat source/contracts/test-results.log;
+        elif [[ "$TESTS" == "security:maian" ]]; then
+        npm run docker:run:test:security:maian;
         else
           npm run docker:run:test:unit -- $TESTS;
         fi
@@ -77,3 +79,4 @@ env:
     - TESTS="integration:geth"
     - TESTS="integration:parity"
     - TESTS="security:mythril"
+    - TESTS="security:maian"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "docker:run:test:integration:geth": "docker-compose -f ./source/support/test/integration/docker-compose-parity.yml up --abort-on-container-exit --force-recreate",
     "docker:run:test:integration:parity": "docker-compose -f ./source/support/test/integration/docker-compose-geth.yml up --abort-on-container-exit --force-recreate",
     "docker:run:test:security:mythril": "docker run -v `pwd`:/augur-core --workdir /augur-core/source/contracts cryptomental/augur-mythril-ci python /scripts/processor.py",
+    "docker:run:test:security:maian": "docker-compose -f ./source/support/test/integration/docker-compose-geth.yml up --abort-on-container-exit --force-recreate && docker cp integration_geth-integration-tests_1:/app/output/contracts/ contracts/ && docker run -v `pwd`/contracts:/app/output/contracts/ cryptomental/maian-augur-ci python /scripts/test_runner.py",
     "docker:run:test": "npm run docker:run:test:unit:all && npm run docker:run:test:integration",
     "docker:run:deploy:net": "bash support/deploy/run.sh docker",
     "docker:run:deploy:rinkeby": "npm run docker:run:deploy:net -- rinkeby",


### PR DESCRIPTION
This PR solves #609 - running security analysis of Augur contracts on CI against MAIAN tool.

MAIAN tool evaluates each Augur contract against three possible vulnerability types: greedy, prodigal and suicidal.

Full details on the approach are available in the "Finding The Greedy, Prodigal, and Suicidal Contracts at Scale" paper: https://arxiv.org/pdf/1802.06038.pdf

augur-maian-ci Docker image is based on GitHub repo https://github.com/cryptomental/maian-augur-ci and pushed to Docker Hub using automated build: https://hub.docker.com/r/cryptomental/maian-augur-ci/builds/ . The image contains all MAIAN dependencies, the test runnner and Solidity compiler 0.4.20 used for Augur 1.0.0 release.

Augur contracts are compiled with augurproject/augur-code image using Augur compiler libraries and contracts bytecode is extracted by the test runner to bin files for further evaulation. Then the test runner executes MAIAN tool three times for each Augur contract and provides a summary after test run finishes.

Refs: #609