### PR TITLE
Dont adjust OI on Set actions

### DIFF
--- a/source/contracts/trading/CompleteSets.sol
+++ b/source/contracts/trading/CompleteSets.sol
@@ -40,7 +40,9 @@ contract CompleteSets is Controlled, CashAutoConverter, ReentrancyGuard, MarketV
             _market.getShareToken(_outcome).createShares(_sender, _amount);
         }
 
-        _market.getUniverse().incrementOpenInterest(_cost);
+        if (!_market.isFinalized()) {
+            _market.getUniverse().incrementOpenInterest(_cost);
+        }
 
         return true;
     }
@@ -58,7 +60,9 @@ contract CompleteSets is Controlled, CashAutoConverter, ReentrancyGuard, MarketV
         uint256 _numOutcomes = _market.getNumberOfOutcomes();
         ICash _denominationToken = _market.getDenominationToken();
         uint256 _payout = _amount.mul(_market.getNumTicks());
-        _market.getUniverse().decrementOpenInterest(_payout);
+        if (!_market.isFinalized()) {
+            _market.getUniverse().decrementOpenInterest(_payout);
+        }
         _creatorFee = _market.deriveMarketCreatorFeeAmount(_payout);
         uint256 _reportingFeeDivisor = _market.getUniverse().getOrCacheReportingFeeDivisor();
         _reportingFee = _payout.div(_reportingFeeDivisor);


### PR DESCRIPTION
We recently changed to a new OI scheme of immediately reducing Universe OI by all of a market's outstanding complete sets at finalization.

This is needed to prevent leakage from the failure to sell outstanding shares and leakage from invalid payouts since the claimed amount for a set will be less than what was paid (even before fees)

In doing this however I forgot to restrict further OI modification for that market, which is needed since otherwise someone could buy sets then claim proceeds which would make Universe OI increase but never decrease from that action.
