### PR TITLE
Achapman/ch15702/use or lose rep

### DIFF
--- a/source/contracts/legacy_reputation/OldLegacyRepToken.sol
+++ b/source/contracts/legacy_reputation/OldLegacyRepToken.sol
@@ -82,7 +82,7 @@ contract OldLegacyReputationToken is DelegationTarget, ITyped, Initializable, Va
         totalMigrated += _attotokens;
         // Award a bonus if migration is done before the fork period is over, even if it has finalized
         if (controller.getTimestamp() < _parentUniverse.getForkEndTime()) {
-            uint256 _bonus = _attotokens.div(Reporting.getForkMigrationPercentageBonusDivisor());
+            uint256 _bonus = _attotokens.div(20);
             mint(_reporter, _bonus);
             totalTheoreticalSupply += _bonus;
         }

--- a/source/contracts/reporting/IInitialReporter.sol
+++ b/source/contracts/reporting/IInitialReporter.sol
@@ -7,10 +7,10 @@ import 'reporting/IMarket.sol';
 contract IInitialReporter is IReportingParticipant {
     function initialize(IMarket _market, address _designatedReporter) public returns (bool);
     function report(address _reporter, bytes32 _payoutDistributionHash, uint256[] _payoutNumerators, bool _invalid, uint256 _initialReportStake) public returns (bool);
-    function resetReportTimestamp() public returns (bool);
     function designatedReporterShowed() public view returns (bool);
     function designatedReporterWasCorrect() public view returns (bool);
     function getDesignatedReporter() public view returns (address);
     function getReportTimestamp() public view returns (uint256);
-    function migrateREP() public returns (bool);
+    function migrateToNewUniverse(address _designatedReporter) public returns (bool);
+    function returnRepFromDisavow() public returns (bool);
 }

--- a/source/contracts/reporting/InitialReporter.sol
+++ b/source/contracts/reporting/InitialReporter.sol
@@ -59,24 +59,17 @@ contract InitialReporter is DelegationTarget, Ownable, BaseReportingParticipant,
         return true;
     }
 
-    function resetReportTimestamp() public returns (bool) {
+    function returnRepFromDisavow() public returns (bool) {
         require(IMarket(msg.sender) == market);
-        if (reportTimestamp == 0) {
-            return;
-        }
-        reportTimestamp = controller.getTimestamp();
+        require(reputationToken.transfer(owner, reputationToken.balanceOf(this)));
+        reportTimestamp = 0;
         return true;
     }
 
-    function migrateREP() public returns (bool) {
+    function migrateToNewUniverse(address _designatedReporter) public returns (bool) {
         require(IMarket(msg.sender) == market);
-        IUniverse _newUniverse = market.getUniverse();
-        IReputationToken _newReputationToken = _newUniverse.getReputationToken();
-        uint256 _balance = reputationToken.balanceOf(this);
-        if (_balance > 0) {
-            reputationToken.migrateOut(_newReputationToken, _balance);
-        }
-        reputationToken = _newReputationToken;
+        designatedReporter = _designatedReporter;
+        reputationToken = market.getUniverse().getReputationToken();
         return true;
     }
 

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -310,9 +310,11 @@ contract Market is DelegationTarget, ITyped, Initializable, Ownable, IMarket {
         // Pay the No Show REP bond
         noShowBond = universe.getOrCacheDesignatedReportStake();
         noShowBondOwner = msg.sender;
+        getReputationToken().trustedMarketTransfer(noShowBondOwner, this, noShowBond);
+
+        // Update the Initial Reporter
         IInitialReporter _initialReporter = getInitialReporter();
         _initialReporter.migrateToNewUniverse(msg.sender);
-        getReputationToken().trustedMarketTransfer(noShowBondOwner, this, noShowBond);
 
         // If the market is past expiration use the reporting data to make an initial report
         uint256 _timestamp = controller.getTimestamp();

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -145,6 +145,7 @@ contract Market is DelegationTarget, ITyped, Initializable, Ownable, IMarket {
         } else {
             require(_reputationToken.transfer(_initialReporter, _initialReportStake));
         }
+        noShowBond = 0;
         return _initialReportStake;
     }
 
@@ -339,9 +340,8 @@ contract Market is DelegationTarget, ITyped, Initializable, Ownable, IMarket {
         participants.push(_initialParticipant);
         // Send REP from the no show bond back to the address that placed it. If a report has been made tell the InitialReporter to return that REP and reset
         IReputationToken _reputationToken = getReputationToken();
-        uint256 _balance = _reputationToken.balanceOf(this);
-        if (_balance > 0) {
-            require(_reputationToken.transfer(noShowBondOwner, _balance));
+        if (noShowBond > 0) {
+            require(_reputationToken.transfer(noShowBondOwner, noShowBond));
             noShowBond = 0;
         } else {
             _initialParticipant.returnRepFromDisavow();

--- a/source/contracts/reporting/Market.sol
+++ b/source/contracts/reporting/Market.sol
@@ -121,7 +121,7 @@ contract Market is DelegationTarget, ITyped, Initializable, Ownable, IMarket {
         return true;
     }
 
-    function doInitialReportInternal(address _reporter, uint256[] _payoutNumerators, bool _invalid, string _description) public returns (bool) {
+    function doInitialReportInternal(address _reporter, uint256[] _payoutNumerators, bool _invalid, string _description) private returns (bool) {
         require(!universe.isForking());
         IInitialReporter _initialReporter = getInitialReporter();
         uint256 _timestamp = controller.getTimestamp();
@@ -339,8 +339,8 @@ contract Market is DelegationTarget, ITyped, Initializable, Ownable, IMarket {
         delete participants;
         participants.push(_initialParticipant);
         // Send REP from the no show bond back to the address that placed it. If a report has been made tell the InitialReporter to return that REP and reset
-        IReputationToken _reputationToken = getReputationToken();
         if (noShowBond > 0) {
+            IReputationToken _reputationToken = getReputationToken();
             require(_reputationToken.transfer(noShowBondOwner, noShowBond));
             noShowBond = 0;
         } else {

--- a/source/contracts/reporting/Reporting.sol
+++ b/source/contracts/reporting/Reporting.sol
@@ -21,8 +21,6 @@ library Reporting {
     uint256 private constant TARGET_REP_MARKET_CAP_MULTIPLIER = 15; // We multiply and divide by constants since we want to multiply by a fractional amount (7.5)
     uint256 private constant TARGET_REP_MARKET_CAP_DIVISOR = 2;
 
-    uint256 private constant FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR = 20; // 5% bonus to any REP migrated during a fork
-
     function getDesignatedReportingDurationSeconds() internal pure returns (uint256) { return DESIGNATED_REPORTING_DURATION_SECONDS; }
     function getDisputeRoundDurationSeconds() internal pure returns (uint256) { return DISPUTE_ROUND_DURATION_SECONDS; }
     function getClaimTradingProceedsWaitTime() internal pure returns (uint256) { return CLAIM_PROCEEDS_WAIT_TIME; }
@@ -34,7 +32,6 @@ library Reporting {
     function getTargetDesignatedReportNoShowsDivisor() internal pure returns (uint256) { return TARGET_DESIGNATED_REPORT_NO_SHOWS_DIVISOR; }
     function getTargetRepMarketCapMultiplier() internal pure returns (uint256) { return TARGET_REP_MARKET_CAP_MULTIPLIER; }
     function getTargetRepMarketCapDivisor() internal pure returns (uint256) { return TARGET_REP_MARKET_CAP_DIVISOR; }
-    function getForkMigrationPercentageBonusDivisor() internal pure returns (uint256) { return FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR; }
     function getMaximumReportingFeeDivisor() internal pure returns (uint256) { return MAXIMUM_REPORTING_FEE_DIVISOR; }
     function getMinimumReportingFeeDivisor() internal pure returns (uint256) { return MINIMUM_REPORTING_FEE_DIVISOR; }
     function getDefaultReportingFeeDivisor() internal pure returns (uint256) { return DEFAULT_REPORTING_FEE_DIVISOR; }

--- a/source/contracts/reporting/ReputationToken.sol
+++ b/source/contracts/reporting/ReputationToken.sol
@@ -53,14 +53,9 @@ contract ReputationToken is DelegationTarget, ITyped, Initializable, VariableSup
     function migrateIn(address _reporter, uint256 _attotokens) public afterInitialized returns (bool) {
         IUniverse _parentUniverse = universe.getParentUniverse();
         require(ReputationToken(msg.sender) == _parentUniverse.getReputationToken());
+        require(controller.getTimestamp() < _parentUniverse.getForkEndTime());
         mint(_reporter, _attotokens);
         totalMigrated += _attotokens;
-        // Award a bonus if migration is done before the fork period is over, even if it has finalized
-        if (controller.getTimestamp() < _parentUniverse.getForkEndTime()) {
-            uint256 _bonus = _attotokens.div(Reporting.getForkMigrationPercentageBonusDivisor());
-            mint(_reporter, _bonus);
-            totalTheoreticalSupply += _bonus;
-        }
         // Update the fork tenative winner and finalize if we can
         if (!_parentUniverse.getForkingMarket().isFinalized()) {
             _parentUniverse.updateTentativeWinningChildUniverse(universe.getParentPayoutDistributionHash());

--- a/tests/reporting/test_fee_distribution.py
+++ b/tests/reporting/test_fee_distribution.py
@@ -351,7 +351,6 @@ def test_forkAndRedeem(localFixture, universe, market, categoricalMarket, cash, 
         key = localFixture.testerKey[i % 4]
         reportingParticipant = localFixture.applySignature("DisputeCrowdsourcer", market.getReportingParticipant(i))
         expectedRep = reportingParticipant.getStake()
-        expectedRep += expectedRep / localFixture.contracts["Constants"].FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR()
         expectedRep += reportingParticipant.getStake() / 2
         repToken = noUniverseReputationToken if i % 2 == 0 else yesUniverseReputationToken
         with TokenDelta(repToken, expectedRep, account, "Redeeming didn't increase REP correctly for " + str(i)):

--- a/tests/reporting/test_fee_distribution.py
+++ b/tests/reporting/test_fee_distribution.py
@@ -329,7 +329,7 @@ def test_forkAndRedeem(localFixture, universe, market, categoricalMarket, cash, 
     categoricalDisputeCrowdsourcer = localFixture.applySignature("DisputeCrowdsourcer", categoricalMarket.getReportingParticipant(1))
 
     # Migrate the categorical market into the winning universe. This will disavow the dispute crowdsourcer on it, letting us redeem for original universe rep and eth
-    assert categoricalMarket.migrateThroughOneFork()
+    assert categoricalMarket.migrateThroughOneFork([0,0,categoricalMarket.getNumTicks()], False, "")
 
     expectedRep = categoricalDisputeCrowdsourcer.getStake()
     expectedEth = getExpectedFees(localFixture, cash, categoricalDisputeCrowdsourcer, 1)

--- a/tests/reporting/test_stake_calculations.py
+++ b/tests/reporting/test_stake_calculations.py
@@ -21,29 +21,3 @@ def test_initial_report_bond_size(contractsFixture, market, universe):
     designatedReportCost = universe.getOrCacheDesignatedReportStake()
     initialReporter = contractsFixture.applySignature('InitialReporter', initialReporterAddress)
     assert initialReporter.getSize() == designatedReportCost
-
-def test_fork_bonus(contractsFixture, market, universe):
-    # proceed to forking
-    while (market.getForkingMarket() == longToHexString(0)):
-        proceedToNextRound(contractsFixture, market)
-
-    reputationToken = contractsFixture.applySignature('ReputationToken', universe.getReputationToken())
-    payoutHash = market.derivePayoutDistributionHash([market.getNumTicks(), 0], False)
-    childUniverse = contractsFixture.applySignature("Universe", universe.createChildUniverse([market.getNumTicks(), 0], False))
-    childReputationToken = contractsFixture.applySignature("ReputationToken", childUniverse.getReputationToken())
-
-    # We'll transfer some additional REP to the initial reporter contract to try and get a larger bonus
-    initialReporterAddress = market.getInitialReporter()
-    extraAmount = 10000
-    assert reputationToken.transfer(initialReporterAddress, extraAmount)
-
-    # When we redeem the bonus we will only be given a bonus relative to the legitimate stake in the bond
-    designatedReportCost = universe.getOrCacheDesignatedReportStake()
-    initialReporter = contractsFixture.applySignature('InitialReporter', initialReporterAddress)
-
-    # Skip to after the fork end to not deal with 5% bonus math
-    contractsFixture.contracts["Time"].setTimestamp(universe.getForkEndTime() + 1)
-
-    expectedPayout = designatedReportCost + (designatedReportCost / 2) + extraAmount
-    with TokenDelta(childReputationToken, expectedPayout, tester.a0, "Redeeming forked bond didn't result in the expected amount"):
-        assert initialReporter.forkAndRedeem()

--- a/tests/solidity_test_helpers/Constants.sol
+++ b/tests/solidity_test_helpers/Constants.sol
@@ -24,7 +24,6 @@ contract Constants {
     uint256 public constant TARGET_REP_MARKET_CAP_DIVISOR = Reporting.getTargetRepMarketCapDivisor();
 
     uint256 public constant INITIAL_REP_SUPPLY = Reporting.getInitialREPSupply();
-    uint256 public constant FORK_MIGRATION_PERCENTAGE_BONUS_DIVISOR = Reporting.getForkMigrationPercentageBonusDivisor();
 
     uint256 public constant BID = uint256(Order.Types.Bid);
     uint256 public constant ASK = uint256(Order.Types.Ask);

--- a/tests/solidity_test_helpers/MockInitialReporter.sol
+++ b/tests/solidity_test_helpers/MockInitialReporter.sol
@@ -103,7 +103,11 @@ contract MockInitialReporter is IInitialReporter {
         return 0;
     }
 
-    function migrateREP() public returns (bool) {
+    function returnRepFromDisavow() public returns (bool) {
+        return true;
+    }
+
+    function migrateToNewUniverse(address _designatedReporter) public returns (bool) {
         return true;
     }
 }

--- a/tests/unit/test_market_unit.py
+++ b/tests/unit/test_market_unit.py
@@ -147,20 +147,6 @@ def test_market_finalize_fork(localFixture, initializedMarket, mockUniverse):
     assert initializedMarket.finalizeFork() == True
     assert initializedMarket.getWinningPayoutDistributionHash() == stringToBytes("111")
 
-def test_migrate_through_one_fork(localFixture, initializedMarket, mockUniverse):
-    with raises(TransactionFailed, message="universe forking market needs to be finialized"):
-        initializedMarket.migrateThroughOneFork()
-
-    forkingMarket = localFixture.upload('solidity_test_helpers/MockMarket.sol', 'forkingMarket')
-    winningUniverse = localFixture.upload('solidity_test_helpers/MockUniverse.sol', 'winningUniverse')
-    mockUniverse.setForkingMarket(forkingMarket.address)
-    mockUniverse.setChildUniverse(winningUniverse.address)
-
-    initializedMarket.migrateThroughOneFork()
-    assert initializedMarket.getUniverse() == winningUniverse.address
-    assert winningUniverse.addMarketToWasCalled() == True
-    assert mockUniverse.removeMarketFromWasCalled() == True
-
 
 def test_finalize(localFixture, chain, initializedMarket, mockInitialReporter, mockNextFeeWindow, mockUniverse):
     with raises(TransactionFailed, message="can't finalize without an initial report"):

--- a/tests/unit/test_reputation_token.py
+++ b/tests/unit/test_reputation_token.py
@@ -24,6 +24,7 @@ def test_reputation_token_migrate_in(localFixture, mockUniverse, initializedRepu
     parentUniverse = localFixture.upload('solidity_test_helpers/MockUniverse.sol', 'parentUniverse')
     parentUniverse.setReputationToken(mockReputationToken.address)
     mockUniverse.setParentUniverse(parentUniverse.address)
+    parentUniverse.setForkEndTime(1000000000000000)
     mockReputationToken.setUniverse(mockUniverse.address)
     with raises(TransactionFailed, message="parent universe needs to have a forking market"):
         mockReputationToken.callMigrateIn(initializedReputationToken.address, tester.a1, 100)


### PR DESCRIPTION
Use or Lose Implementation.

 - No more fork bonus
 - Migrating REP is disallowed past the fork window
 - Market disavowal now returns the No Show Bond / Initial Report Bond
 - Migration to a new Universe requires a No Show Bond / Initial Report be placed