### PR TITLE
Silence solium warnings that popped up

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -20,6 +20,8 @@
     "camelcase": "warning",
     "no-unused-vars": "error",
     "blank-lines": "warning",
+    "max-len": "off",
+    "emit": "off",
     "whitespace": "warning",
     "pragma-on-top": "warning",
     "function-order": "off",


### PR DESCRIPTION
Solium changed their config names for some warnings in the recent patch.