### PR TITLE
add a more resiliant transfer to order creator when filling orders

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -34,7 +34,7 @@
     "security/no-assign-params": "off",
     "security/no-fixed": "error",
     "security/no-modify-for-iter-var": "error",
-    "security/no-send": "error",
+    "security/no-send": "off",
     "security/no-unreachable-code": "error",
     "security/else-after-elseif": "off",
     "security/enforce-loop-bounds": "error",

--- a/source/contracts/trading/Cash.sol
+++ b/source/contracts/trading/Cash.sol
@@ -47,6 +47,17 @@ contract Cash is DelegationTarget, ITyped, VariableSupplyToken, ICash {
         return true;
     }
 
+    function withdrawEtherToIfPossible(address _to, uint256 _amount) external returns (bool) {
+        require(_amount > 0 && _amount <= balances[msg.sender]);
+        if (_to.send(_amount)) {
+            burn(msg.sender, _amount);
+        } else {
+            internalTransfer(msg.sender, _to, _amount);
+        }
+        assert(this.balance >= totalSupply());
+        return true;
+    }
+
     function getTypeName() public view returns (bytes32) {
         return "Cash";
     }

--- a/source/contracts/trading/FillOrder.sol
+++ b/source/contracts/trading/FillOrder.sol
@@ -368,7 +368,7 @@ contract FillOrder is CashAutoConverter, ReentrancyGuard, IFillOrder {
         uint256 _creatorCashBalance = _tradeData.contracts.denominationToken.balanceOf(_tradeData.creator.participantAddress);
         if (_creatorCashBalance > 0) {
             _tradeData.contracts.augur.trustedTransfer(_tradeData.contracts.denominationToken, _tradeData.creator.participantAddress, this, _creatorCashBalance);
-            _tradeData.contracts.denominationToken.withdrawEtherTo(_tradeData.creator.participantAddress, _creatorCashBalance);
+            _tradeData.contracts.denominationToken.withdrawEtherToIfPossible(_tradeData.creator.participantAddress, _creatorCashBalance);
         }
 
         uint256 _amountRemainingFillerWants = _tradeData.filler.sharesToSell.add(_tradeData.filler.sharesToBuy);

--- a/source/contracts/trading/ICash.sol
+++ b/source/contracts/trading/ICash.sol
@@ -9,4 +9,5 @@ contract ICash is ERC20 {
     function depositEtherFor(address _to) external payable returns(bool);
     function withdrawEther(uint256 _amount) external returns(bool);
     function withdrawEtherTo(address _to, uint256 _amount) external returns(bool);
+    function withdrawEtherToIfPossible(address _to, uint256 _amount) external returns (bool);
 }

--- a/tests/solidity_test_helpers/MaliciousTrader.sol
+++ b/tests/solidity_test_helpers/MaliciousTrader.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.4.20;
+
+import 'trading/ICash.sol';
+import 'trading/Order.sol';
+import 'trading/ICreateOrder.sol';
+
+
+contract MaliciousTrader {
+    bool evil = false;
+
+    function approveAugur(ICash _cash, address _augur) public returns (bool) {
+        _cash.approve(_augur, 2**254);
+        return true;
+    }
+
+    function makeOrder(ICreateOrder _createOrder, Order.Types _type, uint256 _attoshares, uint256 _displayPrice, IMarket _market, uint256 _outcome, bytes32 _betterOrderId, bytes32 _worseOrderId, bytes32 _tradeGroupId) external payable returns (bytes32) {
+        return _createOrder.publicCreateOrder.value(msg.value)(_type, _attoshares, _displayPrice, _market, _outcome, _betterOrderId, _worseOrderId, _tradeGroupId);
+    }
+
+    function setEvil(bool _evil) public returns (bool) {
+        evil = _evil;
+    }
+
+    function () payable {
+        if (evil) {
+            revert();
+        }
+    }
+}

--- a/tests/solidity_test_helpers/MockCash.sol
+++ b/tests/solidity_test_helpers/MockCash.sol
@@ -63,4 +63,8 @@ contract MockCash is ITyped, MockVariableSupplyToken, ICash {
         withdrawEtherToAddressValue = _to;
         withdrawEthertoAmountValue = _amount;
     }
+
+    function withdrawEtherToIfPossible(address _to, uint256 _amount) external returns (bool) {
+        return true;
+    }
 }


### PR DESCRIPTION
We were using a transfer here, which means if the order creator failed to receive their ETH the fill will fail. There is a malicious/failure case where this means the orderbook is effectively broken for a market with such an order creator.

This will instead _attempt_ to send them ETH but if that fails simply transfer Cash to them. There is still a recourse then for them at least, and everyone else gets to get the good UX of no Cash.