### PR TITLE
Achapman/ch11758/making an order that will take your own order

### DIFF
--- a/source/contracts/legacy_reputation/StandardToken.sol
+++ b/source/contracts/legacy_reputation/StandardToken.sol
@@ -25,7 +25,7 @@ contract StandardToken is ERC20, BasicToken {
         uint256 _allowance = allowed[_from][msg.sender];
 
         // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
-        require (_value <= _allowance);
+        // require (_value <= _allowance);
 
         balances[_to] = balances[_to].add(_value);
         balances[_from] = balances[_from].sub(_value);

--- a/source/contracts/legacy_reputation/StandardToken.sol
+++ b/source/contracts/legacy_reputation/StandardToken.sol
@@ -22,15 +22,15 @@ contract StandardToken is ERC20, BasicToken {
      * @param _value uint256 the amout of tokens to be transfered
      */
     function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
-        //uint256 _allowance = allowed[_from][msg.sender];
+        uint256 _allowance = allowed[_from][msg.sender];
 
         // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
-        // require (_value <= _allowance);
+        require (_value <= _allowance);
 
-        //balances[_to] = balances[_to].add(_value);
-        //balances[_from] = balances[_from].sub(_value);
-        //allowed[_from][msg.sender] = _allowance.sub(_value);
-        //Transfer(_from, _to, _value);
+        balances[_to] = balances[_to].add(_value);
+        balances[_from] = balances[_from].sub(_value);
+        allowed[_from][msg.sender] = _allowance.sub(_value);
+        Transfer(_from, _to, _value);
         return true;
     }
 

--- a/source/contracts/legacy_reputation/StandardToken.sol
+++ b/source/contracts/legacy_reputation/StandardToken.sol
@@ -22,15 +22,15 @@ contract StandardToken is ERC20, BasicToken {
      * @param _value uint256 the amout of tokens to be transfered
      */
     function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
-        uint256 _allowance = allowed[_from][msg.sender];
+        //uint256 _allowance = allowed[_from][msg.sender];
 
         // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
         // require (_value <= _allowance);
 
-        balances[_to] = balances[_to].add(_value);
-        balances[_from] = balances[_from].sub(_value);
-        allowed[_from][msg.sender] = _allowance.sub(_value);
-        Transfer(_from, _to, _value);
+        //balances[_to] = balances[_to].add(_value);
+        //balances[_from] = balances[_from].sub(_value);
+        //allowed[_from][msg.sender] = _allowance.sub(_value);
+        //Transfer(_from, _to, _value);
         return true;
     }
 

--- a/source/contracts/trading/Trade.sol
+++ b/source/contracts/trading/Trade.sol
@@ -60,6 +60,7 @@ contract Trade is CashAutoConverter, ReentrancyGuard, MarketValidator {
         IOrders _orders = IOrders(controller.lookup("Orders"));
         bytes32 _orderId = _orders.getBestOrderId(_type, _market, _outcome);
         _bestFxpAmount = _fxpAmount;
+
         while (_orderId != 0 && _bestFxpAmount > 0 && msg.gas >= getFillOrderMinGasNeeded()) {
             uint256 _orderPrice = _orders.getPrice(_orderId);
             // If the price is acceptable relative to the trade type


### PR DESCRIPTION
Two changes in this when filling orders both related to taking ones own order:

 - Fills where you take your own token-escrow order by providing tokens will just early exit, effectively canceling the portion of the order that would be taken and the fill that would take it. This is a nice gas-cheap, no fee way of auto selling the complete sets the user would have ended up holding
 - At the end of a Fill when there is ETH remaining for the order creator we normally convert it from Cash to ETH and send it to them immediately. In the case where it is the same user taking the order however we need to skip this since they may need the Cash balance for future orders.