### PR TITLE
contracts: Fix SMT errors for Solidity 0.4.25.

### DIFF
--- a/source/contracts/Augur.sol
+++ b/source/contracts/Augur.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'Controlled.sol';
 import 'IAugur.sol';
@@ -244,14 +244,14 @@ contract Augur is Controlled, IAugur {
     function logFeeWindowTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForFeeWindow(IFeeWindow(msg.sender)));
-        emit TokensTransferred(_universe, msg.sender, _from, _to, _value, TokenType.FeeWindow, 0);
+        emit TokensTransferred(_universe, msg.sender, _from, _to, _value, TokenType.FeeWindow, address(0));
         return true;
     }
 
     function logReputationTokensTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.getReputationToken() == IReputationToken(msg.sender));
-        emit TokensTransferred(_universe, msg.sender, _from, _to, _value, TokenType.ReputationToken, 0);
+        emit TokensTransferred(_universe, msg.sender, _from, _to, _value, TokenType.ReputationToken, address(0));
         return true;
     }
 
@@ -273,14 +273,14 @@ contract Augur is Controlled, IAugur {
     function logReputationTokenBurned(IUniverse _universe, address _target, uint256 _amount) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.getReputationToken() == IReputationToken(msg.sender));
-        emit TokensBurned(_universe, msg.sender, _target, _amount, TokenType.ReputationToken, 0);
+        emit TokensBurned(_universe, msg.sender, _target, _amount, TokenType.ReputationToken, address(0));
         return true;
     }
 
     function logReputationTokenMinted(IUniverse _universe, address _target, uint256 _amount) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.getReputationToken() == IReputationToken(msg.sender));
-        emit TokensMinted(_universe, msg.sender, _target, _amount, TokenType.ReputationToken, 0);
+        emit TokensMinted(_universe, msg.sender, _target, _amount, TokenType.ReputationToken, address(0));
         return true;
     }
 
@@ -303,14 +303,14 @@ contract Augur is Controlled, IAugur {
     function logFeeWindowBurned(IUniverse _universe, address _target, uint256 _amount) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForFeeWindow(IFeeWindow(msg.sender)));
-        emit TokensBurned(_universe, msg.sender, _target, _amount, TokenType.FeeWindow, 0);
+        emit TokensBurned(_universe, msg.sender, _target, _amount, TokenType.FeeWindow, address(0));
         return true;
     }
 
     function logFeeWindowMinted(IUniverse _universe, address _target, uint256 _amount) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForFeeWindow(IFeeWindow(msg.sender)));
-        emit TokensMinted(_universe, msg.sender, _target, _amount, TokenType.FeeWindow, 0);
+        emit TokensMinted(_universe, msg.sender, _target, _amount, TokenType.FeeWindow, address(0));
         return true;
     }
 
@@ -337,21 +337,21 @@ contract Augur is Controlled, IAugur {
     function logFeeTokenTransferred(IUniverse _universe, address _from, address _to, uint256 _value) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForFeeToken(IFeeToken(msg.sender)));
-        emit TokensTransferred(_universe, msg.sender, _from, _to, _value, TokenType.FeeToken, 0);
+        emit TokensTransferred(_universe, msg.sender, _from, _to, _value, TokenType.FeeToken, address(0));
         return true;
     }
 
     function logFeeTokenBurned(IUniverse _universe, address _target, uint256 _amount) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForFeeToken(IFeeToken(msg.sender)));
-        emit TokensBurned(_universe, msg.sender, _target, _amount, TokenType.FeeToken, 0);
+        emit TokensBurned(_universe, msg.sender, _target, _amount, TokenType.FeeToken, address(0));
         return true;
     }
 
     function logFeeTokenMinted(IUniverse _universe, address _target, uint256 _amount) public returns (bool) {
         require(isKnownUniverse(_universe));
         require(_universe.isContainerForFeeToken(IFeeToken(msg.sender)));
-        emit TokensMinted(_universe, msg.sender, _target, _amount, TokenType.FeeToken, 0);
+        emit TokensMinted(_universe, msg.sender, _target, _amount, TokenType.FeeToken, address(0));
         return true;
     }
 

--- a/source/contracts/Controlled.sol
+++ b/source/contracts/Controlled.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'IControlled.sol';

--- a/source/contracts/Controller.sol
+++ b/source/contracts/Controller.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 /**
  * The Controller is used to manage whitelisting of contracts and and halt the normal use of Augur’s contracts (e.g., if there is a vulnerability found in Augur).  There is only one instance of the Controller, and it gets uploaded to the blockchain before all of the other contracts.  The `owner` attribute of the Controller is set to the address that called the constructor of the Controller.  The Augur team can then call functions from this address to interact with the Controller.

--- a/source/contracts/IAugur.sol
+++ b/source/contracts/IAugur.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IUniverse.sol';
 import 'libraries/token/ERC20.sol';

--- a/source/contracts/IControlled.sol
+++ b/source/contracts/IControlled.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'IController.sol';

--- a/source/contracts/IController.sol
+++ b/source/contracts/IController.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'IAugur.sol';
 

--- a/source/contracts/ITime.sol
+++ b/source/contracts/ITime.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'Controlled.sol';
 import 'libraries/Initializable.sol';

--- a/source/contracts/LegacyReputationToken.sol
+++ b/source/contracts/LegacyReputationToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/ContractExists.sol';
 import 'libraries/Ownable.sol';

--- a/source/contracts/TestNetReputationToken.sol
+++ b/source/contracts/TestNetReputationToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/ContractExists.sol';
 import 'reporting/ReputationToken.sol';

--- a/source/contracts/Time.sol
+++ b/source/contracts/Time.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'ITime.sol';
 

--- a/source/contracts/TimeControlled.sol
+++ b/source/contracts/TimeControlled.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'ITime.sol';
 import 'libraries/ContractExists.sol';

--- a/source/contracts/factories/DisputeCrowdsourcerFactory.sol
+++ b/source/contracts/factories/DisputeCrowdsourcerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/Delegator.sol';
 import 'reporting/IDisputeCrowdsourcer.sol';

--- a/source/contracts/factories/FeeTokenFactory.sol
+++ b/source/contracts/factories/FeeTokenFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IFeeToken.sol';
 import 'IController.sol';

--- a/source/contracts/factories/FeeWindowFactory.sol
+++ b/source/contracts/factories/FeeWindowFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/Delegator.sol';
 import 'IController.sol';

--- a/source/contracts/factories/InitialReporterFactory.sol
+++ b/source/contracts/factories/InitialReporterFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/Delegator.sol';
 import 'reporting/IInitialReporter.sol';

--- a/source/contracts/factories/MailboxFactory.sol
+++ b/source/contracts/factories/MailboxFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/Delegator.sol';
 import 'IController.sol';

--- a/source/contracts/factories/MapFactory.sol
+++ b/source/contracts/factories/MapFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/Delegator.sol';

--- a/source/contracts/factories/MarketFactory.sol
+++ b/source/contracts/factories/MarketFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/Delegator.sol';

--- a/source/contracts/factories/ReputationTokenFactory.sol
+++ b/source/contracts/factories/ReputationTokenFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/Delegator.sol';

--- a/source/contracts/factories/ShareTokenFactory.sol
+++ b/source/contracts/factories/ShareTokenFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/Delegator.sol';

--- a/source/contracts/factories/UniverseFactory.sol
+++ b/source/contracts/factories/UniverseFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/Delegator.sol';

--- a/source/contracts/legacy_reputation/BasicToken.sol
+++ b/source/contracts/legacy_reputation/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'legacy_reputation/ERC20Basic.sol';

--- a/source/contracts/legacy_reputation/ERC20.sol
+++ b/source/contracts/legacy_reputation/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'legacy_reputation/ERC20Basic.sol';

--- a/source/contracts/legacy_reputation/ERC20Basic.sol
+++ b/source/contracts/legacy_reputation/ERC20Basic.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/legacy_reputation/Initializable.sol
+++ b/source/contracts/legacy_reputation/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/legacy_reputation/LegacyRepToken.sol
+++ b/source/contracts/legacy_reputation/LegacyRepToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'legacy_reputation/Initializable.sol';

--- a/source/contracts/legacy_reputation/Ownable.sol
+++ b/source/contracts/legacy_reputation/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/legacy_reputation/Pausable.sol
+++ b/source/contracts/legacy_reputation/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import "legacy_reputation/Ownable.sol";

--- a/source/contracts/legacy_reputation/PausableToken.sol
+++ b/source/contracts/legacy_reputation/PausableToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'legacy_reputation/StandardToken.sol';

--- a/source/contracts/legacy_reputation/SafeMath.sol
+++ b/source/contracts/legacy_reputation/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/legacy_reputation/StandardToken.sol
+++ b/source/contracts/legacy_reputation/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'legacy_reputation/BasicToken.sol';

--- a/source/contracts/libraries/CashAutoConverter.sol
+++ b/source/contracts/libraries/CashAutoConverter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/ICash.sol';

--- a/source/contracts/libraries/ContractExists.sol
+++ b/source/contracts/libraries/ContractExists.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 // Utility to check if the address actually contains a contract based on size.

--- a/source/contracts/libraries/DelegationTarget.sol
+++ b/source/contracts/libraries/DelegationTarget.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'Controlled.sol';

--- a/source/contracts/libraries/Delegator.sol
+++ b/source/contracts/libraries/Delegator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'IController.sol';

--- a/source/contracts/libraries/IOwnable.sol
+++ b/source/contracts/libraries/IOwnable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IOwnable {

--- a/source/contracts/libraries/ITyped.sol
+++ b/source/contracts/libraries/ITyped.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract ITyped {

--- a/source/contracts/libraries/Initializable.sol
+++ b/source/contracts/libraries/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/libraries/MarketValidator.sol
+++ b/source/contracts/libraries/MarketValidator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IMarket.sol';
 import 'Controlled.sol';

--- a/source/contracts/libraries/Ownable.sol
+++ b/source/contracts/libraries/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/IOwnable.sol';

--- a/source/contracts/libraries/ReentrancyGuard.sol
+++ b/source/contracts/libraries/ReentrancyGuard.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 /**

--- a/source/contracts/libraries/collections/Map.sol
+++ b/source/contracts/libraries/collections/Map.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/DelegationTarget.sol';
 import 'libraries/Ownable.sol';
@@ -26,7 +26,7 @@ contract Map is DelegationTarget, Ownable, Initializable {
     }
 
     function add(bytes32 _key, address _value) public onlyOwner returns (bool) {
-        return add(_key, bytes32(_value));
+        return add(_key, _value);
     }
 
     function remove(bytes32 _key) public onlyOwner returns (bool) {
@@ -49,11 +49,11 @@ contract Map is DelegationTarget, Ownable, Initializable {
     }
 
     function getAsAddressOrZero(bytes32 _key) public view returns (address) {
-        return address(getValueOrZero(_key));
+        return address(uint160(uint256(getValueOrZero(_key))));
     }
 
     function getAsAddress(bytes32 _key) public view returns (address) {
-        return address(get(_key));
+        return address(uint160(uint256(get(_key))));
     }
 
     function contains(bytes32 _key) public view returns (bool) {

--- a/source/contracts/libraries/math/RunningAverage.sol
+++ b/source/contracts/libraries/math/RunningAverage.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/math/SafeMathUint256.sol';
 

--- a/source/contracts/libraries/math/SafeMathInt256.sol
+++ b/source/contracts/libraries/math/SafeMathInt256.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 /**

--- a/source/contracts/libraries/math/SafeMathUint256.sol
+++ b/source/contracts/libraries/math/SafeMathUint256.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 /**

--- a/source/contracts/libraries/token/BasicToken.sol
+++ b/source/contracts/libraries/token/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/token/ERC20Basic.sol';

--- a/source/contracts/libraries/token/ERC20.sol
+++ b/source/contracts/libraries/token/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/token/ERC20Basic.sol';

--- a/source/contracts/libraries/token/ERC20Basic.sol
+++ b/source/contracts/libraries/token/ERC20Basic.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/libraries/token/StandardToken.sol
+++ b/source/contracts/libraries/token/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/token/BasicToken.sol';

--- a/source/contracts/libraries/token/VariableSupplyToken.sol
+++ b/source/contracts/libraries/token/VariableSupplyToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/token/StandardToken.sol';

--- a/source/contracts/reporting/BaseReportingParticipant.sol
+++ b/source/contracts/reporting/BaseReportingParticipant.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IReportingParticipant.sol';
 import 'reporting/IMarket.sol';

--- a/source/contracts/reporting/DisputeCrowdsourcer.sol
+++ b/source/contracts/reporting/DisputeCrowdsourcer.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IDisputeCrowdsourcer.sol';
 import 'libraries/token/VariableSupplyToken.sol';

--- a/source/contracts/reporting/FeeToken.sol
+++ b/source/contracts/reporting/FeeToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IFeeToken.sol';
 import 'reporting/IFeeWindow.sol';

--- a/source/contracts/reporting/FeeWindow.sol
+++ b/source/contracts/reporting/FeeWindow.sol
@@ -1,6 +1,6 @@
 // Copyright (C) 2015 Forecast Foundation OU, full GPL notice in LICENSE
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'reporting/IFeeWindow.sol';

--- a/source/contracts/reporting/IDisputeCrowdsourcer.sol
+++ b/source/contracts/reporting/IDisputeCrowdsourcer.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IReportingParticipant.sol';
 import 'reporting/IFeeWindow.sol';

--- a/source/contracts/reporting/IFeeToken.sol
+++ b/source/contracts/reporting/IFeeToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/token/ERC20.sol';
 import 'libraries/Initializable.sol';

--- a/source/contracts/reporting/IFeeWindow.sol
+++ b/source/contracts/reporting/IFeeWindow.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/ITyped.sol';

--- a/source/contracts/reporting/IInitialReporter.sol
+++ b/source/contracts/reporting/IInitialReporter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IReportingParticipant.sol';
 import 'reporting/IMarket.sol';

--- a/source/contracts/reporting/IMailbox.sol
+++ b/source/contracts/reporting/IMailbox.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IMarket.sol';
 

--- a/source/contracts/reporting/IMarket.sol
+++ b/source/contracts/reporting/IMarket.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/ITyped.sol';

--- a/source/contracts/reporting/IRepPriceOracle.sol
+++ b/source/contracts/reporting/IRepPriceOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IRepPriceOracle {

--- a/source/contracts/reporting/IReportingParticipant.sol
+++ b/source/contracts/reporting/IReportingParticipant.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IMarket.sol';
 import 'reporting/IFeeWindow.sol';

--- a/source/contracts/reporting/IReputationToken.sol
+++ b/source/contracts/reporting/IReputationToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/ITyped.sol';
 import 'libraries/token/ERC20.sol';

--- a/source/contracts/reporting/IUniverse.sol
+++ b/source/contracts/reporting/IUniverse.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/ITyped.sol';

--- a/source/contracts/reporting/InitialReporter.sol
+++ b/source/contracts/reporting/InitialReporter.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/Initializable.sol';
 import 'libraries/DelegationTarget.sol';

--- a/source/contracts/reporting/Mailbox.sol
+++ b/source/contracts/reporting/Mailbox.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/DelegationTarget.sol';
 import 'libraries/Ownable.sol';

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'reporting/IMarket.sol';
 import 'libraries/DelegationTarget.sol';

--- a/source/contracts/reporting/RepPriceOracle.sol
+++ b/source/contracts/reporting/RepPriceOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'libraries/Ownable.sol';
 import 'reporting/IRepPriceOracle.sol';

--- a/source/contracts/reporting/Reporting.sol
+++ b/source/contracts/reporting/Reporting.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 library Reporting {

--- a/source/contracts/reporting/ReputationToken.sol
+++ b/source/contracts/reporting/ReputationToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'reporting/IReputationToken.sol';

--- a/source/contracts/reporting/Universe.sol
+++ b/source/contracts/reporting/Universe.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'reporting/IUniverse.sol';

--- a/source/contracts/trading/CancelOrder.sol
+++ b/source/contracts/trading/CancelOrder.sol
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Forecast Foundation OU, full GPL notice in LICENSE
  */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/ICancelOrder.sol';

--- a/source/contracts/trading/Cash.sol
+++ b/source/contracts/trading/Cash.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import 'trading/ICash.sol';
 import 'Controlled.sol';

--- a/source/contracts/trading/ClaimTradingProceeds.sol
+++ b/source/contracts/trading/ClaimTradingProceeds.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/IClaimTradingProceeds.sol';

--- a/source/contracts/trading/CompleteSets.sol
+++ b/source/contracts/trading/CompleteSets.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/ICompleteSets.sol';

--- a/source/contracts/trading/CreateOrder.sol
+++ b/source/contracts/trading/CreateOrder.sol
@@ -1,6 +1,6 @@
 // Copyright (C) 2015 Forecast Foundation OU, full GPL notice in LICENSE
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'Controlled.sol';

--- a/source/contracts/trading/FillOrder.sol
+++ b/source/contracts/trading/FillOrder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/IFillOrder.sol';

--- a/source/contracts/trading/ICancelOrder.sol
+++ b/source/contracts/trading/ICancelOrder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/trading/ICash.sol
+++ b/source/contracts/trading/ICash.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/token/ERC20.sol';

--- a/source/contracts/trading/IClaimTradingProceeds.sol
+++ b/source/contracts/trading/IClaimTradingProceeds.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 

--- a/source/contracts/trading/ICompleteSets.sol
+++ b/source/contracts/trading/ICompleteSets.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'reporting/IMarket.sol';

--- a/source/contracts/trading/ICreateOrder.sol
+++ b/source/contracts/trading/ICreateOrder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/Order.sol';

--- a/source/contracts/trading/IFillOrder.sol
+++ b/source/contracts/trading/IFillOrder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/Order.sol';

--- a/source/contracts/trading/IOrders.sol
+++ b/source/contracts/trading/IOrders.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/Order.sol';

--- a/source/contracts/trading/IOrdersFetcher.sol
+++ b/source/contracts/trading/IOrdersFetcher.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/Order.sol';

--- a/source/contracts/trading/IShareToken.sol
+++ b/source/contracts/trading/IShareToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'libraries/ITyped.sol';

--- a/source/contracts/trading/ITrade.sol
+++ b/source/contracts/trading/ITrade.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/Order.sol';

--- a/source/contracts/trading/ITradingEscapeHatch.sol
+++ b/source/contracts/trading/ITradingEscapeHatch.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'reporting/IMarket.sol';

--- a/source/contracts/trading/Order.sol
+++ b/source/contracts/trading/Order.sol
@@ -5,7 +5,7 @@
 // amount is the number of attoshares the order is for (either to buy or to sell).
 // price is the exact price you want to buy/sell at [which may not be the cost, for example to short a yesNo market it'll cost numTicks-price, to go long it'll cost price]
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'IAugur.sol';
@@ -120,7 +120,8 @@ library Order {
 
         // Figure out how many almost-complete-sets (just missing `outcome` share) the creator has
         uint256 _attosharesHeld = 2**254;
-        for (uint256 _i = 0; _i < _numberOfOutcomes; _i++) {
+        uint256 _i;
+        for (_i = 0; _i < _numberOfOutcomes; _i++) {
             if (_i != _orderData.outcome) {
                 uint256 _creatorShareTokenBalance = _orderData.market.getShareToken(_i).balanceOf(_orderData.creator);
                 _attosharesHeld = SafeMathUint256.min(_creatorShareTokenBalance, _attosharesHeld);

--- a/source/contracts/trading/Orders.sol
+++ b/source/contracts/trading/Orders.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/IOrders.sol';

--- a/source/contracts/trading/OrdersFetcher.sol
+++ b/source/contracts/trading/OrdersFetcher.sol
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Forecast Foundation OU, full GPL notice in LICENSE
  */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/IOrdersFetcher.sol';

--- a/source/contracts/trading/ShareToken.sol
+++ b/source/contracts/trading/ShareToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/IShareToken.sol';

--- a/source/contracts/trading/Trade.sol
+++ b/source/contracts/trading/Trade.sol
@@ -1,6 +1,6 @@
 // Copyright (C) 2015 Forecast Foundation OU, full GPL notice in LICENSE
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'Controlled.sol';

--- a/source/contracts/trading/TradingEscapeHatch.sol
+++ b/source/contracts/trading/TradingEscapeHatch.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 import 'trading/ITradingEscapeHatch.sol';
@@ -71,9 +71,10 @@ contract TradingEscapeHatch is DelegationTarget, CashAutoConverter, MarketValida
         uint256[] memory _shiftedPrices = new uint256[](_numOutcomes);
         uint256 _sumOfBids = 0;
         IOrders _orders = IOrders(controller.lookup("Orders"));
+        uint256 _tempOutcome;
 
         // fill in any outcome prices that have an order history
-        for (uint256 _tempOutcome = 0; _tempOutcome < _numOutcomes; ++_tempOutcome) {
+        for (_tempOutcome = 0; _tempOutcome < _numOutcomes; ++_tempOutcome) {
             uint256 _lastTradePrice = uint256(_orders.getLastOutcomePrice(_market, _tempOutcome));
             uint256 _lastTradePriceShifted = _lastTradePrice;
             if (_lastTradePriceShifted > 0) {

--- a/source/support/test/smt/Dockerfile
+++ b/source/support/test/smt/Dockerfile
@@ -11,8 +11,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 
 RUN apt-get update && apt-get install -y unzip libz3-dev
 
-RUN wget --quiet --output-document /usr/local/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux \
-	&& chmod a+x /usr/local/bin/solc
+RUN wget --quiet https://github.com/cryptomental/solidity/releases/download/v0.4.25-develop.2018.7.4-smt/solc.zip \
+	&& unzip solc.zip -d /usr/local/bin && chmod a+x /usr/local/bin/solc
 
 COPY requirements.txt /app/requirements.txt
 WORKDIR /app


### PR DESCRIPTION
The InternalCompilerError does not occur anymore on a pre-release solc
0.4.25-develop.2018.7.4+commit.cde976ca.mod.Linux.g++.

* Update pramga in contracts to accept pre-released 0.4.25 Solidity compiler.
* Use explicit casts for address in certain emits.
* Change bytes32 to address casts from address() to address(uint160(uint256()))

Refs: Solidity #4341