### PR TITLE
rep migration script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,11 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.7.tgz",
             "integrity": "sha512-MuUfEDBrQ/hb7KOqMiDeItAuRxlilQUgNRthTSCU4HgilH8UBh7wiHxWrv/lcyHyFZcREaODVVRNrAunphVwlg=="
         },
+        "@types/yargs": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-11.0.0.tgz",
+            "integrity": "sha512-vFql3tOxs6clgh+WVoLW3nOkNGCdeKsMU6mQZkOerJpV/CR9Xc1c1lZ+kYU+hNSobrQIOcNovWfPFDJIhcG5Pw=="
+        },
         "abbrev": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -6715,6 +6720,21 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
+        "types-bn": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/types-bn/-/types-bn-0.0.1.tgz",
+            "integrity": "sha512-Kqx+ic862yy/dqXex5M6ZFEf3w1Hwx2yynygY7zhnWw3n58jImSwUlN0JoaWyuCFWfbf12X+7/qiURXYSKv6GA==",
+            "requires": {
+                "bn.js": "4.11.7"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.7",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+                    "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA=="
+                }
+            }
+        },
         "typescript": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
@@ -6937,6 +6957,55 @@
                 "watchpack": "1.4.0",
                 "webpack-sources": "1.1.0",
                 "yargs": "8.0.2"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        }
+                    }
+                },
+                "yargs": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
+                }
             }
         },
         "webpack-addons": {
@@ -7267,50 +7336,58 @@
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-            "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+            "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
             "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
+                "cliui": "4.1.0",
                 "decamelize": "1.2.0",
+                "find-up": "2.1.0",
                 "get-caller-file": "1.0.2",
                 "os-locale": "2.1.0",
-                "read-pkg-up": "2.0.0",
                 "require-directory": "2.1.1",
                 "require-main-filename": "1.0.1",
                 "set-blocking": "2.0.0",
                 "string-width": "2.1.1",
                 "which-module": "2.0.0",
                 "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
+                "yargs-parser": "9.0.2"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                 },
                 "cliui": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
                         "wrap-ansi": "2.1.0"
-                    },
-                    "dependencies": {
-                        "string-width": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                            "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
-                            }
-                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+                    "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+                    "requires": {
+                        "camelcase": "4.1.0"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/mkdirp": "0.5.1",
     "@types/mocha": "2.2.43",
     "@types/node": "9.6.7",
+    "@types/yargs": "11.0.0",
     "async-file": "2.0.2",
     "async-mkdirp": "1.2.0",
     "binascii": "0.0.1",
@@ -92,7 +93,8 @@
     "solidity-coverage": "0.4.15",
     "copy-dir": "0.3.0",
     "rimraf": "2.6.2",
-    "replace": "0.3.0"
+    "replace": "0.3.0",
+    "yargs": "11.0.0"
   },
   "devDependencies": {
     "solc": "0.4.20",

--- a/source/contracts/LegacyReputationToken.sol
+++ b/source/contracts/LegacyReputationToken.sol
@@ -1,12 +1,15 @@
 pragma solidity 0.4.20;
 
 import 'libraries/ContractExists.sol';
+import 'libraries/Ownable.sol';
 import 'libraries/token/VariableSupplyToken.sol';
 
 
-contract LegacyReputationToken is VariableSupplyToken {
+contract LegacyReputationToken is VariableSupplyToken, Ownable {
     using ContractExists for address;
     event FundedAccount(address indexed _universe, address indexed _sender, uint256 _repBalance, uint256 _timestamp);
+    event Pause();
+    event Unpause();
 
     uint256 private constant DEFAULT_FAUCET_AMOUNT = 47 ether;
     address private constant FOUNDATION_REP_ADDRESS = address(0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6);
@@ -14,6 +17,24 @@ contract LegacyReputationToken is VariableSupplyToken {
     string public constant name = "Reputation";
     string public constant symbol = "REP";
     uint256 public constant decimals = 18;
+
+    bool public paused = false;
+
+    /**
+     * @dev modifier to allow actions only when the contract IS paused
+     */
+    modifier whenNotPaused() {
+        require(!paused);
+        _;
+    }
+
+    /**
+     * @dev modifier to allow actions only when the contract IS NOT paused
+     */
+    modifier whenPaused {
+        require(paused);
+        _;
+    }
 
     function LegacyReputationToken() public {
         // This is to confirm we are not on foundation network
@@ -39,6 +60,28 @@ contract LegacyReputationToken is VariableSupplyToken {
     }
 
     function onTokenTransfer(address, address, uint256) internal returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev called by the owner to pause, triggers stopped state
+     */
+    function pause() public onlyOwner whenNotPaused returns (bool) {
+        paused = true;
+        Pause();
+        return true;
+    }
+
+    /**
+     * @dev called by the owner to unpause, returns to normal state
+     */
+    function unpause() public onlyOwner whenPaused returns (bool) {
+        paused = false;
+        Unpause();
+        return true;
+    }
+
+    function onTransferOwnership(address, address) internal returns (bool) {
         return true;
     }
 }

--- a/source/libraries/ContractInterfaces.ts
+++ b/source/libraries/ContractInterfaces.ts
@@ -964,6 +964,20 @@
             return <BN>result[0];
         }
 
+        public unpause = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"unpause","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [], "unpause", options.sender, options.gasPrice);
+            return;
+        }
+
+        public unpause_ = async( options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"unpause","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <boolean>result[0];
+        }
+
         public faucet = async(amount: BN, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
             options = options || {};
             const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_amount","type":"uint256"}],"name":"faucet","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
@@ -975,6 +989,13 @@
             options = options || {};
             const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_amount","type":"uint256"}],"name":"faucet","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
             const result = await this.localCall(abi, [amount], options.sender);
+            return <boolean>result[0];
+        }
+
+        public paused_ = async( options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"paused","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
             return <boolean>result[0];
         }
 
@@ -1004,6 +1025,27 @@
             const abi: AbiFunction = {"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"};
             const result = await this.localCall(abi, [owner], options.sender);
             return <BN>result[0];
+        }
+
+        public pause = async( options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"pause","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [], "pause", options.sender, options.gasPrice);
+            return;
+        }
+
+        public pause_ = async( options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[],"name":"pause","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <boolean>result[0];
+        }
+
+        public getOwner_ = async( options?: { sender?: string }): Promise<string> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":true,"inputs":[],"name":"getOwner","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"};
+            const result = await this.localCall(abi, [], options.sender);
+            return <string>result[0];
         }
 
         public symbol_ = async( options?: { sender?: string }): Promise<string> => {
@@ -1046,6 +1088,20 @@
             const abi: AbiFunction = {"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"remaining","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"};
             const result = await this.localCall(abi, [owner, spender], options.sender);
             return <BN>result[0];
+        }
+
+        public transferOwnership = async(newOwner: string, options?: { sender?: string, gasPrice?: BN }): Promise<void> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_newOwner","type":"address"}],"name":"transferOwnership","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            await this.remoteCall(abi, [newOwner], "transferOwnership", options.sender, options.gasPrice);
+            return;
+        }
+
+        public transferOwnership_ = async(newOwner: string, options?: { sender?: string }): Promise<boolean> => {
+            options = options || {};
+            const abi: AbiFunction = {"constant":false,"inputs":[{"name":"_newOwner","type":"address"}],"name":"transferOwnership","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"};
+            const result = await this.localCall(abi, [newOwner], options.sender);
+            return <boolean>result[0];
         }
     }
 

--- a/source/libraries/DeployerConfiguration.ts
+++ b/source/libraries/DeployerConfiguration.ts
@@ -31,6 +31,7 @@ export class DeployerConfiguration {
         const controllerAddress = process.env.AUGUR_CONTROLLER_ADDRESS;
         const createGenesisUniverse = (typeof process.env.CREATE_GENESIS_UNIVERSE === 'undefined') ? true : process.env.CREATE_GENESIS_UNIVERSE === 'true';
         const useNormalTime = (typeof process.env.USE_NORMAL_TIME === 'string') ? process.env.USE_NORMAL_TIME === 'true' : true;
+        isProduction = (typeof process.env.IS_PRODUCTION === 'string') ? process.env.IS_PRODUCTION === 'true' : isProduction;
 
         return new DeployerConfiguration(contractInputRoot, artifactOutputRoot, controllerAddress, createGenesisUniverse, isProduction, useNormalTime, legacyRepAddress);
     }
@@ -40,6 +41,7 @@ export class DeployerConfiguration {
         const controllerAddress = process.env.AUGUR_CONTROLLER_ADDRESS;
         const createGenesisUniverse = (typeof process.env.CREATE_GENESIS_UNIVERSE === 'undefined') ? true : process.env.CREATE_GENESIS_UNIVERSE === 'true';
         const useNormalTime = false;
+        isProduction = (typeof process.env.IS_PRODUCTION === 'string') ? process.env.IS_PRODUCTION === 'true' : isProduction;
 
         return new DeployerConfiguration(contractInputRoot, artifactOutputRoot, controllerAddress, createGenesisUniverse, isProduction, useNormalTime, legacyRepAddress);
     }

--- a/source/libraries/DeployerConfiguration.ts
+++ b/source/libraries/DeployerConfiguration.ts
@@ -1,6 +1,9 @@
 import * as path from 'path';
 
 const ARTIFACT_OUTPUT_ROOT  = (typeof process.env.ARTIFACT_OUTPUT_ROOT === 'undefined') ? path.join(__dirname, '../../output/contracts') : path.normalize(<string> process.env.ARTIFACT_OUTPUT_ROOT);
+
+const PRODUCTION_LEGACY_REP_CONTRACT_ADDRESS = "0xe94327d07fc17907b4db788e5adf2ed424addff6";
+
 export class DeployerConfiguration {
     public readonly contractInputPath: string;
     public readonly contractAddressesOutputPath: string;
@@ -9,33 +12,35 @@ export class DeployerConfiguration {
     public readonly createGenesisUniverse: boolean;
     public readonly useNormalTime: boolean;
     public readonly isProduction: boolean;
+    public readonly legacyRepAddress: string;
 
-    public constructor(contractInputRoot: string, artifactOutputRoot: string, controllerAddress: string|undefined, createGenesisUniverse: boolean=true, isProduction: boolean=false, useNormalTime: boolean=true) {
+    public constructor(contractInputRoot: string, artifactOutputRoot: string, controllerAddress: string|undefined, createGenesisUniverse: boolean=true, isProduction: boolean=false, useNormalTime: boolean=true, legacyRepAddress: string=PRODUCTION_LEGACY_REP_CONTRACT_ADDRESS) {
         this.isProduction = isProduction;
         this.controllerAddress = controllerAddress;
         this.createGenesisUniverse = createGenesisUniverse;
         this.useNormalTime = isProduction || useNormalTime;
+        this.legacyRepAddress = legacyRepAddress;
 
         this.contractAddressesOutputPath = path.join(artifactOutputRoot, 'addresses.json');
         this.uploadBlockNumbersOutputPath = path.join(artifactOutputRoot, 'upload-block-numbers.json');
         this.contractInputPath = path.join(contractInputRoot, 'contracts.json');
     }
 
-    public static create(artifactOutputRoot: string=ARTIFACT_OUTPUT_ROOT, isProduction: boolean=false): DeployerConfiguration {
+    public static create(artifactOutputRoot: string=ARTIFACT_OUTPUT_ROOT, isProduction: boolean=false, legacyRepAddress: string=PRODUCTION_LEGACY_REP_CONTRACT_ADDRESS): DeployerConfiguration {
         const contractInputRoot = (typeof process.env.CONTRACT_INPUT_ROOT === 'undefined') ? path.join(__dirname, '../../output/contracts') : path.normalize(<string> process.env.CONTRACT_INPUT_ROOT);
         const controllerAddress = process.env.AUGUR_CONTROLLER_ADDRESS;
         const createGenesisUniverse = (typeof process.env.CREATE_GENESIS_UNIVERSE === 'undefined') ? true : process.env.CREATE_GENESIS_UNIVERSE === 'true';
         const useNormalTime = (typeof process.env.USE_NORMAL_TIME === 'string') ? process.env.USE_NORMAL_TIME === 'true' : true;
 
-        return new DeployerConfiguration(contractInputRoot, artifactOutputRoot, controllerAddress, createGenesisUniverse, isProduction, useNormalTime);
+        return new DeployerConfiguration(contractInputRoot, artifactOutputRoot, controllerAddress, createGenesisUniverse, isProduction, useNormalTime, legacyRepAddress);
     }
 
-    public static createWithControlledTime(artifactOutputRoot: string=ARTIFACT_OUTPUT_ROOT, isProduction: boolean=false): DeployerConfiguration {
+    public static createWithControlledTime(legacyRepAddress: string=PRODUCTION_LEGACY_REP_CONTRACT_ADDRESS, isProduction: boolean=false, artifactOutputRoot: string=ARTIFACT_OUTPUT_ROOT): DeployerConfiguration {
         const contractInputRoot = (typeof process.env.CONTRACT_INPUT_ROOT === 'undefined') ? path.join(__dirname, '../../output/contracts') : path.normalize(<string> process.env.CONTRACT_INPUT_ROOT);
         const controllerAddress = process.env.AUGUR_CONTROLLER_ADDRESS;
         const createGenesisUniverse = (typeof process.env.CREATE_GENESIS_UNIVERSE === 'undefined') ? true : process.env.CREATE_GENESIS_UNIVERSE === 'true';
         const useNormalTime = false;
 
-        return new DeployerConfiguration(contractInputRoot, artifactOutputRoot, controllerAddress, createGenesisUniverse, isProduction, useNormalTime);
+        return new DeployerConfiguration(contractInputRoot, artifactOutputRoot, controllerAddress, createGenesisUniverse, isProduction, useNormalTime, legacyRepAddress);
     }
 }

--- a/source/libraries/LegacyRepMigrator.ts
+++ b/source/libraries/LegacyRepMigrator.ts
@@ -1,0 +1,202 @@
+import { Connector } from '../libraries/Connector';
+import { AccountManager } from '../libraries/AccountManager';
+import { NetworkConfiguration } from '../libraries/NetworkConfiguration';
+import { LegacyReputationToken, ReputationToken } from '../libraries/ContractInterfaces';
+import { resolveAll } from "../libraries/HelperFunctions";
+
+export interface LegacyRepData {
+    balances: Array<string>;
+    allowanceOwners: Array<string>;
+    allowanceSpenders: Array<string>;
+}
+
+export class LegacyRepMigrator {
+    private readonly repContract: ReputationToken;
+    private readonly legacyRepContract: LegacyReputationToken;
+    private legacyRepData: LegacyRepData;
+    private unmigratedLegacyRepData: LegacyRepData;
+    private chunkedBalances: Array<Array<string>>;
+    private chunkedAllowanceOwners: Array<Array<string>>;
+    private chunkedAllowanceSpenders: Array<Array<string>>;
+    private readonly chunkSize: number;
+
+    private constructor(repContract: ReputationToken, legacyRepContract: LegacyReputationToken, legacyRepData: LegacyRepData, chunkSize: number) {
+        this.repContract = repContract;
+        this.legacyRepContract = legacyRepContract;
+        this.chunkSize = chunkSize;
+        this.legacyRepData = legacyRepData;
+        this.unmigratedLegacyRepData = {
+            balances: [],
+            allowanceOwners: [],
+            allowanceSpenders: []
+        };
+        this.chunkedBalances = [];
+        this.chunkedAllowanceOwners = [];
+        this.chunkedAllowanceSpenders = [];
+    }
+
+    private async initialize(): Promise<void> {
+        await this.getUnMigratedLegacyData(this.legacyRepData);
+        this.chunkedBalances = this.chunk(this.unmigratedLegacyRepData.balances);
+        this.chunkedAllowanceOwners = this.chunk(this.unmigratedLegacyRepData.allowanceOwners);
+        this.chunkedAllowanceSpenders = this.chunk(this.unmigratedLegacyRepData.allowanceSpenders);
+    }
+
+    public static create = async (legacyRepData: LegacyRepData, repContractAddress: string, txSize: number): Promise<LegacyRepMigrator> => {
+        const networkConfiguration = NetworkConfiguration.create();
+        const connector = new Connector(networkConfiguration);
+        console.log(`Waiting for connection to: ${networkConfiguration.networkName} at ${networkConfiguration.http}`);
+        await connector.waitUntilConnected();
+        const accountManager = new AccountManager(connector, networkConfiguration.privateKey);
+
+        console.log(`Using REP Contract at: ${repContractAddress}`);
+        const repContract = new ReputationToken(connector, accountManager, repContractAddress, connector.gasPrice);
+
+        const legacyRepContractAddress = await repContract.getLegacyRepToken_();
+        const legacyRepContract = new LegacyReputationToken(connector, accountManager, legacyRepContractAddress, connector.gasPrice);
+
+        const isPaused = await legacyRepContract.paused_();
+        if (!isPaused) {
+            throw new Error("Legacy REP contract must be paused! You should pause it an re-collect balances and allowances");
+        }
+
+        const legacyRepMigrator = new LegacyRepMigrator(repContract, legacyRepContract, legacyRepData, txSize);
+        await legacyRepMigrator.initialize();
+
+        return legacyRepMigrator;
+    }
+
+    public async migrateLegacyRep(): Promise<void> {
+
+        console.log("Migrating Approvals");
+        await this.migrateApprovals();
+        console.log("Verifying Approvals");
+        await this.verifyApprovals();
+        console.log("Migrating Approvals Complete");
+
+        console.log("Migrating Balances");
+        await this.migrateBalances();
+        console.log("Verifying Balances");
+        await this.verifyBalances();
+        console.log("Migrating Balances Complete");
+
+        return;
+    }
+
+    private async migrateApprovals(): Promise<void> {
+        const promises: Array<Promise<any>> = [];
+        for (let i = 0; i < this.chunkedAllowanceOwners.length; i++) {
+            promises.push(this.migrateAllowances(this.chunkedAllowanceOwners[i], this.chunkedAllowanceSpenders[i]));
+        }
+        await resolveAll(promises);
+        return;
+    }
+
+    private async migrateAllowances(owners: Array<string>, spenders: Array<string>): Promise<void> {
+        await this.repContract.migrateAllowancesFromLegacyRep(owners, spenders);
+        return;
+    }
+
+    private async migrateBalances(): Promise<void> {
+        const promises: Array<Promise<any>> = [];
+        for (let balancesChunk of this.chunkedBalances) {
+            promises.push(this.migrateOwners(balancesChunk));
+        }
+        await resolveAll(promises);
+        return;
+    }
+
+    private async migrateOwners(owners: Array<string>): Promise<void> {
+        await this.repContract.migrateBalancesFromLegacyRep(owners);
+        const supply = await this.repContract.totalSupply_();
+        console.log(`Total Rep Supply: ${supply}`);
+        return;
+    }
+
+    private async verifyApprovals(): Promise<void> {
+        const promises: Array<Promise<any>> = [];
+
+        for (let i = 0; i < this.legacyRepData.allowanceOwners.length; i++) {
+            promises.push(this.verifyApproval(
+                this.legacyRepData.allowanceOwners[i],
+                this.legacyRepData.allowanceSpenders[i],
+            ));
+        }
+
+        await resolveAll(promises);
+        return;
+    }
+
+    private async verifyApproval(owner: string, spender: string): Promise<void> {
+        const legacyAllowance = await this.legacyRepContract.allowance_(owner, spender);
+        const allowance = await this.repContract.allowance_(owner, spender);
+        if (!allowance.eq(legacyAllowance)) {
+            throw new Error(`Allowance mismatch: OWNER: ${owner} SPENDER: ${spender} LEGACY: ${legacyAllowance} CURRENT: ${allowance}`);
+        }
+        return;
+    }
+
+    private async verifyBalances(): Promise<void> {
+        const promises: Array<Promise<any>> = [];
+
+        for (let owner of this.legacyRepData.balances) {
+            promises.push(this.verifyBalance(owner));
+        }
+
+        await resolveAll(promises);
+        return;
+    }
+
+    private async verifyBalance(owner: string): Promise<void> {
+        const legacyBalance = await this.legacyRepContract.balanceOf_(owner);
+        const balance = await this.repContract.balanceOf_(owner);
+        if (!balance.eq(legacyBalance)) {
+            throw new Error(`Allowance mismatch: OWNER: ${owner} LEGACY: ${legacyBalance} CURRENT: ${balance}`);
+        }
+        return;
+    }
+
+    private chunk(items: Array<string>): Array<Array<string>> {
+        const numChunks = Math.ceil(items.length / this.chunkSize);
+        const chunked = new Array(numChunks);
+        for (let i = 1; i <= numChunks; ++i) {
+            chunked[i - 1] = items.slice((i - 1) * this.chunkSize, i * this.chunkSize);
+        }
+        return chunked;
+    }
+
+    private async getUnMigratedLegacyData(legacyRepData: LegacyRepData): Promise<void> {
+        const promises: Array<Promise<any>> = [];
+
+        for (let i = 0; i < legacyRepData.allowanceOwners.length; i++) {
+            promises.push(this.addToAllowancesIfUnmigrated(
+                legacyRepData.allowanceOwners[i],
+                legacyRepData.allowanceSpenders[i],
+            ));
+        }
+
+        for (let owner of legacyRepData.balances) {
+            promises.push(this.addToBalancesIfUnmigrated(owner));
+        }
+
+        await resolveAll(promises);
+        return;
+    }
+
+    private async addToBalancesIfUnmigrated(address: string): Promise<void> {
+        const balance = await this.repContract.balanceOf_(address);
+        if (balance.isZero()) {
+            this.unmigratedLegacyRepData.balances.push(address);
+        }
+        return;
+    }
+
+    private async addToAllowancesIfUnmigrated(owner: string, spender: string): Promise<void> {
+        const allowance = await this.repContract.allowance_(owner, spender);
+        if (allowance.isZero()) {
+            this.unmigratedLegacyRepData.allowanceOwners.push(owner);
+            this.unmigratedLegacyRepData.allowanceSpenders.push(spender);
+        }
+        return;
+    }
+}

--- a/source/tests-integration/RepMigration.ts
+++ b/source/tests-integration/RepMigration.ts
@@ -1,5 +1,3 @@
-// Create market, make a trade on it, designated reporter reports, market is finalized, traders settle shares, reporters redeem tokens.
-
 import BN = require('bn.js');
 import { expect } from "chai";
 import { TestFixture } from './TestFixture';
@@ -27,7 +25,7 @@ describe("RepMigration", () => {
         };
 
         // Before we run the migration which will freeze legacy REP lets create some balances and approvals
-        for (var i = 0; i < 5; i++) {
+        for (let i = 0; i < 5; i++) {
             const amount = new BN(i + 1);
             const address = `0x000000000000000000000000000000000000000${i}`;
 
@@ -54,7 +52,7 @@ describe("RepMigration", () => {
         repLocked = await fixture.isRepMigratingFromLegacy();
         expect(repLocked).to.be.false;
 
-        for (var i = 0; i < 5; i++) {
+        for (let i = 0; i < 5; i++) {
             const amount = new BN(i + 1);
             const address = `0x000000000000000000000000000000000000000${i}`;
 

--- a/source/tests-integration/RepMigration.ts
+++ b/source/tests-integration/RepMigration.ts
@@ -1,0 +1,68 @@
+// Create market, make a trade on it, designated reporter reports, market is finalized, traders settle shares, reporters redeem tokens.
+
+import BN = require('bn.js');
+import { expect } from "chai";
+import { TestFixture } from './TestFixture';
+import { LegacyRepMigrator, LegacyRepData } from '../libraries/LegacyRepMigrator';
+
+describe("RepMigration", () => {
+    let fixture: TestFixture;
+    before(async () => {
+        fixture = await TestFixture.create(true);
+    });
+    it("#repMigration", async () => {
+        // The legacy rep contract must be paused prior to migration since we have to have the list of token owners and allowances ready and frozen
+        await fixture.pauseLegacyRep();
+        let legacyRepLocked = await fixture.isLegacyRepPaused();
+        expect(legacyRepLocked).to.be.true;
+
+        // The "real" REP contract is locked until migration occurs
+        let repLocked = await fixture.isRepMigratingFromLegacy();
+        expect(repLocked).to.be.true;
+
+        const legacyRepData: LegacyRepData = {
+            balances: [fixture.accountManager.defaultAddress],
+            allowanceOwners: [],
+            allowanceSpenders: [],
+        };
+
+        // Before we run the migration which will freeze legacy REP lets create some balances and approvals
+        for (var i = 0; i < 5; i++) {
+            const amount = new BN(i + 1);
+            const address = `0x000000000000000000000000000000000000000${i}`;
+
+            await fixture.transferLegacyRep(address, amount);
+            await fixture.approveLegacyRep(address, amount);
+
+            const balance = await fixture.getLegacyRepBalance(address);
+            const allowance = await fixture.getLegacyRepAllowance(fixture.accountManager.defaultAddress, address);
+
+            expect(balance.toNumber()).to.eq(amount.toNumber());
+            expect(allowance.toNumber()).to.eq(amount.toNumber());
+
+            legacyRepData.balances.push(address);
+            legacyRepData.allowanceOwners.push(fixture.accountManager.defaultAddress);
+            legacyRepData.allowanceSpenders.push(address);
+        }
+
+        // Now we can run the LegacyRepMigrator which will freeze the legacy REP contract and migrate allowances and balances to the new one, making it unlock. When running the script normally we'll be reading from a file and passing a large data structure but here we'll just pass in the data corresponding to the balances and allowances we created.
+        const reputationTokenAddress = await fixture.universe.getReputationToken_();
+        const txSize = 2;
+        const legacyRepMigrator = await LegacyRepMigrator.create(legacyRepData, reputationTokenAddress, txSize);
+        await legacyRepMigrator.migrateLegacyRep();
+
+        repLocked = await fixture.isRepMigratingFromLegacy();
+        expect(repLocked).to.be.false;
+
+        for (var i = 0; i < 5; i++) {
+            const amount = new BN(i + 1);
+            const address = `0x000000000000000000000000000000000000000${i}`;
+
+            const balance = await fixture.getRepBalance(address);
+            const allowance = await fixture.getRepAllowance(fixture.accountManager.defaultAddress, address);
+
+            expect(balance.toNumber()).to.eq(amount.toNumber());
+            expect(allowance.toNumber()).to.eq(amount.toNumber());
+        }
+    });
+});

--- a/source/tools/migrateRep.ts
+++ b/source/tools/migrateRep.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+require('source-map-support').install();
+import * as fs from "async-file";
+import { LegacyRepMigrator } from '../libraries/LegacyRepMigrator';
+import * as yargs from 'yargs';
+
+let argv =  yargs
+    .option('repAddress', {
+        describe: "Address of the new REP contract to migrates to",
+    })
+    .option('balances', {
+        describe: "File containing newline delimited addresses that have REP balances",
+    })
+    .option('allowanceOwners', {
+        describe: "File containing newline delimited addresses for the allowance owners",
+    })
+    .option('allowanceSpenders', {
+        describe: "File containing newline delimited addresses that the allowance spenders",
+    })
+    .option('chunkSize', {
+        describe: "Number of addresses to use per TX",
+        default: 25,
+    })
+.help()
+.demandOption(['repAddress', 'balances', 'allowanceOwners', 'allowanceSpenders'], 'Please provide required arguments')
+.argv;
+
+async function doWork(): Promise<void> {
+    const balancesFileContents = await fs.readFile(argv.balances);
+    const allowanceOwnersFileContents = await fs.readFile(argv.allowanceOwners);
+    const allowanceSpendersFileContents = await fs.readFile(argv.allowanceSpenders);
+
+    const balances = balancesFileContents.split('\n');
+    const allowanceOwners = allowanceOwnersFileContents.split('\n');
+    const allowanceSpenders = allowanceSpendersFileContents.split('\n');
+
+    const legacyRepData = {
+        balances,
+        allowanceOwners,
+        allowanceSpenders,
+    }
+
+    const repContractAddress = argv.repAddress;
+    const chunkSize = argv.chunkSize;
+
+    const legacyRepMigrator: LegacyRepMigrator = await LegacyRepMigrator.create(legacyRepData, repContractAddress, chunkSize);
+    await legacyRepMigrator.migrateLegacyRep();
+}
+
+doWork().then(() => {
+    process.exit();
+}).catch(error => {
+    console.log(error);
+    process.exit(1);
+});

--- a/typings/bn.js/index.d.ts
+++ b/typings/bn.js/index.d.ts
@@ -8,6 +8,8 @@ declare module 'bn.js' {
         mul(other: BN): BN;
         div(other: BN): BN;
         pow(other: BN): BN;
+        eq(other:BN): boolean;
+        isZero(): boolean;
 
         static min(... args: Array<number|string|BN>): BN;
         static max(... args: Array<number|string|BN>): BN;


### PR DESCRIPTION
Handles the REP approvals/balances migration assuming files containing the list of token holders and approval pairs are provided.

Still need to add a script to the rep migration repo to handle generating the allowances files but that should be real easy.

I also had to modify a test contract since it wasn't actually an accurate representation of the existing legacy rep contract.