### PR TITLE
bond recalculations should look at window before previous window

### DIFF
--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -139,6 +139,10 @@ contract Universe is DelegationTarget, ITyped, Initializable, IUniverse {
         return feeWindows[_windowId];
     }
 
+    function getOrCreatePreviousPreviousFeeWindow() public onlyInGoodTimes returns (IFeeWindow) {
+        return getOrCreateFeeWindowByTimestamp(controller.getTimestamp().sub(getDisputeRoundDurationInSeconds().mul(2)));
+    }
+
     function getOrCreatePreviousFeeWindow() public onlyInGoodTimes returns (IFeeWindow) {
         return getOrCreateFeeWindowByTimestamp(controller.getTimestamp().sub(getDisputeRoundDurationInSeconds()));
     }
@@ -305,7 +309,7 @@ contract Universe is DelegationTarget, ITyped, Initializable, IUniverse {
 
     function getOrCacheValidityBond() public onlyInGoodTimes returns (uint256) {
         IFeeWindow _feeWindow = getOrCreateCurrentFeeWindow();
-        IFeeWindow  _previousFeeWindow = getOrCreatePreviousFeeWindow();
+        IFeeWindow  _previousFeeWindow = getOrCreatePreviousPreviousFeeWindow();
         uint256 _currentValidityBondInAttoeth = validityBondInAttoeth[_feeWindow];
         if (_currentValidityBondInAttoeth != 0) {
             return _currentValidityBondInAttoeth;
@@ -320,7 +324,7 @@ contract Universe is DelegationTarget, ITyped, Initializable, IUniverse {
 
     function getOrCacheDesignatedReportStake() public onlyInGoodTimes returns (uint256) {
         IFeeWindow _feeWindow = getOrCreateCurrentFeeWindow();
-        IFeeWindow _previousFeeWindow = getOrCreatePreviousFeeWindow();
+        IFeeWindow _previousFeeWindow = getOrCreatePreviousPreviousFeeWindow();
         uint256 _currentDesignatedReportStakeInAttoRep = designatedReportStakeInAttoRep[_feeWindow];
         if (_currentDesignatedReportStakeInAttoRep != 0) {
             return _currentDesignatedReportStakeInAttoRep;
@@ -336,7 +340,7 @@ contract Universe is DelegationTarget, ITyped, Initializable, IUniverse {
 
     function getOrCacheDesignatedReportNoShowBond() public onlyInGoodTimes returns (uint256) {
         IFeeWindow _feeWindow = getOrCreateCurrentFeeWindow();
-        IFeeWindow _previousFeeWindow = getOrCreatePreviousFeeWindow();
+        IFeeWindow _previousFeeWindow = getOrCreatePreviousPreviousFeeWindow();
         uint256 _currentDesignatedReportNoShowBondInAttoRep = designatedReportNoShowBondInAttoRep[_feeWindow];
         if (_currentDesignatedReportNoShowBondInAttoRep != 0) {
             return _currentDesignatedReportNoShowBondInAttoRep;

--- a/tests/unit/test_universe.py
+++ b/tests/unit/test_universe.py
@@ -168,6 +168,13 @@ def test_universe_calculate_bonds_stakes(localFixture, chain, populatedUniverse,
     localFixture.contracts["Time"].incrementTimestamp(populatedUniverse.getDisputeRoundDurationInSeconds())
     assert populatedUniverse.getOrCreatePreviousFeeWindow() == currentFeeWindow.address
 
+    currentFeeWindow.setAvgReportingGasPrice(14)
+    targetGasCost = getGasToReport * 14 * 2
+    assert populatedUniverse.getOrCacheTargetReporterGasCosts() == targetGasCost
+
+    localFixture.contracts["Time"].incrementTimestamp(populatedUniverse.getDisputeRoundDurationInSeconds())
+    assert populatedUniverse.getOrCreatePreviousPreviousFeeWindow() == currentFeeWindow.address
+
     numMarket = 6
     currentFeeWindow.setNumMarkets(numMarket)
     currentFeeWindow.setNumIncorrectDesignatedReportMarkets(5)


### PR DESCRIPTION
Described in discord as well but to note here for posterity in GH:

When we recalculate the various market creation bonds we do so by looking at the results of markets assigned to the previous fee window. We cannot know (record really) this data until the markets have been finalized however. This means that if we simply look at the direct previous fee window to get this data there is an opportunity to simply create a market before any of the previous windows markets have finalized, thereby locking in decreased bond sizes regardless of how the markets actually resolved (valid, with DR input, with correct initial report).

To address this problem the change in this PR simply makes the calculations look at the window _before_ the previous fee window. This gives a 7 day window for markets to be finalized before calculating bond changes.