### PR TITLE
initial reporter logging for forked redemption. Prevent public fork call

### DIFF
--- a/source/contracts/reporting/BaseReportingParticipant.sol
+++ b/source/contracts/reporting/BaseReportingParticipant.sol
@@ -33,7 +33,7 @@ contract BaseReportingParticipant is Controlled, IReportingParticipant {
         return true;
     }
 
-    function fork() public onlyInGoodTimes returns (bool) {
+    function fork() internal onlyInGoodTimes returns (bool) {
         require(market == market.getUniverse().getForkingMarket());
         IUniverse _newUniverse = market.getUniverse().createChildUniverse(payoutNumerators, invalid);
         IReputationToken _newReputationToken = _newUniverse.getReputationToken();

--- a/source/contracts/reporting/IReportingParticipant.sol
+++ b/source/contracts/reporting/IReportingParticipant.sol
@@ -8,7 +8,6 @@ contract IReportingParticipant {
     function getStake() public view returns (uint256);
     function getPayoutDistributionHash() public view returns (bytes32);
     function liquidateLosing() public returns (bool);
-    function fork() public returns (bool);
     function redeem(address _redeemer) public returns (bool);
     function isInvalid() public view returns (bool);
     function isDisavowed() public view returns (bool);

--- a/source/contracts/reporting/InitialReporter.sol
+++ b/source/contracts/reporting/InitialReporter.sol
@@ -86,6 +86,9 @@ contract InitialReporter is DelegationTarget, Ownable, BaseReportingParticipant,
     }
 
     function forkAndRedeem() public onlyInGoodTimes returns (bool) {
+        if (!isDisavowed()) {
+            controller.getAugur().logInitialReporterRedeemed(market.getUniverse(), owner, market, size, reputationToken.balanceOf(this), cash.balanceOf(this), payoutNumerators);
+        }
         fork();
         redeem(msg.sender);
         return true;

--- a/tests/reporting/test_reporting.py
+++ b/tests/reporting/test_reporting.py
@@ -219,7 +219,7 @@ def test_forking(finalizeByMigration, manuallyDisavow, localFixture, universe, c
 
     # confirm we cannot fork it
     with raises(TransactionFailed):
-        categoricalDisputeCrowdsourcer.fork()
+        categoricalDisputeCrowdsourcer.forkAndRedeem()
 
     if manuallyDisavow:
         marketParticipantsDisavowedLog = {

--- a/tests/reporting_utils.py
+++ b/tests/reporting_utils.py
@@ -60,7 +60,7 @@ def proceedToFork(fixture, market, universe):
 
     for i in range(market.getNumParticipants()):
         reportingParticipant = fixture.applySignature("DisputeCrowdsourcer", market.getReportingParticipant(i))
-        reportingParticipant.fork()
+        reportingParticipant.forkAndRedeem()
 
 def finalizeFork(fixture, market, universe, finalizeByMigration = True):
     reputationToken = fixture.applySignature('ReputationToken', universe.getReputationToken())

--- a/tests/solidity_test_helpers/MockDisputeCrowdsourcer.sol
+++ b/tests/solidity_test_helpers/MockDisputeCrowdsourcer.sol
@@ -54,7 +54,7 @@ contract MockDisputeCrowdsourcer is IDisputeCrowdsourcer, MockVariableSupplyToke
         return true;
     }
 
-    function fork() public returns (bool) {
+    function fork() internal returns (bool) {
         return true;
     }
 

--- a/tests/solidity_test_helpers/MockInitialReporter.sol
+++ b/tests/solidity_test_helpers/MockInitialReporter.sol
@@ -70,7 +70,7 @@ contract MockInitialReporter is IInitialReporter {
         return true;
     }
 
-    function fork() public returns (bool) {
+    function fork() internal returns (bool) {
         return true;
     }
 

--- a/tests/solidity_test_helpers/TestTrade.sol
+++ b/tests/solidity_test_helpers/TestTrade.sol
@@ -4,7 +4,10 @@ import 'trading/Trade.sol';
 
 
 contract TestTrade is Trade {
-    function getMinGasNeeded() internal pure returns (uint256) {
+    function getFillOrderMinGasNeeded() internal pure returns (uint256) {
+        return 5000000;
+    }
+    function getCreateOrderMinGasNeeded() internal pure returns (uint256) {
         return 5000000;
     }
 }

--- a/tests/trading/test_trade.py
+++ b/tests/trading/test_trade.py
@@ -15,7 +15,7 @@ def test_minimum_gas_failure(contractsFixture, cash, market, universe):
     # create order
     orderID = createOrder.publicCreateOrder(BID, fix(4), 6000, market.address, YES, longTo32Bytes(0), longTo32Bytes(0), tradeGroupID, sender = tester.k1, value=fix('4', '6000'))
 
-    # We need to provide a minimum gas amount or we'll get back a failure. In testing we use a much higher minimum since in some cases we alter the contracts in a way that massively increases gas cost. In production this value is 500000
+    # We need to provide a minimum gas amount or we'll get back a failure. In testing we use a much higher minimum since in some cases we alter the contracts in a way that massively increases gas cost. In production this value is 2000000
     minGas = 5000000
     fillOrderID = trade.publicSell(market.address, YES, fix(5), 6000, "0", "0", tradeGroupID, sender = tester.k2, value=fix('5', '4000'), startgas=minGas-1)
 


### PR DESCRIPTION
the test removal is one that tests forking then redeeming. Directly below we have the equivalent test for forkAndRedeem which is all we allow now