### PR TITLE
Update contributing info to redirect to monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,7 @@
 Thank you for taking the time to contribute to the Augur Project! Before you start, please view our [READEME](https://github.com/AugurProject/augur-core/blob/master/README.md) and our [code of conduct.](https://github.com/AugurProject/augur-core/blob/master/CODE_OF_CONDUCT.md)
 
 ### Issues and Pull Requests
-IMPORTANT: Please refrain from filing new issues in this repository. Instead, all new issues should be filed in our new [monorepo](https://github.com/AugurProject/augur). This is a new repository we have created for the Augur version 2.0 code, and we would like to consolidate all issues for Augur version 1.0 and 2.0 here. When [raising an issue](https://help.github.com/articles/creating-an-issue/), please follow the appropriate issue template in the root directory.
-
-[Pull requests](https://help.github.com/articles/creating-a-pull-request/) are welcome!  Make sure to run the tests (via docker is easiest) and verify the linter (Solium) doesn't complain.  Make sure commit messages are informative and concise.
+[Pull requests](https://help.github.com/articles/creating-a-pull-request/) are welcome.  Make sure to run the tests (via docker is easiest) and verify the linter (Solium) doesn't complain. When [raising issues](https://help.github.com/articles/creating-an-issue/), follow the appropriate issue template in the root directory. Make sure commit messages are informative and concise.
 
 ### Communication
 Finally, join the Augur Project on [Discord](https://discordapp.com/invite/faud6Fx)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to the Augur Project
-Thank you for taking the time to contribute to the Augur Project! Before you start, please view our [READEME](https://github.com/AugurProject/augur-core/blob/master/README.md) our [code of conduct.](https://github.com/AugurProject/augur-core/blob/master/CODE_OF_CONDUCT.md)
+Thank you for taking the time to contribute to the Augur Project! Before you start, please view our [READEME](https://github.com/AugurProject/augur-core/blob/master/README.md) and our [code of conduct.](https://github.com/AugurProject/augur-core/blob/master/CODE_OF_CONDUCT.md)
 
 ### Issues and Pull Requests
 IMPORTANT: Please refrain from filing new issues in this repository. Instead, all new issues should be filed in our new [monorepo](https://github.com/AugurProject/augur). This is a new repository we have created for the Augur version 2.0 code, and we would like to consolidate all issues for Augur version 1.0 and 2.0 here. When [raising an issue](https://help.github.com/articles/creating-an-issue/), please follow the appropriate issue template in the root directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,12 @@
 # Contributing to the Augur Project
-Thank you for taking the time to contribute to the Augur Project! Before you start, please read the following guidelines and our [code of conduct.](https://github.com/AugurProject/augur-core/blob/master/CODE_OF_CONDUCT.md)
+Thank you for taking the time to contribute to the Augur Project! Before you start, please view our [READEME](https://github.com/AugurProject/augur-core/blob/master/README.md) our [code of conduct.](https://github.com/AugurProject/augur-core/blob/master/CODE_OF_CONDUCT.md)
 
-### Versions
-Make sure to be using Python 2.7.xx, and Ethereum 1.6.1. It is recommended to clone from the master branch for both [Pyethereum](https://github.com/ethereum/pyethereum). Pyethereum may install Ethereum 1.4.0 -- uninstall the latter if it happens. Check your version of Ethereum by running this on terminal: `pip show ethereum | grep Version`
-Check your version of python by running this: `python --version`
+### Issues and Pull Requests
+IMPORTANT: Please refrain from filing new issues in this repository. Instead, all new issues should be filed in our new [monorepo](https://github.com/AugurProject/augur). This is a new repository we have created for the Augur version 2.0 code, and we would like to consolidate all issues for Augur version 1.0 and 2.0 here. When [raising an issue](https://help.github.com/articles/creating-an-issue/), please follow the appropriate issue template in the root directory.
 
-### Pull Requests and Issues
-[Pull requests](https://help.github.com/articles/creating-a-pull-request/) are welcome.  Make sure to run the tests (via docker is easiest) and verify the linter (Solium) doesn't complain. When [raising issues](https://help.github.com/articles/creating-an-issue/), follow the appropriate issue template in the root directory. Make sure commit messages are informative and concise.
+[Pull requests](https://help.github.com/articles/creating-a-pull-request/) are welcome!  Make sure to run the tests (via docker is easiest) and verify the linter (Solium) doesn't complain.  Make sure commit messages are informative and concise.
 
 ### Communication
-Finally, join the Augur Project on Slack! Invite yourself [here](http://invite.augur.net/).
+Finally, join the Augur Project on [Discord](https://discordapp.com/invite/faud6Fx)!
 
 Happy Coding!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to the Augur Project
 Thank you for taking the time to contribute to the Augur Project! Before you start, please view our [READEME](https://github.com/AugurProject/augur-core/blob/master/README.md) and our [code of conduct.](https://github.com/AugurProject/augur-core/blob/master/CODE_OF_CONDUCT.md)
 
-### Issues and Pull Requests
+### Pull Requests and Issues
 [Pull requests](https://help.github.com/articles/creating-a-pull-request/) are welcome.  Make sure to run the tests (via docker is easiest) and verify the linter (Solium) doesn't complain. When [raising issues](https://help.github.com/articles/creating-an-issue/), follow the appropriate issue template in the root directory. Make sure commit messages are informative and concise.
 
 ### Communication


### PR DESCRIPTION
If this looks ok, I'd like to add a similar CONTRIBUTING.md file to our other repos.  I believe having a CONTRIBUTING.md file should automatically add a banner like this to the top of the page:

<img width="993" alt="screen shot 2018-12-07 at 3 01 47 pm" src="https://user-images.githubusercontent.com/11491365/49676982-27a0ef00-fa31-11e8-9e42-3b0231ee58bb.png">

(For some reason, though, I'm not seeing this banner on the augur-core Issues page. I thought it might be because I had already dismissed the banner, but I still don't see it even if I view the page using an incognito window.)